### PR TITLE
Temporary solution for DisplayPropertyName.

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,3 +1,6 @@
 {
-    "projects": ["src", "test/TestApps"]
+  "projects": [ "src", "test/TestApps" ],
+  "sdk": {
+    "version": "1.0.0-rc2-16595"
+  }
 }

--- a/src/Microsoft.Extensions.CodeGeneration.Utils/Microsoft.Extensions.CodeGeneration.Utils.xproj
+++ b/src/Microsoft.Extensions.CodeGeneration.Utils/Microsoft.Extensions.CodeGeneration.Utils.xproj
@@ -10,6 +10,9 @@
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
     <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\</OutputPath>
   </PropertyGroup>
+  <PropertyGroup Label="Configuration">
+    <RootNamespace>Microsoft.Extensions.CodeGeneration.Utils</RootNamespace>
+  </PropertyGroup>
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>

--- a/src/Microsoft.Extensions.CodeGenerators.Mvc/Templates/ControllerGenerator/MvcControllerWithContext.cshtml
+++ b/src/Microsoft.Extensions.CodeGenerators.Mvc/Templates/ControllerGenerator/MvcControllerWithContext.cshtml
@@ -132,7 +132,7 @@ namespace @Model.ControllerNamespace
 @{
     foreach (var property in relatedProperties.Values)
     {
-            @:ViewData["@(property.ForeignKeyPropertyNames[0])"] = new SelectList(_context.@property.EntitySetName, "@property.PrimaryKeyNames[0]", "@property.DisplayPropertyName");
+            @:ViewData["@(property.ForeignKeyPropertyNames[0])"] = new SelectList(_context.@property.EntitySetName, "@property.PrimaryKeyNames[0]", typeof(@property.EntitySetName).GetProperties().Where(p=>p.Name!= "@property.PrimaryKeyNames[0]").FirstOrDefault().Name);
     }
 }            return View();
         }
@@ -171,7 +171,7 @@ namespace @Model.ControllerNamespace
 @{
     foreach (var property in relatedProperties.Values)
     {
-            @:ViewData["@(property.ForeignKeyPropertyNames[0])"] = new SelectList(_context.@property.EntitySetName, "@property.PrimaryKeyNames[0]", "@property.DisplayPropertyName", @(Model.ModelVariable).@property.ForeignKeyPropertyNames[0]);
+            @:ViewData["@(property.ForeignKeyPropertyNames[0])"] = new SelectList(_context.@property.EntitySetName, "@property.PrimaryKeyNames[0]", typeof(@property.EntitySetName).GetProperties().Where(p=>p.Name!= "@property.PrimaryKeyNames[0]").FirstOrDefault().Name, @(Model.ModelVariable).@property.ForeignKeyPropertyNames[0]);
     }
 }
             return View(@Model.ModelVariable);
@@ -209,7 +209,7 @@ namespace @Model.ControllerNamespace
 @{
     foreach (var property in relatedProperties.Values)
     {
-            @:ViewData["@(property.ForeignKeyPropertyNames[0])"] = new SelectList(_context.@property.EntitySetName, "@property.PrimaryKeyNames[0]", "@property.DisplayPropertyName", @(Model.ModelVariable).@property.ForeignKeyPropertyNames[0]);
+            @:ViewData["@(property.ForeignKeyPropertyNames[0])"] = new SelectList(_context.@property.EntitySetName, "@property.PrimaryKeyNames[0]", typeof(@property.EntitySetName).GetProperties().Where(p=>p.Name!= "@property.PrimaryKeyNames[0]").FirstOrDefault().Name, @(Model.ModelVariable).@property.ForeignKeyPropertyNames[0]);
     }
 }
             return View(@Model.ModelVariable);
@@ -245,7 +245,7 @@ namespace @Model.ControllerNamespace
 @{
     foreach (var property in relatedProperties.Values)
     {
-            @:ViewData["@(property.ForeignKeyPropertyNames[0])"] = new SelectList(_context.@property.EntitySetName, "@property.PrimaryKeyNames[0]", "@property.DisplayPropertyName", @(Model.ModelVariable).@property.ForeignKeyPropertyNames[0]);
+            @:ViewData["@(property.ForeignKeyPropertyNames[0])"] = new SelectList(_context.@property.EntitySetName, "@property.PrimaryKeyNames[0]", typeof(@property.EntitySetName).GetProperties().Where(p=>p.Name!= "@property.PrimaryKeyNames[0]").FirstOrDefault().Name, @(Model.ModelVariable).@property.ForeignKeyPropertyNames[0]);
     }
 }
             return View(@Model.ModelVariable);

--- a/src/Microsoft.Extensions.CodeGenerators.Mvc/Templates/ViewGenerator/Create.cshtml
+++ b/src/Microsoft.Extensions.CodeGenerators.Mvc/Templates/ViewGenerator/Create.cshtml
@@ -36,7 +36,7 @@
 @:
         //    PushIndent("    ");
     }
-@:<form asp-action="@Model.ViewName">
+@:<form asp-action="@Model.ViewName" asp-antiforgery="true">
     @:<div class="form-horizontal">
         @:<h4>@Model.ViewDataTypeShortName</h4>
         @:<hr />

--- a/src/Microsoft.Extensions.CodeGenerators.Mvc/Templates/ViewGenerator/Delete.cshtml
+++ b/src/Microsoft.Extensions.CodeGenerators.Mvc/Templates/ViewGenerator/Delete.cshtml
@@ -57,7 +57,7 @@
     }
     @:</dl>
     @:
-    @:<form asp-action="@Model.ViewName">
+    @:<form asp-action="@Model.ViewName" asp-antiforgery="true">
         @:<div class="form-actions no-color">
             @:<input type="submit" value="Delete" class="btn btn-default" /> |
             @:<a asp-action="Index">Back to List</a>

--- a/src/Microsoft.Extensions.CodeGenerators.Mvc/Templates/ViewGenerator/Edit.cshtml
+++ b/src/Microsoft.Extensions.CodeGenerators.Mvc/Templates/ViewGenerator/Edit.cshtml
@@ -36,7 +36,7 @@
 @:
         //    PushIndent("    ");
     }
-@:<form asp-action="@Model.ViewName">
+@:<form asp-action="@Model.ViewName" asp-antiforgery="true">
     @:<div class="form-horizontal">
         @:<h4>@Model.ViewDataTypeShortName</h4>
         @:<hr />


### PR DESCRIPTION
scaffolder has problem in controller generate.
in the other words "DisplayPropertyName" property in the "NavigationMetadata" class is not correct.() --> //Needs further implementation
so we can solve this with reflection Temporary.
we can change "@property.DisplayPropertyName" to "typeof(@property.EntitySetName).GetProperties().Where(p=>p.Name!= "@property.PrimaryKeyNames[0]").FirstOrDefault().Name" in the "MvcControllerWithContext" (templates) or set it for "DisplayPropertyName" in the "NavigationMetadata" class.