### PR TITLE
DB context related changes

### DIFF
--- a/src/Microsoft.Extensions.CodeGeneration.EntityFramework/Templates/DbContext/NewLocalDbContext.cshtml
+++ b/src/Microsoft.Extensions.CodeGeneration.EntityFramework/Templates/DbContext/NewLocalDbContext.cshtml
@@ -23,23 +23,9 @@ using Microsoft.Data.Entity;
     } 
 }    public class @Model.DbContextTypeName : @baseClassName
     {
-        private static bool _created = false;
-
         public @(Model.DbContextTypeName)()
         {
-            if (!_created)
-            {
-                _created = true;
-                Database.EnsureCreated();
-            }
-        }
-
-        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-        {
-        }
-
-        protected override void OnModelCreating(ModelBuilder builder)
-        {
+            
         }
 
         public DbSet<@Model.ModelTypeName> @Model.ModelTypeName { get; set; }

--- a/src/Microsoft.Extensions.CodeGeneration.EntityFramework/Templates/DbContext/NewLocalDbContext.cshtml
+++ b/src/Microsoft.Extensions.CodeGeneration.EntityFramework/Templates/DbContext/NewLocalDbContext.cshtml
@@ -23,11 +23,6 @@ using Microsoft.Data.Entity;
     } 
 }    public class @Model.DbContextTypeName : @baseClassName
     {
-        public @(Model.DbContextTypeName)()
-        {
-            
-        }
-
         public DbSet<@Model.ModelTypeName> @Model.ModelTypeName { get; set; }
     }
 @{

--- a/src/Microsoft.Extensions.CodeGenerators.Mvc/Templates/ControllerGenerator/ApiControllerWithContext.cshtml
+++ b/src/Microsoft.Extensions.CodeGenerators.Mvc/Templates/ControllerGenerator/ApiControllerWithContext.cshtml
@@ -65,11 +65,11 @@ namespace @Model.ControllerNamespace
 @{
     if (Model.UseAsync)
     {
-            @:@Model.ModelTypeName @Model.ModelVariable = await _context.@(entitySetName).SingleAsync(m => m.@primaryKeyName == id);
+            @:@Model.ModelTypeName @Model.ModelVariable = await _context.@(entitySetName).SingleOrDefaultAsync(m => m.@primaryKeyName == id);
     }
     else
     {
-            @:@Model.ModelTypeName @Model.ModelVariable = _context.@(entitySetName).Single(m => m.@primaryKeyName == id);
+            @:@Model.ModelTypeName @Model.ModelVariable = _context.@(entitySetName).SingleOrDefault(m => m.@primaryKeyName == id);
     }
 }
 
@@ -216,11 +216,11 @@ namespace @Model.ControllerNamespace
 @{
     if (Model.UseAsync)
     {
-            @:@Model.ModelTypeName @Model.ModelVariable = await _context.@(entitySetName).SingleAsync(m => m.@primaryKeyName == id);
+            @:@Model.ModelTypeName @Model.ModelVariable = await _context.@(entitySetName).SingleOrDefaultAsync(m => m.@primaryKeyName == id);
     }
     else
     {
-            @:@Model.ModelTypeName @Model.ModelVariable = _context.@(entitySetName).Single(m => m.@primaryKeyName == id);
+            @:@Model.ModelTypeName @Model.ModelVariable = _context.@(entitySetName).SingleOrDefault(m => m.@primaryKeyName == id);
     }
 }
             if (@Model.ModelVariable == null)

--- a/src/Microsoft.Extensions.CodeGenerators.Mvc/Templates/ControllerGenerator/MvcControllerWithContext.cshtml
+++ b/src/Microsoft.Extensions.CodeGenerators.Mvc/Templates/ControllerGenerator/MvcControllerWithContext.cshtml
@@ -113,11 +113,11 @@ namespace @Model.ControllerNamespace
 @{
     if (Model.UseAsync)
     {
-            @:@Model.ModelTypeName @Model.ModelVariable = await _context.@(entitySetName).SingleAsync(m => m.@primaryKeyName == id);
+            @:@Model.ModelTypeName @Model.ModelVariable = await _context.@(entitySetName).SingleOrDefaultAsync(m => m.@primaryKeyName == id);
     }
     else
     {
-            @:@Model.ModelTypeName @Model.ModelVariable = _context.@(entitySetName).Single(m => m.@primaryKeyName == id);
+            @:@Model.ModelTypeName @Model.ModelVariable = _context.@(entitySetName).SingleOrDefault(m => m.@primaryKeyName == id);
     }
 }            if (@Model.ModelVariable == null)
             {
@@ -197,11 +197,11 @@ namespace @Model.ControllerNamespace
 @{
     if (Model.UseAsync)
     {
-            @:@Model.ModelTypeName @Model.ModelVariable = await _context.@(entitySetName).SingleAsync(m => m.@primaryKeyName == id);
+            @:@Model.ModelTypeName @Model.ModelVariable = await _context.@(entitySetName).SingleOrDefaultAsync(m => m.@primaryKeyName == id);
     }
     else
     {
-            @:@Model.ModelTypeName @Model.ModelVariable = _context.@(entitySetName).Single(m => m.@primaryKeyName == id);
+            @:@Model.ModelTypeName @Model.ModelVariable = _context.@(entitySetName).SingleOrDefault(m => m.@primaryKeyName == id);
     }
 }            if (@Model.ModelVariable == null)
             {
@@ -272,11 +272,11 @@ namespace @Model.ControllerNamespace
 @{
     if (Model.UseAsync)
     {
-            @:@Model.ModelTypeName @Model.ModelVariable = await _context.@(entitySetName).SingleAsync(m => m.@primaryKeyName == id);
+            @:@Model.ModelTypeName @Model.ModelVariable = await _context.@(entitySetName).SingleOrDefaultAsync(m => m.@primaryKeyName == id);
     }
     else
     {
-            @:@Model.ModelTypeName @Model.ModelVariable = _context.@(entitySetName).Single(m => m.@primaryKeyName == id);
+            @:@Model.ModelTypeName @Model.ModelVariable = _context.@(entitySetName).SingleOrDefault(m => m.@primaryKeyName == id);
     }
 }            if (@Model.ModelVariable == null)
             {
@@ -301,11 +301,11 @@ namespace @Model.ControllerNamespace
         @:{
     if (Model.UseAsync)
     {
-            @:@Model.ModelTypeName @Model.ModelVariable = await _context.@(entitySetName).SingleAsync(m => m.@primaryKeyName == id);
+            @:@Model.ModelTypeName @Model.ModelVariable = await _context.@(entitySetName).SingleOrDefaultAsync(m => m.@primaryKeyName == id);
     }
     else
     {
-            @:@Model.ModelTypeName @Model.ModelVariable = _context.@(entitySetName).Single(m => m.@primaryKeyName == id);
+            @:@Model.ModelTypeName @Model.ModelVariable = _context.@(entitySetName).SingleOrDefault(m => m.@primaryKeyName == id);
     }
             @:_context.@(entitySetName).Remove(@Model.ModelVariable);
     if (Model.UseAsync)


### PR DESCRIPTION
Addressing below issues identified by @rowanmiller  

•	Null check after using Single is not needed as Single will throw if no entity is found. We probably want to swap to SingleOrDefault (rather than removing the null check) so that we return a Not Found status code.
•	We already discussed, but we should remove the EnsureCreated call to create the database. It’s not thread safe, and blocks you from using migrations in the future. We could look at scaffolding the corresponding migration for the user when we change the model for a given context.
•	Remove empty override of OnConfiguring, folks should use Startup.cs rather than this hook in ASP.NET 5 apps.
•	I would remove the empty override of OnModelCreating too – it doesn’t add much value.

cc @abpiskunov, @sayedihashimi, @barrytang 