### PR TITLE
Fix: https://github.com/aspnet/Scaffolding/issues/65

### DIFF
--- a/src/Microsoft.Framework.CodeGeneration.EntityFramework/ClassNameModel.cs
+++ b/src/Microsoft.Framework.CodeGeneration.EntityFramework/ClassNameModel.cs
@@ -1,9 +1,9 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-namespace Microsoft.Framework.CodeGeneration
+namespace Microsoft.Framework.CodeGeneration.EntityFramework
 {
-    internal class ClassNameModel
+    public class ClassNameModel
     {
         public string ClassName { get; set; }
 

--- a/src/Microsoft.Framework.CodeGeneration.EntityFramework/TypeUtilities.cs
+++ b/src/Microsoft.Framework.CodeGeneration.EntityFramework/TypeUtilities.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.Framework.CodeGeneration.EntityFramework
+{
+    internal static class TypeUtilities
+    {
+        public static ClassNameModel GetTypeNameandNamespace(string fullTypeName)
+        {
+            ExceptionUtilities.ValidateStringArgument(fullTypeName, "fullTypeName");
+
+            var index = fullTypeName.LastIndexOf(".");
+            if (index == -1)
+            {
+                return new ClassNameModel()
+                {
+                    ClassName = fullTypeName,
+                    NamespaceName = string.Empty
+                };
+            }
+            else
+            {
+                return new ClassNameModel()
+                {
+                    ClassName = fullTypeName.Substring(index + 1),
+                    NamespaceName = fullTypeName.Substring(0, index)
+                };
+            }
+        }
+    }
+}

--- a/src/Microsoft.Framework.CodeGenerators.Mvc/ClassNameModel.cs
+++ b/src/Microsoft.Framework.CodeGenerators.Mvc/ClassNameModel.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.Framework.CodeGenerators.Mvc
+{
+    public class ClassNameModel
+    {
+        public string ClassName { get; set; }
+
+        public string NamespaceName { get; set; }
+    }
+}

--- a/src/Microsoft.Framework.CodeGenerators.Mvc/TypeUtilities.cs
+++ b/src/Microsoft.Framework.CodeGenerators.Mvc/TypeUtilities.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-namespace Microsoft.Framework.CodeGeneration
+using Microsoft.Framework.CodeGeneration;
+
+namespace Microsoft.Framework.CodeGenerators.Mvc
 {
     internal static class TypeUtilities
     {


### PR DESCRIPTION
The root cause is that ‘dynamic’ does not work if the underlying object is internal with beta Roslyn bits. [I know this worked in alpha4]

So the fix is to simply make the class (template model used for empty template) from internal to public.

[Since this used to be a shared class in a shared project, I had to remove it from shared project and make copies in the actual projects that used it]
