### PR TITLE
React to TagHelper additions to Razor

### DIFF
--- a/src/Microsoft.Framework.CodeGeneration.Templating/RazorTemplatingHost.cs
+++ b/src/Microsoft.Framework.CodeGeneration.Templating/RazorTemplatingHost.cs
@@ -31,7 +31,8 @@ namespace Microsoft.Framework.CodeGeneration.Templating
                 writeLiteralMethodName: "WriteLiteral",
                 writeToMethodName: "WriteTo",
                 writeLiteralToMethodName: "WriteLiteralTo",
-                templateTypeName: "")
+                templateTypeName: "",
+                generatedTagHelperContext: new GeneratedTagHelperContext())
             {
             };
 


### PR DESCRIPTION
- Fixed the RazorTemplatingHost to now construct its GeneratedClassContext with the appropriate TagHelper metadata.
