### PR TITLE
Add controllerNamespace parameter to Controller generator

### DIFF
--- a/src/Microsoft.VisualStudio.Web.CodeGenerators.Mvc/Common/CommonCommandLineModel.cs
+++ b/src/Microsoft.VisualStudio.Web.CodeGenerators.Mvc/Common/CommonCommandLineModel.cs
@@ -29,5 +29,8 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc
 
         [Option(Name = "relativeFolderPath", ShortName = "outDir", Description = "Specify the relative output folder path from project where the file needs to be generated, if not specified, file will be generated in the project folder")]
         public string RelativeFolderPath { get; set; }
+
+        [Option(Name = "controllerNamespace", ShortName = "namespace", Description = "Specify the name of the namespace to use for the generated controller")]
+        public string ControllerNamespace { get; set; }
     }
 }

--- a/src/Microsoft.VisualStudio.Web.CodeGenerators.Mvc/Controller/ControllerGeneratorBase.cs
+++ b/src/Microsoft.VisualStudio.Web.CodeGenerators.Mvc/Controller/ControllerGeneratorBase.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.Web.CodeGeneration.DotNet;
 using Microsoft.VisualStudio.Web.CodeGeneration;
@@ -83,13 +84,21 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Controller
             }
         }
 
-        protected string GetControllerNamespace()
+        protected string GetDefaultControllerNamespace(string relativeFolderPath)
         {
-            // Review: MVC scaffolding used ActiveProject's MSBuild RootNamespace property
-            // That's not possible in command line scaffolding - the closest we can get is
-            // the name of assembly??
-            var appName = ApplicationInfo.ApplicationName;
-            return appName + "." + Constants.ControllersFolderName;
+            return NameSpaceUtilities.GetSafeNameSpaceFromPath(relativeFolderPath, ApplicationInfo.ApplicationName);
+        }
+
+        protected void ValidateNameSpaceName(CommandLineGeneratorModel generatorModel)
+        {
+            if (!string.IsNullOrEmpty(generatorModel.ControllerNamespace) &&
+                !RoslynUtilities.IsValidNamespace(generatorModel.ControllerNamespace))
+            {
+                throw new InvalidOperationException(string.Format(
+                    CultureInfo.CurrentCulture,
+                    MessageStrings.InvalidNamespaceName,
+                    generatorModel.ControllerNamespace));
+            }
         }
 
         protected string ValidateAndGetOutputPath(CommandLineGeneratorModel generatorModel)

--- a/src/Microsoft.VisualStudio.Web.CodeGenerators.Mvc/Controller/ControllerWithContextGenerator.cs
+++ b/src/Microsoft.VisualStudio.Web.CodeGenerators.Mvc/Controller/ControllerWithContextGenerator.cs
@@ -78,7 +78,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Controller
         public override async Task Generate(CommandLineGeneratorModel controllerGeneratorModel)
         {
             Contract.Assert(!String.IsNullOrEmpty(controllerGeneratorModel.ModelClass));
-
+            ValidateNameSpaceName(controllerGeneratorModel);
             string outputPath = ValidateAndGetOutputPath(controllerGeneratorModel);
             var modelTypeAndContextModel = await ValidateModelAndGetMetadata(controllerGeneratorModel);
 
@@ -87,13 +87,15 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Controller
                 //Todo: Pluralize model name
                 controllerGeneratorModel.ControllerName = modelTypeAndContextModel.ModelType.Name + Constants.ControllerSuffix;
             }
-
+            var namespaceName = string.IsNullOrEmpty(controllerGeneratorModel.ControllerNamespace)
+                ? GetDefaultControllerNamespace(controllerGeneratorModel.RelativeFolderPath)
+                : controllerGeneratorModel.ControllerNamespace;
             var templateModel = new ControllerWithContextTemplateModel(modelTypeAndContextModel.ModelType, modelTypeAndContextModel.DbContextFullName)
             {
                 ControllerName = controllerGeneratorModel.ControllerName,
                 AreaName = string.Empty, //ToDo
                 UseAsync = controllerGeneratorModel.UseAsync, // This is no longer used for controllers with context.
-                ControllerNamespace = GetControllerNamespace(),
+                ControllerNamespace = namespaceName,
                 ModelMetadata = modelTypeAndContextModel.ContextProcessingResult.ModelMetadata
             };
 

