### PR TITLE
Pk/ef add

### DIFF
--- a/src/Microsoft.Framework.CodeGeneration.Core/ModelType.cs
+++ b/src/Microsoft.Framework.CodeGeneration.Core/ModelType.cs
@@ -13,6 +13,11 @@ namespace Microsoft.Framework.CodeGeneration
 
         public string FullName { get; set; }
 
+        // Violating the principle that ModelType should be decoupled from Roslyn's API.
+        // I had to do this for editing DbContext scenarios but I need to figure out if there
+        // is a better way.
+        public ITypeSymbol TypeSymbol { get; private set; }
+
         public static ModelType FromITypeSymbol([NotNull]ITypeSymbol typeSymbol)
         {
             // Should we check for typeSymbol.IsType before returning here?
@@ -22,7 +27,8 @@ namespace Microsoft.Framework.CodeGeneration
                 FullName = typeSymbol.ToDisplayString(),
                 Namespace = typeSymbol.ContainingNamespace.IsGlobalNamespace
                     ? string.Empty
-                    : typeSymbol.ContainingNamespace.ToDisplayString()
+                    : typeSymbol.ContainingNamespace.ToDisplayString(),
+                TypeSymbol = typeSymbol
             };
         }
     }

--- a/src/Microsoft.Framework.CodeGeneration.Core/ModelTypesLocator.cs
+++ b/src/Microsoft.Framework.CodeGeneration.Core/ModelTypesLocator.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Framework.CodeGeneration
         {
             return _libraryExporter
                 .GetProjectsInApp(_application)
-                .Select(compilation => GetDirectTypesInCompilation(compilation.Compilation))
+                .Select(compilation => RoslynUtilities.GetDirectTypesInCompilation(compilation.Compilation))
                 .Aggregate((coll1, coll2) => coll1.Concat(coll2).ToList())
                 .Select(ts => ModelType.FromITypeSymbol(ts));
         }
@@ -48,23 +48,6 @@ namespace Microsoft.Framework.CodeGeneration
             //should we do that?
             return GetAllTypes()
                 .Where(type => string.Equals(type.Name, typeName, StringComparison.Ordinal));
-        }
-
-        private IEnumerable<ITypeSymbol> GetDirectTypesInCompilation([NotNull]Compilation compilation)
-        {
-            var types = new List<ITypeSymbol>();
-            CollectTypes(compilation.Assembly.GlobalNamespace, types);
-            return types;
-        }
-
-        private static void CollectTypes(INamespaceSymbol ns, List<ITypeSymbol> types)
-        {
-            types.AddRange(ns.GetTypeMembers().Cast<ITypeSymbol>());
-
-            foreach (var nestedNs in ns.GetNamespaceMembers())
-            {
-                CollectTypes(nestedNs, types);
-            }
         }
     }
 }

--- a/src/Microsoft.Framework.CodeGeneration.Core/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.Framework.CodeGeneration.Core/Properties/AssemblyInfo.cs
@@ -5,4 +5,5 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Microsoft.Framework.CodeGeneration.Core.Test")]
+[assembly: InternalsVisibleTo("Microsoft.Framework.CodeGeneration.EntityFramework.Test")]
 [assembly: AssemblyMetadata("Serviceable", "True")]

--- a/src/Microsoft.Framework.CodeGeneration.Core/RoslynUtilities.cs
+++ b/src/Microsoft.Framework.CodeGeneration.Core/RoslynUtilities.cs
@@ -1,0 +1,26 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+
+namespace Microsoft.Framework.CodeGeneration
+{
+    internal static class RoslynUtilities
+    {
+        public static IEnumerable<ITypeSymbol> GetDirectTypesInCompilation([NotNull]Compilation compilation)
+        {
+            var types = new List<ITypeSymbol>();
+            CollectTypes(compilation.Assembly.GlobalNamespace, types);
+            return types;
+        }
+
+        private static void CollectTypes(INamespaceSymbol ns, List<ITypeSymbol> types)
+        {
+            types.AddRange(ns.GetTypeMembers().Cast<ITypeSymbol>());
+
+            foreach (var nestedNs in ns.GetNamespaceMembers())
+            {
+                CollectTypes(nestedNs, types);
+            }
+        }
+    }
+}

--- a/src/Microsoft.Framework.CodeGeneration.EntityFramework/AddModelResult.cs
+++ b/src/Microsoft.Framework.CodeGeneration.EntityFramework/AddModelResult.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis;
+
+namespace Microsoft.Framework.CodeGeneration.EntityFramework
+{
+    public class AddModelResult
+    {
+        public bool Added { get; set; }
+
+        public SyntaxTree OldTree { get; set; }
+
+        public SyntaxTree NewTree { get; set; }
+    }
+}

