### PR TITLE
Updating to correct src path for jquery.validate

### DIFF
--- a/src/Microsoft.Extensions.CodeGenerators.Mvc/Templates/ViewGenerator/Create.cshtml
+++ b/src/Microsoft.Extensions.CodeGenerators.Mvc/Templates/ViewGenerator/Create.cshtml
@@ -115,7 +115,7 @@
     {
 @:@@section Scripts {
     @:<script src="~/lib/jquery/dist/jquery.min.js"></script>
-    @:<script src="~/lib/jquery-validation/jquery.validate.min.js"></script>
+    @:<script src="~/lib/jquery-validation/jquery.validate.js"></script>
     @:<script src="~/lib/jquery-validation-unobtrusive/jquery.validate.unobtrusive.min.js"></script>
 @:}
     }
@@ -126,7 +126,7 @@
         {
 @:@@section Scripts {
     @:<script src="~/lib/jquery/dist/jquery.min.js"></script>
-    @:<script src="~/lib/jquery-validation/jquery.validate.min.js"></script>
+    @:<script src="~/lib/jquery-validation/jquery.validate.js"></script>
     @:<script src="~/lib/jquery-validation-unobtrusive/jquery.validate.unobtrusive.min.js"></script>
 @:}
         //ClearIndent();


### PR DESCRIPTION
The previous version was using a path which did not exist on disk and caused an in browser JavaScript error to be surfaced.