### PR TITLE
Compute the display property for the navigation metadata.

### DIFF
--- a/src/Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore/NavigationMetadata.cs
+++ b/src/Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore/NavigationMetadata.cs
@@ -21,7 +21,6 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore
             Contract.Assert(navigation.IsDependentToPrincipal());
 
             AssociationPropertyName = navigation.Name;
-            DisplayPropertyName = AssociationPropertyName; //Needs further implementation
 
             var otherEntityType = navigation.ForeignKey.ResolveOtherEntityType(navigation.DeclaringEntityType);
             EntitySetName = ModelMetadata.GetEntitySetName(dbContextType, otherEntityType.ClrType);
@@ -32,6 +31,20 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore
                 .Where(p => p.DeclaringEntityType == navigation.DeclaringEntityType)
                 .Select(p => p.Name)
                 .ToArray();
+
+            // The default for the display property is the primary key of the navigation. 
+            DisplayPropertyName = PrimaryKeyNames[0];
+
+            // If there is a non nullable string property in the navigation's target type, we use that instead. 
+            var displayPropertyCandidate = navigation
+                .GetTargetType()
+                .GetProperties()
+                .FirstOrDefault(p => !p.IsNullable && p.ClrType == typeof(string));
+
+            if (displayPropertyCandidate != null)
+            {
+                DisplayPropertyName = displayPropertyCandidate.Name;
+            }
         }
 
         public string AssociationPropertyName { get; set; }

--- a/test/Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore.Test/NavigationMetadataTests.cs
+++ b/test/Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore.Test/NavigationMetadataTests.cs
@@ -24,7 +24,7 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore.Test
             Assert.NotNull(navigationMetadata);
             Assert.Equal(nameof(Product.Category), navigationMetadata.AssociationPropertyName);
             Assert.Equal(nameof(TestDbContext.Categories), navigationMetadata.EntitySetName);
-            Assert.Equal(nameof(Product.Category), navigationMetadata.DisplayPropertyName); //Todo
+            Assert.Equal(nameof(Category.CategoryName), navigationMetadata.DisplayPropertyName);
             Assert.Equal(1, navigationMetadata.ForeignKeyPropertyNames.Count());
             Assert.Equal(nameof(Product.CategoryId), navigationMetadata.ForeignKeyPropertyNames[0]);
             Assert.Equal(1, navigationMetadata.PrimaryKeyNames.Count());
@@ -47,7 +47,7 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore.Test
             Assert.NotNull(navigationMetadata);
             Assert.Equal(nameof(Order.Customer), navigationMetadata.AssociationPropertyName);
             Assert.Equal(nameof(TestDbContext.Customers), navigationMetadata.EntitySetName);
-            Assert.Equal(nameof(Order.Customer), navigationMetadata.DisplayPropertyName); //Todo
+            Assert.Equal(nameof(Customer.CustomerId), navigationMetadata.DisplayPropertyName); //Todo
             Assert.Equal(1, navigationMetadata.ForeignKeyPropertyNames.Count());
             Assert.Equal(nameof(Order.CustomerId), navigationMetadata.ForeignKeyPropertyNames[0]);
             Assert.Equal(1, navigationMetadata.PrimaryKeyNames.Count());

--- a/test/Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore.Test/TestModels/Models.cs
+++ b/test/Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore.Test/TestModels/Models.cs
@@ -38,11 +38,15 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore.Test.Tes
         public string ReadOnlyProperty { get; set; }
     }
 
-    public class Category
+    public class CategoryBase
+    {
+        [Required]
+        public string CategoryName { get; set; }
+    }
+
+    public class Category : CategoryBase
     {
         public int CategoryId { get; set; }
-
-        public string CategoryName { get; set; }
 
         public ICollection<Product> Products { get; set; }
     }


### PR DESCRIPTION
Fixes #232 

The `Displayname` property is used in the [MvcControllerWithContext.cshtml](https://github.com/aspnet/Scaffolding/blob/dev/src/Microsoft.VisualStudio.Web.CodeGenerators.Mvc/Templates/ControllerGenerator/MvcControllerWithContext.cshtml#L106) to create a `SelectList`

In MVC5 the behavior was if the `Navigation.TargetType` has a string property it would use it as the display property. 
If there is no string property it would use the primary key from the navigation. 
Here we do the same thing, except we also check if the string column is nullable or not. 
If it is nullable, we fall back to using the navigation's primary key.  

cc @natemcmaster 