--- a/src/Microsoft.Framework.CodeGeneration.EntityFramework/DbContextEditorServices.cs
+++ b/src/Microsoft.Framework.CodeGeneration.EntityFramework/DbContextEditorServices.cs
@@ -4,7 +4,9 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.Contracts;
+using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -53,7 +55,92 @@ namespace Microsoft.Framework.CodeGeneration.EntityFramework
             var newContextContent = templateResult.GeneratedText;
 
             var sourceText = SourceText.From(newContextContent);
-            return CSharpSyntaxTree.ParseText(sourceText);
+
+            return CSharpSyntaxTree.ParseText(sourceText)
+                .WithFilePath(GetPathForNewContext(dbContextTemplateModel.DbContextTypeName));
+        }
+
+        public AddModelResult AddModelToContext(ModelType dbContext, ModelType modelType)
+        {
+            if (!IsModelPropertyExists(dbContext.TypeSymbol, modelType.FullName))
+            {
+                // Todo : Need to add model and DbSet namespaces if required
+
+                // Todo : Need pluralization for modelType.Name below as that's the property name
+                var dbSetProperty = "public DbSet<" + modelType.FullName + "> " + modelType.Name + " { get; set; }" + Environment.NewLine;
+                var propertyDeclarationWrapper = CSharpSyntaxTree.ParseText(dbSetProperty);
+
+                // Todo : Consider using DeclaringSyntaxtReference 
+                var sourceLocation = dbContext.TypeSymbol.Locations.Where(l => l.IsInSource).FirstOrDefault();
+                if (sourceLocation != null)
+                {
+                    var syntaxTree = sourceLocation.SourceTree;
+                    var rootNode = syntaxTree.GetRoot();
+                    var dbContextNode = rootNode.FindNode(sourceLocation.SourceSpan);
+                    var lastNode = dbContextNode.ChildNodes().Last();
+                    var newNode = rootNode.InsertNodesAfter(lastNode,
+                            propertyDeclarationWrapper.GetRoot().WithLeadingTrivia(lastNode.GetLeadingTrivia()).ChildNodes());
+
+                    var modifiedTree = syntaxTree.WithRootAndOptions(newNode, syntaxTree.Options);
+
+                    return new AddModelResult()
+                    {
+                        Added = true,
+                        OldTree = syntaxTree,
+                        NewTree = modifiedTree
+                    };
+                }
+            }
+
+            return new AddModelResult()
+            {
+                Added = false
+            };
+        }
+
+        private string GetPathForNewContext(string contextTypeName)
+        {
+            //ToDo: What's the best place to write the DbContext?
+            var appBasePath = _environment.ApplicationBasePath;
+            var outputPath = Path.Combine(
+                appBasePath,
+                "Models",
+                contextTypeName + ".cs");
+
+            if (File.Exists(outputPath))
+            {
+                // Odd case, a file exists with the same name as the DbContextTypeName but perhaps
+                // the type defined in that file is different, what should we do in this case?
+                // How likely is the above scenario?
+                // Perhaps we can enumerate files with prefix and generate a safe name? For now, just throw.
+                throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture,
+                    "There was an error creating a DbContext, the file {0} already exists",
+                    outputPath));
+            }
+
+            return outputPath;
+        }
+
+        private bool IsModelPropertyExists(ITypeSymbol dbContext, string modelTypeFullName)
+        {
+            var propertySymbols = dbContext.GetMembers().Select(m => m as IPropertySymbol).Where(s => s != null);
+            foreach (var pSymbol in propertySymbols)
+            {
+                var namedType = pSymbol.Type as INamedTypeSymbol; //When can this go wrong?
+                if (namedType != null && namedType.IsGenericType && !namedType.IsUnboundGenericType &&
+                    namedType.ContainingAssembly.Name == "EntityFramework.Core" &&
+                    namedType.ContainingNamespace.ToDisplayString() == "Microsoft.Data.Entity" &&
+                    namedType.Name == "DbSet") // What happens if the type is referenced in full in code??
+                {
+                    // Can we check for equality of typeSymbol itself?
+                    if (namedType.TypeArguments.Any(t => t.ToDisplayString() == modelTypeFullName))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
         }
 
         private IEnumerable<string> TemplateFolders

--- a/src/Microsoft.Framework.CodeGeneration.EntityFramework/DbContextEditorServices.cs
+++ b/src/Microsoft.Framework.CodeGeneration.EntityFramework/DbContextEditorServices.cs
@@ -56,8 +56,7 @@ namespace Microsoft.Framework.CodeGeneration.EntityFramework
 
             var sourceText = SourceText.From(newContextContent);
 
-            return CSharpSyntaxTree.ParseText(sourceText)
-                .WithFilePath(GetPathForNewContext(dbContextTemplateModel.DbContextTypeName));
+            return CSharpSyntaxTree.ParseText(sourceText);
         }
 
         public AddModelResult AddModelToContext(ModelType dbContext, ModelType modelType)
@@ -79,7 +78,7 @@ namespace Microsoft.Framework.CodeGeneration.EntityFramework
                     var dbContextNode = rootNode.FindNode(sourceLocation.SourceSpan);
                     var lastNode = dbContextNode.ChildNodes().Last();
                     var newNode = rootNode.InsertNodesAfter(lastNode,
-                            propertyDeclarationWrapper.GetRoot().WithLeadingTrivia(lastNode.GetLeadingTrivia()).ChildNodes());
+                            propertyDeclarationWrapper.GetRoot().WithTriviaFrom(lastNode).ChildNodes());
 
                     var modifiedTree = syntaxTree.WithRootAndOptions(newNode, syntaxTree.Options);
 