--- a/src/Microsoft.VisualStudio.Web.CodeGenerators.Mvc/Controller/MvcController.cs
+++ b/src/Microsoft.VisualStudio.Web.CodeGenerators.Mvc/Controller/MvcController.cs
@@ -38,11 +38,13 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Controller
             {
                 throw new ArgumentException(GetRequiredNameError);
             }
-
+            ValidateNameSpaceName(controllerGeneratorModel);
             var layoutDependencyInstaller = ActivatorUtilities.CreateInstance<MvcLayoutDependencyInstaller>(ServiceProvider);
             await layoutDependencyInstaller.Execute();
-
-            var templateModel = new ClassNameModel(className: controllerGeneratorModel.ControllerName, namespaceName: GetControllerNamespace());
+            var namespaceName = string.IsNullOrEmpty(controllerGeneratorModel.ControllerNamespace)
+                ? GetDefaultControllerNamespace(controllerGeneratorModel.RelativeFolderPath)
+                : controllerGeneratorModel.ControllerNamespace;
+            var templateModel = new ClassNameModel(className: controllerGeneratorModel.ControllerName, namespaceName: namespaceName);
 
             var outputPath = ValidateAndGetOutputPath(controllerGeneratorModel);
             await CodeGeneratorActionsService.AddFileFromTemplateAsync(outputPath, GetTemplateName(controllerGeneratorModel), TemplateFolders, templateModel);

--- a/src/Microsoft.VisualStudio.Web.CodeGenerators.Mvc/MessageStrings.Designer.cs
+++ b/src/Microsoft.VisualStudio.Web.CodeGenerators.Mvc/MessageStrings.Designer.cs
@@ -87,6 +87,15 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc {
         }
         
         /// <summary>