@@ -96,29 +95,6 @@ namespace Microsoft.Framework.CodeGeneration.EntityFramework
             {
                 Added = false
             };
-        }
-
-        private string GetPathForNewContext(string contextTypeName)
-        {
-            //ToDo: What's the best place to write the DbContext?
-            var appBasePath = _environment.ApplicationBasePath;
-            var outputPath = Path.Combine(
-                appBasePath,
-                "Models",
-                contextTypeName + ".cs");
-
-            if (File.Exists(outputPath))
-            {
-                // Odd case, a file exists with the same name as the DbContextTypeName but perhaps
-                // the type defined in that file is different, what should we do in this case?
-                // How likely is the above scenario?
-                // Perhaps we can enumerate files with prefix and generate a safe name? For now, just throw.
-                throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture,
-                    "There was an error creating a DbContext, the file {0} already exists",
-                    outputPath));
-            }
-
-            return outputPath;
         }
 
         private bool IsModelPropertyExists(ITypeSymbol dbContext, string modelTypeFullName)

--- a/src/Microsoft.Framework.CodeGeneration.EntityFramework/EntityFrameworkServices.cs
+++ b/src/Microsoft.Framework.CodeGeneration.EntityFramework/EntityFrameworkServices.cs
@@ -89,8 +89,7 @@ namespace Microsoft.Framework.CodeGeneration.EntityFramework
             }
             else
             {
-                // The last parameter needs pluralization
-                AddModelToContext(dbContextSymbols.First().TypeSymbol, modelTypeSymbol.FullName, modelTypeSymbol.Name);
+                AddModelToContext(dbContextSymbols.First(), modelTypeSymbol);
 
                 dbContextType = _libraryExporter.GetReflectionType(_libraryManager, _environment, dbContextTypeName);
 
@@ -173,17 +172,18 @@ namespace Microsoft.Framework.CodeGeneration.EntityFramework
         }
 
         // Todo : Need pluralization for the third parameter.
-        private void AddModelToContext(ITypeSymbol dbContext, string modelTypeName, string propertyName)
+        private void AddModelToContext(ModelType dbContext, ModelType modelType)
         {
-            if (!IsModelPropertyExists(dbContext, modelTypeName))
+            if (!IsModelPropertyExists(dbContext.TypeSymbol, modelType.FullName))
             {
                 // Todo : Need to add model and DbSet namespaces if required
 
-                var dbSetProperty = "public DbSet<" + modelTypeName + "> " + propertyName + " { get; set; }" + Environment.NewLine;
+                // Todo : Need pluralization for modelType.Name below as that's the property name
+                var dbSetProperty = "public DbSet<" + modelType.FullName + "> " + modelType.Name + " { get; set; }" + Environment.NewLine;
                 var propertyDeclarationWrapper = CSharpSyntaxTree.ParseText(dbSetProperty);
 
                 // Todo : Consider using DeclaringSyntaxtReference 
-                var sourceLocation = dbContext.Locations.Where(l => l.IsInSource).FirstOrDefault();
+                var sourceLocation = dbContext.TypeSymbol.Locations.Where(l => l.IsInSource).FirstOrDefault();
                 if (sourceLocation != null)
                 {
                     var syntaxTree = sourceLocation.SourceTree;

--- a/src/Microsoft.Framework.CodeGeneration.EntityFramework/IDbContextEditorServices.cs
+++ b/src/Microsoft.Framework.CodeGeneration.EntityFramework/IDbContextEditorServices.cs
@@ -9,5 +9,7 @@ namespace Microsoft.Framework.CodeGeneration.EntityFramework
     public interface IDbContextEditorServices
     {
         Task<SyntaxTree> AddNewContext(NewDbContextTemplateModel dbContextTemplateModel);
+
+        AddModelResult AddModelToContext(ModelType dbContext, ModelType modelType);
     }
 }

--- a/src/Microsoft.Framework.CodeGeneration.EntityFramework/Templates/DbContext/NewLocalDbContext.cshtml
+++ b/src/Microsoft.Framework.CodeGeneration.EntityFramework/Templates/DbContext/NewLocalDbContext.cshtml
@@ -24,19 +24,6 @@ using Microsoft.Data.Entity.Metadata;
     } 
 }    public class @Model.DbContextTypeName : @baseClassName
     {
-        private static bool _created = false;
-
-        public @(Model.DbContextTypeName)()
-        {
-            if (!_created)
-            {
-                Database.EnsureCreated();
-                _created = true;
-            }
-        }
-
-        public DbSet<@Model.ModelTypeName> @Model.ModelTypeName { get; set; }
-
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         {
             optionsBuilder.UseSqlServer(@@"Server=(localdb)\mssqllocaldb;Database=@Model.DbContextTypeName;Trusted_Connection=True;MultipleActiveResultSets=true");
@@ -45,6 +32,8 @@ using Microsoft.Data.Entity.Metadata;
         protected override void OnModelCreating(ModelBuilder builder)
         {
         }
+
+        public DbSet<@Model.ModelTypeName> @Model.ModelTypeName { get; set; }
     }
 @{
     if (!String.IsNullOrEmpty(Model.DbContextNamespace))

--- a/test/Microsoft.Framework.CodeGeneration.EntityFramework.Test/DbContextEditorServicesTests.cs
+++ b/test/Microsoft.Framework.CodeGeneration.EntityFramework.Test/DbContextEditorServicesTests.cs
@@ -1,0 +1,47 @@
+﻿using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.Data.Entity;
+using Microsoft.Dnx.Runtime;
+using Microsoft.Framework.CodeGeneration.Templating;
+using Moq;
+using Xunit;
+using System.Diagnostics;
+
+namespace Microsoft.Framework.CodeGeneration.EntityFramework.Test
+{
+    public class DbContextEditorServicesTests
+    {
+        [Theory]
+        [InlineData("DbContext_Before.txt", "MyModel.txt", "DbContext_After.txt")]
+        public void AddModelToContext_Adds_Model_From_Same_Project_To_Context(string beforeContextResource, string modelResource, string afterContextResource)
+        {
+            string resourcePrefix = "compiler/resources/";
+
+            var beforeDbContextText = ResourceUtilities.GetEmbeddedResourceFileContent(resourcePrefix + beforeContextResource);
+            var modelText = ResourceUtilities.GetEmbeddedResourceFileContent(resourcePrefix + modelResource);
+            var afterDbContextText = ResourceUtilities.GetEmbeddedResourceFileContent(resourcePrefix + afterContextResource);
+
+            var contextTree = CSharpSyntaxTree.ParseText(beforeDbContextText);
+            var modelTree = CSharpSyntaxTree.ParseText(modelText);
+            var efReference = MetadataReference.CreateFromFile(typeof(DbContext).Assembly.Location);
+
+            var compilation = CSharpCompilation.Create("DoesNotMatter", new[] { contextTree, modelTree }, new[] { efReference });
+
+            DbContextEditorServices testObj = new DbContextEditorServices(
+                new Mock<ILibraryManager>().Object,
+                new Mock<IApplicationEnvironment>().Object,
+                new Mock<IFilesLocator>().Object,
+                new Mock<ITemplating>().Object);
+
+            var types = RoslynUtilities.GetDirectTypesInCompilation(compilation);
+            var modelType = ModelType.FromITypeSymbol(types.Where(ts => ts.Name == "MyModel").First());
+            var contextType = ModelType.FromITypeSymbol(types.Where(ts => ts.Name == "MyContext").First());
+
+            var result = testObj.AddModelToContext(contextType, modelType);
+
+            Assert.True(result.Added);
+            Assert.Equal(afterDbContextText, result.NewTree.GetText().ToString());
+        }
+    }
+}

--- a/test/Microsoft.Framework.CodeGeneration.EntityFramework.Test/ResourceUtilities.cs
+++ b/test/Microsoft.Framework.CodeGeneration.EntityFramework.Test/ResourceUtilities.cs
@@ -1,0 +1,23 @@
+﻿using System.IO;
+using System.Reflection;
+using Microsoft.AspNet.FileProviders;
+
+namespace Microsoft.Framework.CodeGeneration.EntityFramework.Test
+{
+    internal static class ResourceUtilities
+    {
+        public static string GetEmbeddedResourceFileContent(string relativeResourcePath)
+        {
+            using (var stream = Instance.GetFileInfo(relativeResourcePath).CreateReadStream())
+            {
+                using (StreamReader reader = new StreamReader(stream))
+                {
+                    return reader.ReadToEnd();
+                }
+            }
+        }
+
+        private static EmbeddedFileProvider Instance = new EmbeddedFileProvider(Assembly.GetExecutingAssembly(),
+            "Microsoft.Framework.CodeGeneration.EntityFramework.Test");
+    }
+}

--- a/test/Microsoft.Framework.CodeGeneration.EntityFramework.Test/compiler/resources/DbContext_After.txt
+++ b/test/Microsoft.Framework.CodeGeneration.EntityFramework.Test/compiler/resources/DbContext_After.txt
@@ -1,0 +1,10 @@
+﻿namespace ContextNamespace
+{
+	public class MyContext : DbContext
+	{
+		public MyContext() : base()
+		{
+		}
+		public DbSet<ModelNamespace.MyModel> MyModel { get; set; }
+	}
+}

--- a/test/Microsoft.Framework.CodeGeneration.EntityFramework.Test/compiler/resources/DbContext_Before.txt
+++ b/test/Microsoft.Framework.CodeGeneration.EntityFramework.Test/compiler/resources/DbContext_Before.txt
@@ -1,0 +1,9 @@
+﻿namespace ContextNamespace
+{
+	public class MyContext : DbContext
+	{
+		public MyContext() : base()
+		{
+		}
+	}
+}

--- a/test/Microsoft.Framework.CodeGeneration.EntityFramework.Test/compiler/resources/MyModel.txt
+++ b/test/Microsoft.Framework.CodeGeneration.EntityFramework.Test/compiler/resources/MyModel.txt
@@ -1,0 +1,6 @@
+﻿namespace ModelNamespace
+{
+	public class MyModel
+	{
+	}
+}

--- a/test/Microsoft.Framework.CodeGeneration.EntityFramework.Test/project.json
+++ b/test/Microsoft.Framework.CodeGeneration.EntityFramework.Test/project.json
@@ -1,6 +1,7 @@
 {
     "dependencies": {
         "Microsoft.Framework.CodeGeneration.EntityFramework": "1.0.0-*",
+        "Microsoft.AspNet.FileProviders.Embedded": "1.0.0-*",
         "Moq": "4.2.1312.1622",
         "xunit.runner.aspnet": "2.0.0-aspnet-*"
     },

--- a/test/runtests.cmd
+++ b/test/runtests.cmd
@@ -5,6 +5,6 @@ for %%1 in (
     Microsoft.Framework.CodeGeneration.EntityFramework.Test
     ) do (
         cd %%1
-        dnx . test
+        dnx test
         cd ..
     )


### PR DESCRIPTION
This PR adds support for adding a DbSet<Model> property to DbContext when one does not exist.

To give some context, the above scenario can be achieved in 2 ways:
-  Use EF ModelBuilder API to dynamically add missing EntitySet to DbContext at design time, and if EF metadata can be fetched fine, then add it in code (this is the current approach WAP Mvc4 scaffolding uses but the current EF API did not yet offer this and after talking to EF folks I logged an issue in their repo)

- Other approach is to add the property first in code and use Roslyn to compile the entire app again in memory and reflect to get the EF metadata. (Older scaffolding used this approach at one point in time but was doing only partial compilation by taking a subset of project which was fragile , but given we are using the entire app this time, this should be more reliable but could be less performant).

To unblock the above scenario for usability study, I just coded it up 2nd approach and added a simple test for a simple scenario, I am planning to add more tests and fix the code as I find issues).

Once EF team fixes their issue we may revert to approach 1.