+        ///    Looks up a localized string similar to The namespace name &apos;{0}&apos; is not valid..
+        /// </summary>
+        internal static string InvalidNamespaceName {
+            get {
+                return ResourceManager.GetString("InvalidNamespaceName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///    Looks up a localized string similar to Please provide a valid {0}.
         /// </summary>
         internal static string ProvideValidArgument {

--- a/src/Microsoft.VisualStudio.Web.CodeGenerators.Mvc/MessageStrings.resx
+++ b/src/Microsoft.VisualStudio.Web.CodeGenerators.Mvc/MessageStrings.resx
@@ -126,6 +126,9 @@
   <data name="FileExists_useforce" xml:space="preserve">
     <value>The file {0} exists, use -f option to overwrite</value>
   </data>
+  <data name="InvalidNamespaceName" xml:space="preserve">
+    <value>The namespace name '{0}' is not valid.</value>
+  </data>
   <data name="ProvideValidArgument" xml:space="preserve">
     <value>Please provide a valid {0}</value>
   </data>

--- a/src/Microsoft.VisualStudio.Web.CodeGenerators.Mvc/NameSpaceUtilities.cs
+++ b/src/Microsoft.VisualStudio.Web.CodeGenerators.Mvc/NameSpaceUtilities.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc
+{
+    public class NameSpaceUtilities
+    {
+        private static string GetSafeName(string name)
+        {
+            char[] chars = name.ToCharArray();
+            string result = String.Empty;
+            for (int i = 0; i < chars.Length; i++)
+            {
+                if (!Char.IsDigit(chars[i]) && !Char.IsLetter(chars[i]) && chars[i] != '.')
+                {
+                    chars[i] = '_';
+                }
+                result = result + chars[i];
+            }
+            if (Char.IsDigit(result[0]))
+            {
+                result = "_" + result;
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// Converts a namespace name to a safe namespace name.
+        /// </summary>
+        public static string GetSafeNameSpaceName(string namespaceName)
+        {
+            if(namespaceName == null)
+            {
+                throw new ArgumentNullException(nameof(namespaceName));
+            }
+
+            if (namespaceName.Trim().Length == 0)
+            {
+                return "_";
+            }
+
+            string[] names = namespaceName.Split(new char[] { '.' }, StringSplitOptions.RemoveEmptyEntries);
+            string name = String.Empty;
+            for (int i = 0; i < names.Length; i++)
+            {
+                if (i != 0)
+                {
+                    name = name + ".";
+                }
+                name = name + GetSafeName(names[i]);
+            }
+            return string.IsNullOrEmpty(name) ? "_" : name;
+        }
+
+        /// <summary>
+        /// Converts a path like a/b/c/d to namespace like a.b.c.d
+        /// </summary>
+        public static string GetSafeNameSpaceFromPath(string path, string namespacePrefix = null)
+        {
+            if(path == null)
+            {
+                throw new ArgumentNullException(nameof(path));
+            }
+
+            var namespaceName = path.Replace(Path.DirectorySeparatorChar, '.');
+            if (!string.IsNullOrEmpty(namespacePrefix))
+            {
+                namespaceName = namespacePrefix +"." + namespaceName;
+            }
+
+            return GetSafeNameSpaceName(namespaceName);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.Web.CodeGenerators.Mvc/RoslynUtilities.cs
+++ b/src/Microsoft.VisualStudio.Web.CodeGenerators.Mvc/RoslynUtilities.cs
@@ -30,5 +30,28 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc
             }
             return IsKeyWord(identifier) ? $"@{identifier}" : identifier;
         }
+
+        public static bool IsValidNamespace(string namespaceName)
+        {
+            if (namespaceName == null)
+            {
+                throw new ArgumentNullException(nameof(namespaceName));
+            }
+
+            if (IsKeyWord(namespaceName))
+            {
+                return false;
+            }
+
+            var parts = namespaceName.Split('.');
+            foreach (var part in parts)
+            {
+                if (!SyntaxFacts.IsValidIdentifier(part))
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
     }
 }

--- a/test/Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Test/ControllerGeneratorBaseTests.cs
+++ b/test/Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Test/ControllerGeneratorBaseTests.cs
@@ -1,0 +1,90 @@
+﻿using Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Controller;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Web.CodeGeneration;
+using Microsoft.VisualStudio.Web.CodeGeneration.DotNet;
+using Moq;
+using Xunit;
+
+namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Test
+{
+    public class ControllerGeneratorBaseTests
+    {
+        protected Mock<ILibraryManager> _libraryManager;
+        protected Mock<ICodeGeneratorActionsService> _codeGenActionService;
+        protected Mock<IServiceProvider> _serviceProvider;
+        protected ILogger _logger;
+        protected IApplicationInfo _applicationInfo;
+
+        public ControllerGeneratorBaseTests()
+        {
+            _libraryManager = new Mock<ILibraryManager>();
+            _codeGenActionService = new Mock<ICodeGeneratorActionsService>();
+            _serviceProvider = new Mock<IServiceProvider>();
+            _logger = new ConsoleLogger();
+            _applicationInfo = new ApplicationInfo("TestApp", "..", "Debug");
+        }
+
+        [Fact]
+        public void Test_ValidateNameSpace_ThrowsException()
+        {
+            var generator = new MockControllerGenerator(
+                _libraryManager.Object,
+                _applicationInfo,
+                _codeGenActionService.Object,
+                _serviceProvider.Object,
+                _logger
+                );
+
+            var model = GetModel();
+            model.ControllerNamespace = "Invalid Namespace";
+            try
+            {
+                generator.Generate(model);
+                Assert.True(false, "Expected an exception");
+            }
+            catch(InvalidOperationException ex)
+            {
+                Assert.Equal("The namespace name 'Invalid Namespace' is not valid.", ex.Message);
+                return;
+            }
+            
+        }
+
+        [Fact]
+        public void Test_ValidateNameSpace()
+        {
+            var generator = new MockControllerGenerator(
+                _libraryManager.Object,
+                _applicationInfo,
+                _codeGenActionService.Object,
+                _serviceProvider.Object,
+                _logger
+                );
+
+            var model = GetModel();
+            model.ControllerNamespace = "Valid.Namespace";
+            try
+            {
+                generator.Generate(model);
+            }
+            catch
+            {
+                Assert.True(false);
+                return;
+            }
+
+        }
+
+        protected virtual CommandLineGeneratorModel GetModel()
+        {
+            var model = new CommandLineGeneratorModel();
+            model.ControllerName = "TestController";
+            return model;
+        }
+    }
+
+    
+}

--- a/test/Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Test/MockControllerGenerator.cs
+++ b/test/Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Test/MockControllerGenerator.cs
@@ -1,0 +1,35 @@
+﻿using Microsoft.VisualStudio.Web.CodeGeneration;
+using Microsoft.VisualStudio.Web.CodeGeneration.DotNet;
+using Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Controller;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Test
+{
+    public class MockControllerGenerator : ControllerGeneratorBase
+    {
+        public MockControllerGenerator(
+            ILibraryManager libraryManager,
+            IApplicationInfo applicationInfo,
+            ICodeGeneratorActionsService codeGeneratorActionsService,
+            IServiceProvider serviceProvider,
+            ILogger logger)
+            : base(libraryManager, applicationInfo, codeGeneratorActionsService, serviceProvider, logger)
+        {
+        }
+
+        public override Task Generate(CommandLineGeneratorModel controllerGeneratorModel)
+        {
+            ValidateNameSpaceName(controllerGeneratorModel);
+            var outputPath = ValidateAndGetOutputPath(controllerGeneratorModel);
+            return Task.CompletedTask;
+        }
+
+        protected override string GetTemplateName(CommandLineGeneratorModel controllerGeneratorModel)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/test/Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Test/NamespaceUtilitiesTest.cs
+++ b/test/Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Test/NamespaceUtilitiesTest.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Test
+{
+    public class NamespaceUtilitiesTest
+    {
+        [Theory, MemberData("NameSpaceData")]
+        public void TestGetSafeNameSpaceName(string nameSpaceName, string expected)
+        {
+            Assert.Equal(expected, NameSpaceUtilities.GetSafeNameSpaceName(nameSpaceName));
+        }
+
+        public static IEnumerable<object[]> NameSpaceData
+        {
+            get
+            {
+                return new[]
+                {
+                    new object[] {"Valid.NameSpace","Valid.NameSpace"},
+                    new object[] {"NameSpace with spaces","NameSpace_with_spaces"},
+                    new object[] {"Namespace-with-hyphens","Namespace_with_hyphens"},
+                    new object[] {"9.0namespace.numb3r3d","_9._0namespace.numb3r3d"},
+                    new object[] {"","_"},
+                    new object[] {"    ","_"},
+                    new object[] { "prénom", "prénom" }
+                };
+            }
+        }
+
+        [Theory, MemberData("NamespaceFromPathData")]
+        public void TestGetSafeNameSpaceNameFromPath(string path, string prefix, string expected)
+        {
+            Assert.Equal(expected, NameSpaceUtilities.GetSafeNameSpaceFromPath(path, prefix));
+        }
+
+        private static char sep = Path.DirectorySeparatorChar;
+
+        public static IEnumerable<object[]> NamespaceFromPathData
+        {
+            get
+            {
+                return new[]
+                {
+                    new object[] {$"Valid{sep}NameSpace", null, "Valid.NameSpace"},
+                    new object[] {$"{sep}Valid{sep}NameSpace", null, "Valid.NameSpace"},
+                    new object[] {$"Valid{sep}Name.Space", null, "Valid.Name.Space"},
+                    new object[] {$"Valid{sep}NameSpace", "prefix", "prefix.Valid.NameSpace"},
+                    new object[] {$"{sep}Valid{sep}NameSpace", "prefix", "prefix.Valid.NameSpace"},
+                    new object[] {$"Valid{sep}Name.Space", "prefix", "prefix.Valid.Name.Space"},
+                    new object[] {$"..{sep}..{sep}name.space", null, "name.space"},
+                    new object[] {$"..{sep}..{sep}", null, "_"}
+                };
+            }
+        }
+    }
+}

--- a/test/Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Test/RoslynUtilitiesTest.cs
+++ b/test/Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Test/RoslynUtilitiesTest.cs
@@ -104,5 +104,33 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Test
             }
         }
 
+        [Theory, MemberData("NameSpaceTestData")]
+        public void TestCreateValidNameSpace(string identifier, bool expectedValue)
+        {
+            Assert.Equal(expectedValue, RoslynUtilities.IsValidNamespace(identifier));
+        }
+
+        public static IEnumerable<object[]> NameSpaceTestData
+        {
+            get
+            {
+                return new[]
+                {
+                    new object[] {"dotnet-aspnet-codegenerator", false},
+                    new object[] {"abc def", false },
+                    new object[] {"abc.def ghi.xyz", false},
+                    new object[] {"..abc",false},
+                    new object[] {"abc.@xyz", false},
+                    new object[] {"$abd", false}, 
+                    new object[] {"namespace", false},
+                    new object[] {"class", false},
+                    new object[] {"9abc", false},
+                    new object[] {"9.abc", false},
+                    new object[] {"ab.c9.de", true},  
+                    new object[] {"abc.def", true},
+                    new object[] {"validnamespace", true}
+                };
+            }
+        }
     }
 }


### PR DESCRIPTION
Fixes #229 by accepting a namespace parameter from user instead of always using `<appName>.Controllers` as the namespace. 

If the param is not provided, it falls back to old behavior, but checks if the `<appName>.Controllers` is valid or not. If not just uses `Controllers` as the namespace. 

cc @abpiskunov, @sayedihashimi 