### PR TITLE
Use view generator to generate views while generating controller with context.

### DIFF
--- a/src/Microsoft.VisualStudio.Web.CodeGenerators.Mvc/Controller/ControllerWithContextGenerator.cs
+++ b/src/Microsoft.VisualStudio.Web.CodeGenerators.Mvc/Controller/ControllerWithContextGenerator.cs
@@ -81,7 +81,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Controller
             ValidateNameSpaceName(controllerGeneratorModel);
             string outputPath = ValidateAndGetOutputPath(controllerGeneratorModel);
 
-            var modelTypeAndContextModel = await ModelMetadataUtilities.ValidateModelAndGetMetadata(controllerGeneratorModel, EntityFrameworkService, ModelTypesLocator);
+            var modelTypeAndContextModel = await ModelMetadataUtilities.ValidateModelAndGetEFMetadata(controllerGeneratorModel, EntityFrameworkService, ModelTypesLocator);
 
             if (string.IsNullOrEmpty(controllerGeneratorModel.ControllerName))
             {
@@ -120,6 +120,12 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Controller
             {
                 var layoutDependencyInstaller = ActivatorUtilities.CreateInstance<MvcLayoutDependencyInstaller>(ServiceProvider);
                 var viewGenerator = ActivatorUtilities.CreateInstance<ModelBasedViewScaffolder>(ServiceProvider);
+                
+                //TODO need logic for areas
+                var viewBaseOutputPath = Path.Combine(
+                    ApplicationInfo.ApplicationBasePath,
+                    Constants.ViewsFolderName,
+                    controllerRootName);
 
                 await layoutDependencyInstaller.Execute();
                 var viewGeneratorModel = new ViewGeneratorModel()
@@ -128,21 +134,11 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Controller
                     PartialView = false,
                     LayoutPage = controllerGeneratorModel.LayoutPage,
                     Force = controllerGeneratorModel.Force,
-                    RelativeFolderPath = Path.Combine(
-                        ApplicationInfo.ApplicationBasePath,
-                        Constants.ViewsFolderName,
-                        controllerRootName),
+                    RelativeFolderPath = viewBaseOutputPath,
                     ReferenceScriptLibraries = controllerGeneratorModel.ReferenceScriptLibraries
                 };
 
                 var viewAndTemplateNames = new Dictionary<string, string>();
-
-                //TODO need logic for areas
-                var viewBaseOutputPath = Path.Combine(
-                        ApplicationInfo.ApplicationBasePath,
-                        Constants.ViewsFolderName,
-                        controllerRootName);
-
                 foreach (var viewTemplate in _views)
                 {
                     var viewName = viewTemplate == "List" ? "Index" : viewTemplate;

--- a/src/Microsoft.VisualStudio.Web.CodeGenerators.Mvc/Controller/ControllerWithContextGenerator.cs
+++ b/src/Microsoft.VisualStudio.Web.CodeGenerators.Mvc/Controller/ControllerWithContextGenerator.cs
@@ -119,7 +119,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Controller
             if (!controllerGeneratorModel.IsRestController && !controllerGeneratorModel.NoViews)
             {
                 var layoutDependencyInstaller = ActivatorUtilities.CreateInstance<MvcLayoutDependencyInstaller>(ServiceProvider);
-                var viewGenerator = ActivatorUtilities.CreateInstance<ViewGenerator>(ServiceProvider);
+                var viewGenerator = ActivatorUtilities.CreateInstance<ModelBasedViewScaffolder>(ServiceProvider);
 
                 await layoutDependencyInstaller.Execute();
                 var viewGeneratorModel = new ViewGeneratorModel()

--- a/src/Microsoft.VisualStudio.Web.CodeGenerators.Mvc/ModelMetadataUtilities.cs
+++ b/src/Microsoft.VisualStudio.Web.CodeGenerators.Mvc/ModelMetadataUtilities.cs
@@ -1,0 +1,58 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.Contracts;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Web.CodeGeneration;
+using Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore;
+
+namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc
+{
+    internal static class ModelMetadataUtilities
+    {
+        internal static async Task<ModelTypeAndContextModel> ValidateModelAndGetCodeModelMetadata(
+            CommonCommandLineModel commandLineModel, 
+            IEntityFrameworkService entityFrameworkService, 
+            IModelTypesLocator modelTypesLocator)
+        {
+            ModelType model = ValidationUtil.ValidateType(commandLineModel.ModelClass, "model", modelTypesLocator);
+
+            Contract.Assert(model != null, MessageStrings.ValidationSuccessfull_modelUnset);
+            var result = await entityFrameworkService.GetModelMetadata(model);
+
+            return new ModelTypeAndContextModel()
+            {
+                ModelType = model,
+                ContextProcessingResult = result
+            };
+        }
+
+        internal static async Task<ModelTypeAndContextModel> ValidateModelAndGetMetadata(
+            CommonCommandLineModel commandLineModel, 
+            IEntityFrameworkService entityFrameworkService, 
+            IModelTypesLocator modelTypesLocator)
+        {
+            ModelType model = ValidationUtil.ValidateType(commandLineModel.ModelClass, "model", modelTypesLocator);
+            ModelType dataContext = ValidationUtil.ValidateType(commandLineModel.DataContextClass, "dataContext", modelTypesLocator, throwWhenNotFound: false);
+
+            // Validation successful
+            Contract.Assert(model != null, MessageStrings.ValidationSuccessfull_modelUnset);
+
+            var dbContextFullName = dataContext != null ? dataContext.FullName : commandLineModel.DataContextClass;
+
+            var modelMetadata = await entityFrameworkService.GetModelMetadata(
+                dbContextFullName,
+                model);
+
+            return new ModelTypeAndContextModel()
+            {
+                ModelType = model,
+                DbContextFullName = dbContextFullName,
+                ContextProcessingResult = modelMetadata
+            };
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.Web.CodeGenerators.Mvc/ModelMetadataUtilities.cs
+++ b/src/Microsoft.VisualStudio.Web.CodeGenerators.Mvc/ModelMetadataUtilities.cs
@@ -30,7 +30,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc
             };
         }
 
-        internal static async Task<ModelTypeAndContextModel> ValidateModelAndGetMetadata(
+        internal static async Task<ModelTypeAndContextModel> ValidateModelAndGetEFMetadata(
             CommonCommandLineModel commandLineModel, 
             IEntityFrameworkService entityFrameworkService, 
             IModelTypesLocator modelTypesLocator)

--- a/src/Microsoft.VisualStudio.Web.CodeGenerators.Mvc/Templates/ViewGenerator/Empty.cshtml
+++ b/src/Microsoft.VisualStudio.Web.CodeGenerators.Mvc/Templates/ViewGenerator/Empty.cshtml
@@ -1,0 +1,52 @@
+@inherits Microsoft.VisualStudio.Web.CodeGeneration.Templating.RazorTemplateBase
+@using Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore
+
+@{
+    if (Model.IsPartialView)
+    {
+@:@@*
+@:    For more information on enabling MVC for empty projects, visit http://go.microsoft.com/fwlink/?LinkID=397860
+@:*@@
+
+    }
+    else if (Model.IsLayoutPageSelected)
+    {
+@:@@{
+    @:ViewData["Title"] = "@Model.ViewName";
+        if (!string.IsNullOrEmpty(Model.LayoutPageFile))
+        {
+    @:Layout = "@Model.LayoutPageFile";
+        }
+@:}
+@:
+@:<h2>@Model.ViewName</h2>
+@:
+    }
+    else
+    {
+@:@@{
+    @:Layout = null;
+@:}
+@:
+@:<!DOCTYPE html>
+@:
+@:<html>
+@:<head>
+    @:<meta name="viewport" content="width=device-width" />
+    @:<title>@Model.ViewName</title>
+@:</head>
+@:<body>
+    }
+    if (Model.ReferenceScriptLibraries)
+    {
+@:@@section Scripts {
+    @:@@{await Html.RenderPartialAsync("_ValidationScriptsPartial");}
+@:}
+    }
+    // The following code closes the tag used in the case of a view using a layout page and the body and html tags in the case of a regular view page
+    if (!Model.IsPartialView && !Model.IsLayoutPageSelected)
+    {
+@:</body>
+@:</html>
+    }
+}

--- a/src/Microsoft.VisualStudio.Web.CodeGenerators.Mvc/Templates/ViewGenerator/_ValidationScriptsPartial.cshtml
+++ b/src/Microsoft.VisualStudio.Web.CodeGenerators.Mvc/Templates/ViewGenerator/_ValidationScriptsPartial.cshtml
@@ -1,0 +1,14 @@
+<environment names="Development">
+    <script src="~/lib/jquery-validation/dist/jquery.validate.js"></script>
+    <script src="~/lib/jquery-validation-unobtrusive/jquery.validate.unobtrusive.js"></script>
+</environment>
+<environment names="Staging,Production">
+    <script src="https://ajax.aspnetcdn.com/ajax/jquery.validate/1.14.0/jquery.validate.min.js"
+            asp-fallback-src="~/lib/jquery-validation/dist/jquery.validate.min.js"
+            asp-fallback-test="window.jQuery && window.jQuery.validator">
+    </script>
+    <script src="https://ajax.aspnetcdn.com/ajax/jquery.validation.unobtrusive/3.2.6/jquery.validate.unobtrusive.min.js"
+            asp-fallback-src="~/lib/jquery-validation-unobtrusive/jquery.validate.unobtrusive.min.js"
+            asp-fallback-test="window.jQuery && window.jQuery.validator && window.jQuery.validator.unobtrusive">
+    </script>
+</environment>

--- a/src/Microsoft.VisualStudio.Web.CodeGenerators.Mvc/View/EmptyViewScaffolder.cs
+++ b/src/Microsoft.VisualStudio.Web.CodeGenerators.Mvc/View/EmptyViewScaffolder.cs
@@ -1,0 +1,58 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Web.CodeGeneration;
+using Microsoft.VisualStudio.Web.CodeGeneration.DotNet;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Dependency;
+
+namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.View
+{
+    public class EmptyViewScaffolder : ViewScaffolderBase
+    {
+        private static IEnumerable<RequiredFileEntity> RequiredFiles = new List<RequiredFileEntity>();
+        public EmptyViewScaffolder(
+            ILibraryManager libraryManager,
+            IApplicationInfo applicationInfo,
+            ICodeGeneratorActionsService codeGeneratorActionsService,
+            IServiceProvider serviceProvider,
+            ILogger logger)
+            : base(libraryManager, applicationInfo, codeGeneratorActionsService, serviceProvider, logger)
+        {
+
+        }
+
+        public override async Task GenerateCode(ViewGeneratorModel viewGeneratorModel)
+        {
+            if (viewGeneratorModel == null)
+            {
+                throw new ArgumentNullException(nameof(viewGeneratorModel));
+            }
+
+            if (string.IsNullOrEmpty(viewGeneratorModel.ViewName))
+            {
+                throw new ArgumentException(MessageStrings.ViewNameRequired);
+            }
+
+            if (string.IsNullOrEmpty(viewGeneratorModel.TemplateName))
+            {
+                throw new ArgumentException(MessageStrings.TemplateNameRequired);
+            }
+
+            var outputPath = ValidateAndGetOutputPath(viewGeneratorModel, outputFileName: viewGeneratorModel.ViewName + Constants.ViewExtension);
+            var layoutDependencyInstaller = ActivatorUtilities.CreateInstance<MvcLayoutDependencyInstaller>(_serviceProvider);
+            await layoutDependencyInstaller.Execute();
+
+            await GenerateView(viewGeneratorModel, null, outputPath);
+            await layoutDependencyInstaller.InstallDependencies();
+        }
+
+        protected override IEnumerable<RequiredFileEntity> GetRequiredFiles(ViewGeneratorModel viewGeneratorModel)
+        {
+            return RequiredFiles;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.Web.CodeGenerators.Mvc/View/ModelBasedViewScaffolder.cs
+++ b/src/Microsoft.VisualStudio.Web.CodeGenerators.Mvc/View/ModelBasedViewScaffolder.cs
@@ -1,0 +1,154 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Web.CodeGeneration;
+using Microsoft.VisualStudio.Web.CodeGeneration.DotNet;
+using Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Dependency;
+
+namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.View
+{
+    public class ModelBasedViewScaffolder : ViewScaffolderBase
+    {
+        private IEntityFrameworkService _entityFrameworkService;
+        private IModelTypesLocator _modelTypesLocator;
+
+        public ModelBasedViewScaffolder(
+            ILibraryManager libraryManager,
+            IApplicationInfo applicationInfo,
+            IModelTypesLocator modelTypesLocator,
+            IEntityFrameworkService entityFrameworkService,
+            ICodeGeneratorActionsService codeGeneratorActionsService,
+            IServiceProvider serviceProvider,
+            ILogger logger) 
+            : base(libraryManager, applicationInfo, codeGeneratorActionsService, serviceProvider, logger)
+        {
+            if (modelTypesLocator == null)
+            {
+                throw new ArgumentNullException(nameof(modelTypesLocator));
+            }
+
+            if (entityFrameworkService == null)
+            {
+                throw new ArgumentNullException(nameof(entityFrameworkService));
+            }
+            _modelTypesLocator = modelTypesLocator;
+            _entityFrameworkService = entityFrameworkService;
+        }
+
+        public override async Task GenerateCode(ViewGeneratorModel viewGeneratorModel)
+        {
+            if (viewGeneratorModel == null)
+            {
+                throw new ArgumentNullException(nameof(viewGeneratorModel));
+            }
+
+            if (string.IsNullOrEmpty(viewGeneratorModel.ViewName))
+            {
+                throw new ArgumentException(MessageStrings.ViewNameRequired);
+            }
+
+            if (string.IsNullOrEmpty(viewGeneratorModel.TemplateName))
+            {
+                throw new ArgumentException(MessageStrings.TemplateNameRequired);
+            }
+
+            ModelTypeAndContextModel modelTypeAndContextModel = null;
+            var outputPath = ValidateAndGetOutputPath(viewGeneratorModel, outputFileName: viewGeneratorModel.ViewName + Constants.ViewExtension);
+
+            if (string.IsNullOrEmpty(viewGeneratorModel.DataContextClass))
+            {
+                modelTypeAndContextModel = await ModelMetadataUtilities.ValidateModelAndGetCodeModelMetadata(viewGeneratorModel, _entityFrameworkService, _modelTypesLocator);
+            }
+            else
+            {
+                modelTypeAndContextModel = await ModelMetadataUtilities.ValidateModelAndGetMetadata(viewGeneratorModel, _entityFrameworkService, _modelTypesLocator);
+            }
+
+            var layoutDependencyInstaller = ActivatorUtilities.CreateInstance<MvcLayoutDependencyInstaller>(_serviceProvider);
+            await layoutDependencyInstaller.Execute();
+
+            await GenerateView(viewGeneratorModel, modelTypeAndContextModel, outputPath);
+            await layoutDependencyInstaller.InstallDependencies();
+
+            if (modelTypeAndContextModel.ContextProcessingResult.ContextProcessingStatus == ContextProcessingStatus.ContextAddedButRequiresConfig)
+            {
+                throw new Exception(string.Format("{0} {1}", MessageStrings.ScaffoldingSuccessful_unregistered, MessageStrings.Scaffolding_additionalSteps));
+            }
+        }
+
+        protected override IEnumerable<RequiredFileEntity> GetRequiredFiles(ViewGeneratorModel viewGeneratorModel)
+        {
+            List<RequiredFileEntity> requiredFiles = new List<RequiredFileEntity>();
+
+            if (viewGeneratorModel.ReferenceScriptLibraries)
+            {
+                requiredFiles.Add(new RequiredFileEntity(@"Views/Shared/_ValidationScriptsPartial.cshtml", @"_ValidationScriptsPartial.cshtml"));
+            }
+
+            return requiredFiles;
+        }
+
+        /// <summary>
+        /// Method exposed for adding multiple views in one operation.
+        /// Utilised by the ControllerWithContextGenerator which generates 5 views for a MVC controller with context.
+        /// </summary>
+        /// <param name="viewsAndTemplates">Names of views and the corresponding template names</param>
+        /// <param name="viewGeneratorModel">Model for View Generator</param>
+        /// <param name="modelTypeAndContextModel">Model Type and DbContext metadata</param>
+        /// <param name="baseOutputPath">Folder where all views will be generated</param>
+        internal async Task GenerateViews(Dictionary<string, string> viewsAndTemplates, ViewGeneratorModel viewGeneratorModel, ModelTypeAndContextModel modelTypeAndContextModel, string baseOutputPath)
+        {
+
+            if (viewsAndTemplates == null)
+            {
+                throw new ArgumentNullException(nameof(viewsAndTemplates));
+            }
+
+            if (viewGeneratorModel == null)
+            {
+                throw new ArgumentNullException(nameof(viewsAndTemplates));
+            }
+
+            if (modelTypeAndContextModel == null)
+            {
+                throw new ArgumentNullException(nameof(modelTypeAndContextModel));
+            }
+
+            if (string.IsNullOrEmpty(baseOutputPath))
+            {
+                baseOutputPath = ApplicationInfo.ApplicationBasePath;
+            }
+
+            foreach (var entry in viewsAndTemplates)
+            {
+                var viewName = entry.Key;
+                var templateName = entry.Value;
+                if (viewName.EndsWith(Constants.ViewExtension, StringComparison.OrdinalIgnoreCase))
+                {
+                    int viewNameLength = viewName.Length - Constants.ViewExtension.Length;
+                    viewName = viewName.Substring(0, viewNameLength);
+                }
+
+                var outputPath = Path.Combine(baseOutputPath, viewName + Constants.ViewExtension);
+                bool isLayoutSelected = !viewGeneratorModel.PartialView &&
+                    (viewGeneratorModel.UseDefaultLayout || !String.IsNullOrEmpty(viewGeneratorModel.LayoutPage));
+
+                var templateModel = GetViewGeneratorTemplateModel(viewGeneratorModel, modelTypeAndContextModel);
+                templateModel.ViewName = viewName;
+
+                templateName = templateName + Constants.RazorTemplateExtension;
+                await _codeGeneratorActionsService.AddFileFromTemplateAsync(outputPath, templateName, TemplateFolders, templateModel);
+                _logger.LogMessage($"Added View : {outputPath.Substring(ApplicationInfo.ApplicationBasePath.Length)}");
+            }
+
+            await AddRequiredFiles(viewGeneratorModel);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.Web.CodeGenerators.Mvc/View/ModelBasedViewScaffolder.cs
+++ b/src/Microsoft.VisualStudio.Web.CodeGenerators.Mvc/View/ModelBasedViewScaffolder.cs
@@ -68,7 +68,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.View
             }
             else
             {
-                modelTypeAndContextModel = await ModelMetadataUtilities.ValidateModelAndGetMetadata(viewGeneratorModel, _entityFrameworkService, _modelTypesLocator);
+                modelTypeAndContextModel = await ModelMetadataUtilities.ValidateModelAndGetEFMetadata(viewGeneratorModel, _entityFrameworkService, _modelTypesLocator);
             }
 
             var layoutDependencyInstaller = ActivatorUtilities.CreateInstance<MvcLayoutDependencyInstaller>(_serviceProvider);

--- a/src/Microsoft.VisualStudio.Web.CodeGenerators.Mvc/View/RequiredFileEntity.cs
+++ b/src/Microsoft.VisualStudio.Web.CodeGenerators.Mvc/View/RequiredFileEntity.cs
@@ -5,10 +5,10 @@ using System.Threading.Tasks;
 
 namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.View
 {
-    internal class RequiredFileEntity
+    public class RequiredFileEntity
     {
 
-        internal RequiredFileEntity(string outputPath, string templateName)
+        public RequiredFileEntity(string outputPath, string templateName)
         {
             if (string.IsNullOrEmpty(outputPath))
             {

--- a/src/Microsoft.VisualStudio.Web.CodeGenerators.Mvc/View/RequiredFileEntity.cs
+++ b/src/Microsoft.VisualStudio.Web.CodeGenerators.Mvc/View/RequiredFileEntity.cs
@@ -7,7 +7,6 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.View
 {
     public class RequiredFileEntity
     {
-
         public RequiredFileEntity(string outputPath, string templateName)
         {
             if (string.IsNullOrEmpty(outputPath))

--- a/src/Microsoft.VisualStudio.Web.CodeGenerators.Mvc/View/RequiredFileEntity.cs
+++ b/src/Microsoft.VisualStudio.Web.CodeGenerators.Mvc/View/RequiredFileEntity.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.View
+{
+    internal class RequiredFileEntity
+    {
+
+        internal RequiredFileEntity(string outputPath, string templateName)
+        {
+            if (string.IsNullOrEmpty(outputPath))
+            {
+                throw new ArgumentNullException(nameof(outputPath));
+            }
+
+            if (string.IsNullOrEmpty(templateName))
+            {
+                throw new ArgumentNullException(nameof(templateName));
+            }
+
+            TemplateName = templateName;
+            OutputPath = outputPath;
+        }
+        
+        /// <summary>
+        /// Name of the template file.
+        /// </summary>
+        public string TemplateName { get; private set; }
+        
+        /// <summary>
+        /// Path Relative to the project.json.
+        /// </summary>
+        public string OutputPath { get; private set; }
+    }
+}

--- a/src/Microsoft.VisualStudio.Web.CodeGenerators.Mvc/View/ViewGenerator.cs
+++ b/src/Microsoft.VisualStudio.Web.CodeGenerators.Mvc/View/ViewGenerator.cs
@@ -59,7 +59,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.View
             }
 
             ViewScaffolderBase scaffolder = null;
-            if (viewGeneratorModel.ModelClass == null)
+            if (string.IsNullOrEmpty(viewGeneratorModel.ModelClass))
             {
                 scaffolder = ActivatorUtilities.CreateInstance<EmptyViewScaffolder>(_serviceProvider);
             }

--- a/src/Microsoft.VisualStudio.Web.CodeGenerators.Mvc/View/ViewGenerator.cs
+++ b/src/Microsoft.VisualStudio.Web.CodeGenerators.Mvc/View/ViewGenerator.cs
@@ -2,72 +2,29 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using System.Diagnostics.Contracts;
-using System.IO;
-using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.VisualStudio.Web.CodeGeneration;
 using Microsoft.VisualStudio.Web.CodeGeneration.CommandLine;
 using Microsoft.VisualStudio.Web.CodeGeneration.DotNet;
-using Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore;
-using Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Dependency;
-
 
 namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.View
 {
-    /// <summary>
-    /// Both the command line entry point for View generation (implements ICodeGenerator with Alias attribute)
-    /// and View generator itself (extends CommonGeneratorBase).
-    /// Consider separating if there are going to multiple view generators like Controllers.
-    /// </summary>
     [Alias("view")]
     public class ViewGenerator : CommonGeneratorBase, ICodeGenerator
     {
-        private readonly IModelTypesLocator _modelTypesLocator;
-        private readonly IEntityFrameworkService _entityFrameworkService;
-        private readonly ILibraryManager _libraryManager;
-        private readonly ICodeGeneratorActionsService _codeGeneratorActionsService;
         private readonly IServiceProvider _serviceProvider;
         private readonly ILogger _logger;
 
-        // Todo: Instead of each generator taking services, provide them in some base class?
-        // However for it to be effective, it should be property dependecy injection rather
-        // than constructor injection.
         public ViewGenerator(
-            ILibraryManager libraryManager,
             IApplicationInfo applicationInfo,
-            IModelTypesLocator modelTypesLocator,
-            IEntityFrameworkService entityFrameworkService,
-            ICodeGeneratorActionsService codeGeneratorActionsService,
             IServiceProvider serviceProvider,
             ILogger logger)
             : base(applicationInfo)
         {
-            if (libraryManager == null)
-            {
-                throw new ArgumentNullException(nameof(libraryManager));
-            }
-
             if (applicationInfo == null)
             {
                 throw new ArgumentNullException(nameof(applicationInfo));
-            }
-
-            if (modelTypesLocator == null)
-            {
-                throw new ArgumentNullException(nameof(modelTypesLocator));
-            }
-
-            if (entityFrameworkService == null)
-            {
-                throw new ArgumentNullException(nameof(entityFrameworkService));
-            }
-
-            if (codeGeneratorActionsService == null)
-            {
-                throw new ArgumentNullException(nameof(codeGeneratorActionsService));
             }
 
             if (serviceProvider == null)
@@ -80,24 +37,8 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.View
                 throw new ArgumentNullException(nameof(logger));
             }
 
-            _libraryManager = libraryManager;
-            _codeGeneratorActionsService = codeGeneratorActionsService;
-            _modelTypesLocator = modelTypesLocator;
-            _entityFrameworkService = entityFrameworkService;
             _serviceProvider = serviceProvider;
             _logger = logger;
-        }
-
-        public virtual IEnumerable<string> TemplateFolders
-        {
-            get
-            {
-                return TemplateFoldersUtilities.GetTemplateFolders(
-                    containingProject: Constants.ThisAssemblyName,
-                    applicationBasePath: ApplicationInfo.ApplicationBasePath,
-                    baseFolders: new[] { "ViewGenerator" },
-                    libraryManager: _libraryManager);
-            }
         }
 
         public async Task GenerateCode(ViewGeneratorModel viewGeneratorModel)
@@ -117,148 +58,19 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.View
                 throw new ArgumentException(MessageStrings.TemplateNameRequired);
             }
 
-            ModelTypeAndContextModel modelTypeAndContextModel;
-            var outputPath = ValidateAndGetOutputPath(viewGeneratorModel, outputFileName: viewGeneratorModel.ViewName + Constants.ViewExtension);
-            if (string.IsNullOrEmpty(viewGeneratorModel.DataContextClass))
+            ViewScaffolderBase scaffolder = null;
+            if (viewGeneratorModel.ModelClass == null)
             {
-                modelTypeAndContextModel = await ModelMetadataUtilities.ValidateModelAndGetCodeModelMetadata(viewGeneratorModel, _entityFrameworkService, _modelTypesLocator);
+                scaffolder = ActivatorUtilities.CreateInstance<EmptyViewScaffolder>(_serviceProvider);
             }
             else
             {
-                modelTypeAndContextModel = await ModelMetadataUtilities.ValidateModelAndGetMetadata(viewGeneratorModel, _entityFrameworkService, _modelTypesLocator);
+                scaffolder = ActivatorUtilities.CreateInstance<ModelBasedViewScaffolder>(_serviceProvider);
             }
 
-            var layoutDependencyInstaller = ActivatorUtilities.CreateInstance<MvcLayoutDependencyInstaller>(_serviceProvider);
-            await layoutDependencyInstaller.Execute();
-
-            await GenerateView(viewGeneratorModel, modelTypeAndContextModel, outputPath);
-            await layoutDependencyInstaller.InstallDependencies();
-
-            if (modelTypeAndContextModel.ContextProcessingResult.ContextProcessingStatus == ContextProcessingStatus.ContextAddedButRequiresConfig)
+            if (scaffolder != null)
             {
-                throw new Exception(string.Format("{0} {1}", MessageStrings.ScaffoldingSuccessful_unregistered, MessageStrings.Scaffolding_additionalSteps));
-            }
-        }
-
-        internal async Task GenerateView(ViewGeneratorModel viewGeneratorModel, ModelTypeAndContextModel modelTypeAndContextModel, string outputPath)
-        {
-            if (viewGeneratorModel.ViewName.EndsWith(Constants.ViewExtension, StringComparison.OrdinalIgnoreCase))
-            {
-                int viewNameLength = viewGeneratorModel.ViewName.Length - Constants.ViewExtension.Length;
-                viewGeneratorModel.ViewName = viewGeneratorModel.ViewName.Substring(0, viewNameLength);
-            }
-
-            bool isLayoutSelected = !viewGeneratorModel.PartialView &&
-                (viewGeneratorModel.UseDefaultLayout || !String.IsNullOrEmpty(viewGeneratorModel.LayoutPage));
-
-            var templateModel = new ViewGeneratorTemplateModel()
-            {
-                ViewDataTypeName = modelTypeAndContextModel.ModelType.FullName,
-                ViewDataTypeShortName = modelTypeAndContextModel.ModelType.Name,
-                ViewName = viewGeneratorModel.ViewName,
-                LayoutPageFile = viewGeneratorModel.LayoutPage,
-                IsLayoutPageSelected = isLayoutSelected,
-                IsPartialView = viewGeneratorModel.PartialView,
-                ReferenceScriptLibraries = viewGeneratorModel.ReferenceScriptLibraries,
-                ModelMetadata = modelTypeAndContextModel.ContextProcessingResult.ModelMetadata,
-                JQueryVersion = "1.10.2" //Todo
-            };
-
-            var templateName = viewGeneratorModel.TemplateName + Constants.RazorTemplateExtension;
-            await _codeGeneratorActionsService.AddFileFromTemplateAsync(outputPath, templateName, TemplateFolders, templateModel);
-            _logger.LogMessage($"Added View : {outputPath.Substring(ApplicationInfo.ApplicationBasePath.Length)}");
-
-            await GenerateRequiredFiles(viewGeneratorModel);
-        }
-
-        /// <summary>
-        /// Method exposed for adding multiple views in one operation.
-        /// Utilised by the ControllerWithContextGenerator which generates 5 views for a MVC controller with context.
-        /// </summary>
-        /// <param name="viewsAndTemplates">Names of views and the corresponding template names</param>
-        /// <param name="viewGeneratorModel">Model for View Generator</param>
-        /// <param name="modelTypeAndContextModel">Model Type and DbContext metadata</param>
-        /// <param name="baseOutputPath">Folder where all views will be generated</param>
-        internal async Task GenerateViews(Dictionary<string, string> viewsAndTemplates, ViewGeneratorModel viewGeneratorModel, ModelTypeAndContextModel modelTypeAndContextModel, string baseOutputPath)
-        {
-
-            if (viewsAndTemplates == null)
-            {
-                throw new ArgumentNullException(nameof(viewsAndTemplates));
-            }
-
-            if(viewGeneratorModel == null)
-            {
-                throw new ArgumentNullException(nameof(viewsAndTemplates));
-            }
-
-            if(modelTypeAndContextModel == null)
-            {
-                throw new ArgumentNullException(nameof(modelTypeAndContextModel));
-            }
-
-            if(string.IsNullOrEmpty(baseOutputPath))
-            {
-                baseOutputPath = ApplicationInfo.ApplicationBasePath;
-            }
-
-            foreach (var entry in viewsAndTemplates)
-            {
-                var viewName = entry.Key;
-                var templateName = entry.Value;
-                if (viewName.EndsWith(Constants.ViewExtension, StringComparison.OrdinalIgnoreCase))
-                {
-                    int viewNameLength = viewName.Length - Constants.ViewExtension.Length;
-                    viewName = viewName.Substring(0, viewNameLength);
-                }
-
-                var outputPath = Path.Combine(baseOutputPath, viewName + Constants.ViewExtension);
-                bool isLayoutSelected = !viewGeneratorModel.PartialView &&
-                    (viewGeneratorModel.UseDefaultLayout || !String.IsNullOrEmpty(viewGeneratorModel.LayoutPage));
-
-                var templateModel = new ViewGeneratorTemplateModel()
-                {
-                    ViewDataTypeName = modelTypeAndContextModel.ModelType.FullName,
-                    ViewDataTypeShortName = modelTypeAndContextModel.ModelType.Name,
-                    ViewName = viewName,
-                    LayoutPageFile = viewGeneratorModel.LayoutPage,
-                    IsLayoutPageSelected = isLayoutSelected,
-                    IsPartialView = viewGeneratorModel.PartialView,
-                    ReferenceScriptLibraries = viewGeneratorModel.ReferenceScriptLibraries,
-                    ModelMetadata = modelTypeAndContextModel.ContextProcessingResult.ModelMetadata,
-                    JQueryVersion = "1.10.2" //Todo
-                };
-
-                templateName = templateName + Constants.RazorTemplateExtension;
-                await _codeGeneratorActionsService.AddFileFromTemplateAsync(outputPath, templateName, TemplateFolders, templateModel);
-                _logger.LogMessage($"Added View : {outputPath.Substring(ApplicationInfo.ApplicationBasePath.Length)}");
-            }
-            await GenerateRequiredFiles(viewGeneratorModel);
-        }
-
-        private async Task GenerateRequiredFiles(ViewGeneratorModel viewGeneratorModel)
-        {
-            List<RequiredFileEntity> requiredFiles = new List<RequiredFileEntity>();
-
-            if (viewGeneratorModel.ReferenceScriptLibraries)
-            {
-                requiredFiles.Add(new RequiredFileEntity(@"Views/Shared/_ValidationScriptsPartial.cshtml", @"_ValidationScriptsPartial.cshtml"));
-            }
-
-            await AddRequiredFiles(requiredFiles);
-        }
-
-        private async Task AddRequiredFiles(IEnumerable<RequiredFileEntity> requiredFiles)
-        {
-            foreach (var file in requiredFiles)
-            {
-                if (!File.Exists(Path.Combine(ApplicationInfo.ApplicationBasePath, file.OutputPath)))
-                {
-                    await _codeGeneratorActionsService.AddFileAsync(
-                        Path.Combine(ApplicationInfo.ApplicationBasePath, file.OutputPath),
-                        Path.Combine(TemplateFolders.First(), file.TemplateName));
-                    _logger.LogMessage($"Added additional file :{file.OutputPath}");
-                }
+                await scaffolder.GenerateCode(viewGeneratorModel);
             }
         }
     }

--- a/src/Microsoft.VisualStudio.Web.CodeGenerators.Mvc/View/ViewGeneratorModel.cs
+++ b/src/Microsoft.VisualStudio.Web.CodeGenerators.Mvc/View/ViewGeneratorModel.cs
@@ -9,7 +9,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.View
     {
         public string ViewName { get; set; }
 
-        [Argument(Description = "The view template to use, supported view templates: 'Create|Edit|Delete|Details|List'")]
+        [Argument(Description = "The view template to use, supported view templates: 'Empty|Create|Edit|Delete|Details|List'")]
         public string TemplateName { get; set; }
 
         [Option(Name = "partialView", ShortName = "partial", Description = "Generate a partial view, other layout options (-l and -udl) are ignored if this is specified")]

--- a/src/Microsoft.VisualStudio.Web.CodeGenerators.Mvc/View/ViewScaffolderBase.cs
+++ b/src/Microsoft.VisualStudio.Web.CodeGenerators.Mvc/View/ViewScaffolderBase.cs
@@ -1,0 +1,129 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Web.CodeGeneration.DotNet;
+using Microsoft.VisualStudio.Web.CodeGeneration;
+using Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore;
+using System.IO;
+
+namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.View
+{
+    public abstract class ViewScaffolderBase: CommonGeneratorBase
+    {
+        protected readonly ILibraryManager _libraryManager;
+        protected readonly ICodeGeneratorActionsService _codeGeneratorActionsService;
+        protected readonly IServiceProvider _serviceProvider;
+        protected readonly ILogger _logger;
+
+        public ViewScaffolderBase(
+            ILibraryManager libraryManager,
+            IApplicationInfo applicationInfo,
+            ICodeGeneratorActionsService codeGeneratorActionsService,
+            IServiceProvider serviceProvider,
+            ILogger logger)
+            : base(applicationInfo)
+        {
+            if (libraryManager == null)
+            {
+                throw new ArgumentNullException(nameof(libraryManager));
+            }
+
+            if (applicationInfo == null)
+            {
+                throw new ArgumentNullException(nameof(applicationInfo));
+            }
+
+            if (codeGeneratorActionsService == null)
+            {
+                throw new ArgumentNullException(nameof(codeGeneratorActionsService));
+            }
+
+            if (serviceProvider == null)
+            {
+                throw new ArgumentNullException(nameof(serviceProvider));
+            }
+
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            _libraryManager = libraryManager;
+            _codeGeneratorActionsService = codeGeneratorActionsService;
+            _serviceProvider = serviceProvider;
+            _logger = logger;
+        }
+
+        public virtual IEnumerable<string> TemplateFolders
+        {
+            get
+            {
+                return TemplateFoldersUtilities.GetTemplateFolders(
+                    containingProject: Constants.ThisAssemblyName,
+                    applicationBasePath: ApplicationInfo.ApplicationBasePath,
+                    baseFolders: new[] { "ViewGenerator" },
+                    libraryManager: _libraryManager);
+            }
+        }
+
+        protected async Task AddRequiredFiles(ViewGeneratorModel viewGeneratorModel)
+        {
+            IEnumerable<RequiredFileEntity> requiredFiles = GetRequiredFiles(viewGeneratorModel);
+            foreach (var file in requiredFiles)
+            {
+                if (!File.Exists(Path.Combine(ApplicationInfo.ApplicationBasePath, file.OutputPath)))
+                {
+                    await _codeGeneratorActionsService.AddFileAsync(
+                        Path.Combine(ApplicationInfo.ApplicationBasePath, file.OutputPath),
+                        Path.Combine(TemplateFolders.First(), file.TemplateName));
+                    _logger.LogMessage($"Added additional file :{file.OutputPath}");
+                }
+            }
+        }
+        
+        public abstract Task GenerateCode(ViewGeneratorModel viewGeneratorModel);
+
+        internal async Task GenerateView(ViewGeneratorModel viewGeneratorModel, ModelTypeAndContextModel modelTypeAndContextModel, string outputPath)
+        {
+            if (viewGeneratorModel.ViewName.EndsWith(Constants.ViewExtension, StringComparison.OrdinalIgnoreCase))
+            {
+                int viewNameLength = viewGeneratorModel.ViewName.Length - Constants.ViewExtension.Length;
+                viewGeneratorModel.ViewName = viewGeneratorModel.ViewName.Substring(0, viewNameLength);
+            }
+
+            var templateModel = GetViewGeneratorTemplateModel(viewGeneratorModel, modelTypeAndContextModel);
+            var templateName = viewGeneratorModel.TemplateName + Constants.RazorTemplateExtension;
+            await _codeGeneratorActionsService.AddFileFromTemplateAsync(outputPath, templateName, TemplateFolders, templateModel);
+            _logger.LogMessage("Added View : " + outputPath.Substring(ApplicationInfo.ApplicationBasePath.Length));
+
+            await AddRequiredFiles(viewGeneratorModel);
+        }
+
+        protected abstract IEnumerable<RequiredFileEntity> GetRequiredFiles(ViewGeneratorModel viewGeneratorModel);
+
+        protected ViewGeneratorTemplateModel GetViewGeneratorTemplateModel(ViewGeneratorModel viewGeneratorModel, ModelTypeAndContextModel modelTypeAndContextModel)
+        {
+            bool isLayoutSelected = !viewGeneratorModel.PartialView &&
+                (viewGeneratorModel.UseDefaultLayout || !String.IsNullOrEmpty(viewGeneratorModel.LayoutPage));
+
+            ViewGeneratorTemplateModel templateModel = new ViewGeneratorTemplateModel()
+            {
+                ViewDataTypeName = modelTypeAndContextModel?.ModelType?.FullName,
+                ViewDataTypeShortName = modelTypeAndContextModel?.ModelType?.Name,
+                ViewName = viewGeneratorModel.ViewName,
+                LayoutPageFile = viewGeneratorModel.LayoutPage,
+                IsLayoutPageSelected = isLayoutSelected,
+                IsPartialView = viewGeneratorModel.PartialView,
+                ReferenceScriptLibraries = viewGeneratorModel.ReferenceScriptLibraries,
+                ModelMetadata = modelTypeAndContextModel?.ContextProcessingResult?.ModelMetadata,
+                JQueryVersion = "1.10.2" //Todo
+            };
+
+            return templateModel;
+        }
+    }
+}

--- a/test/E2E_Test/Baseline/CarViews/Create.cshtml
+++ b/test/E2E_Test/Baseline/CarViews/Create.cshtml
@@ -44,5 +44,8 @@
     <a asp-action="Index">Back to List</a>
 </div>
 
+@section Scripts {
+    @{await Html.RenderPartialAsync("_ValidationScriptsPartial");}
+}
 </body>
 </html>

--- a/test/E2E_Test/Baseline/SharedViews/_ValidationScriptsPartial.cshtml
+++ b/test/E2E_Test/Baseline/SharedViews/_ValidationScriptsPartial.cshtml
@@ -1,0 +1,14 @@
+﻿<environment names="Development">
+    <script src="~/lib/jquery-validation/dist/jquery.validate.js"></script>
+    <script src="~/lib/jquery-validation-unobtrusive/jquery.validate.unobtrusive.js"></script>
+</environment>
+<environment names="Staging,Production">
+    <script src="https://ajax.aspnetcdn.com/ajax/jquery.validate/1.14.0/jquery.validate.min.js"
+            asp-fallback-src="~/lib/jquery-validation/dist/jquery.validate.min.js"
+            asp-fallback-test="window.jQuery && window.jQuery.validator">
+    </script>
+    <script src="https://ajax.aspnetcdn.com/ajax/jquery.validation.unobtrusive/3.2.6/jquery.validate.unobtrusive.min.js"
+            asp-fallback-src="~/lib/jquery-validation-unobtrusive/jquery.validate.unobtrusive.min.js"
+            asp-fallback-test="window.jQuery && window.jQuery.validator && window.jQuery.validator.unobtrusive">
+    </script>
+</environment>

--- a/test/E2E_Test/Baseline/Views/CarCreate.txt
+++ b/test/E2E_Test/Baseline/Views/CarCreate.txt
@@ -9,16 +9,15 @@
 <html>
 <head>
     <meta name="viewport" content="width=device-width" />
-    <title>Edit</title>
+    <title>CarCreate</title>
 </head>
 <body>
 
-<form asp-action="Edit">
+<form asp-action="CarCreate">
     <div class="form-horizontal">
         <h4>Car</h4>
         <hr />
         <div asp-validation-summary="ModelOnly" class="text-danger"></div>
-    <input type="hidden" asp-for="CarID" />
         <div class="form-group">
             <label asp-for="ModelName" class="col-md-2 control-label"></label>
             <div class="col-md-10">
@@ -35,7 +34,7 @@
         </div>
         <div class="form-group">
             <div class="col-md-offset-2 col-md-10">
-                <input type="submit" value="Save" class="btn btn-default" />
+                <input type="submit" value="Create" class="btn btn-default" />
             </div>
         </div>
     </div>

--- a/test/E2E_Test/Baseline/Views/CarDetails.txt
+++ b/test/E2E_Test/Baseline/Views/CarDetails.txt
@@ -1,0 +1,24 @@
+﻿@model WebApplication1.Models.Car
+
+<div>
+    <h4>Car</h4>
+    <hr />
+    <dl class="dl-horizontal">
+        <dt>
+            @Html.DisplayNameFor(model => model.ModelName)
+        </dt>
+        <dd>
+            @Html.DisplayFor(model => model.ModelName)
+        </dd>
+        <dt>
+            @Html.DisplayNameFor(model => model.Price)
+        </dt>
+        <dd>
+            @Html.DisplayFor(model => model.Price)
+        </dd>
+    </dl>
+</div>
+<div>
+    <a asp-action="Edit" asp-route-id="@Model.CarID">Edit</a> |
+    <a asp-action="Index">Back to List</a>
+</div>

--- a/test/E2E_Test/Baseline/Views/EmptyView.txt
+++ b/test/E2E_Test/Baseline/Views/EmptyView.txt
@@ -1,0 +1,15 @@
+﻿
+@{
+    Layout = null;
+}
+
+<!DOCTYPE html>
+
+<html>
+<head>
+    <meta name="viewport" content="width=device-width" />
+    <title>EmptyView</title>
+</head>
+<body>
+</body>
+</html>

--- a/test/E2E_Test/MvcControllerTest.cs
+++ b/test/E2E_Test/MvcControllerTest.cs
@@ -78,7 +78,8 @@ namespace E2E_Test
                 "--model",
                 "WebApplication1.Models.Car",
                 "--dataContext",
-                "WebApplication1.Models.CarContext"
+                "WebApplication1.Models.CarContext",
+                "--referenceScriptLibraries"
             };
 
             Scaffold(args);
@@ -92,6 +93,7 @@ namespace E2E_Test
             VerifyFileAndContent(Path.Combine(viewFolder, "Details.cshtml"), Path.Combine("CarViews", "Details.cshtml"));
             VerifyFileAndContent(Path.Combine(viewFolder, "Edit.cshtml"), Path.Combine("CarViews", "Edit.cshtml"));
             VerifyFileAndContent(Path.Combine(viewFolder, "Index.cshtml"), Path.Combine("CarViews", "Index.cshtml"));
+            VerifyFileAndContent(Path.Combine(testProjectPath, "Views", "Shared", "_ValidationScriptsPartial.cshtml"), Path.Combine("SharedViews", "_ValidationScriptsPartial.cshtml"));
 
             _fixture.FilesToCleanUp.Add(generatedFilePath);
             _fixture.FilesToCleanUp.Add(Path.Combine(viewFolder, "Create.cshtml"));
@@ -100,6 +102,7 @@ namespace E2E_Test
             _fixture.FilesToCleanUp.Add(Path.Combine(viewFolder, "Details.cshtml"));
             _fixture.FilesToCleanUp.Add(Path.Combine(viewFolder, "Edit.cshtml"));
             _fixture.FilesToCleanUp.Add(Path.Combine(viewFolder, "Index.cshtml"));
+            _fixture.FilesToCleanUp.Add(Path.Combine(testProjectPath, "Views", "Shared", "_ValidationScriptsPartial.cshtml"));
         }
 
         [Fact]

--- a/test/E2E_Test/ViewGeneratorTests.cs
+++ b/test/E2E_Test/ViewGeneratorTests.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace E2E_Test
+{
+    [Collection("ScaffoldingE2ECollection")]
+    public class ViewGeneratorTests : E2ETestBase
+    {
+        private static string[] EMPTY_VIEW_ARGS = new string[] { "-p", testProjectPath, "view", "EmptyView", "Empty" };
+        private static string[] VIEW_WITH_DATACONTEXT = new string[] { "-p", testProjectPath, "view", "CarCreate", "Create", "--model", "WebApplication1.Models.Car", "--dataContext", "WebApplication1.Models.CarContext", "--referenceScriptLibraries" };
+        private static string[] VIEW_NO_DATACONTEXT = new string[] { "-p", testProjectPath, "view", "CarDetails", "Details", "--model", "WebApplication1.Models.Car", "--dataContext", "WebApplication1.Models.CarContext", "--partialView" };
+
+        public ViewGeneratorTests(ScaffoldingE2ETestFixture fixture) : base(fixture)
+        {
+        }
+
+        public static IEnumerable<object[]> TestData
+        {
+            get
+            {
+                return new[]
+                {
+                    new object[] { Path.Combine("Views", "EmptyView.txt"), Path.Combine(testProjectPath, "EmptyView.cshtml"), EMPTY_VIEW_ARGS },
+                    new object[] { Path.Combine("Views", "CarCreate.txt"), Path.Combine(testProjectPath, "CarCreate.cshtml"), VIEW_WITH_DATACONTEXT },
+                    new object[] { Path.Combine("Views", "CarDetails.txt"), Path.Combine(testProjectPath, "CarDetails.cshtml"), VIEW_NO_DATACONTEXT }
+                };
+            }
+        }
+
+        [Theory, MemberData("TestData")]
+        public void TestViewGenerator(string baselineFile, string generatedFilePath, string[] args)
+        {
+            Scaffold(args);
+
+            VerifyFileAndContent(generatedFilePath, baselineFile);
+            _fixture.FilesToCleanUp.Add(generatedFilePath);
+        }
+    }
+}

--- a/test/Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Test/ModelMetadataUtilitiesTest.cs
+++ b/test/Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Test/ModelMetadataUtilitiesTest.cs
@@ -112,7 +112,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Test
                 .Returns(Task.FromResult(contextProcessingResult));
 
             //Act
-            var result = await ModelMetadataUtilities.ValidateModelAndGetMetadata(
+            var result = await ModelMetadataUtilities.ValidateModelAndGetEFMetadata(
                     model,
                     efService.Object,
                     modelTypesLocator.Object);
@@ -133,7 +133,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Test
                 .Returns(Task.FromResult(contextProcessingResult));
 
             //Act
-            result = await ModelMetadataUtilities.ValidateModelAndGetMetadata(
+            result = await ModelMetadataUtilities.ValidateModelAndGetEFMetadata(
                     model,
                     efService.Object,
                     modelTypesLocator.Object);

--- a/test/Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Test/ModelMetadataUtilitiesTest.cs
+++ b/test/Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Test/ModelMetadataUtilitiesTest.cs
@@ -1,0 +1,152 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Web.CodeGeneration;
+using Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore;
+using Moq;
+using Xunit;
+
+namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Test
+{
+    public class ModelMetadataUtilitiesTest
+    {
+        private Mock<IEntityFrameworkService> efService;
+        private CommonCommandLineModel model;
+        private Mock<IModelTypesLocator> modelTypesLocator;
+
+        public ModelMetadataUtilitiesTest()
+        {
+            efService = new Mock<IEntityFrameworkService>();
+            modelTypesLocator = new Mock<IModelTypesLocator>();
+        }
+
+        [Fact]
+        public async void TestValidateModelAndGetCodeModelMetadata()
+        {
+            var modelTypes = new List<ModelType>();
+            //Arrange
+            model = new TestCommandLineModel()
+            {
+                ModelClass = "InvalidModel"
+            };
+            modelTypesLocator.Setup(m => m.GetType("InvalidModel")).Returns(() => { return modelTypes; });
+
+            //Act & Assert
+            Exception ex = await Assert.ThrowsAsync<ArgumentException>(
+                async () => await ModelMetadataUtilities.ValidateModelAndGetCodeModelMetadata(
+                    model,
+                    efService.Object,
+                    modelTypesLocator.Object));
+            Assert.Equal("A type with the name InvalidModel does not exist", ex.Message);
+
+            // Arrange
+            var modelType = new ModelType()
+            {
+                Name = "InvalidModel",
+                FullName = "InvalidModel",
+                Namespace = ""
+            };
+            modelTypes.Add(modelType);
+            var contextProcessingResult = new ContextProcessingResult()
+            {
+                ContextProcessingStatus = ContextProcessingStatus.ContextAdded,
+                ModelMetadata = null
+            };
+
+            efService.Setup(e => e.GetModelMetadata(modelType))
+                .Returns(Task.FromResult(contextProcessingResult));
+
+            //Act
+            var result = await ModelMetadataUtilities.ValidateModelAndGetCodeModelMetadata(
+                    model,
+                    efService.Object,
+                    modelTypesLocator.Object);
+
+            //Assert
+            Assert.Equal(contextProcessingResult.ContextProcessingStatus, result.ContextProcessingResult.ContextProcessingStatus);
+            Assert.Equal(modelType, result.ModelType);
+        }
+
+        [Fact]
+        public async void TestValidateModelAndGetModelMetadata()
+        {
+            var modelTypes = new List<ModelType>();
+            var dataContextTypes = new List<ModelType>();
+            //Arrange
+            model = new TestCommandLineModel()
+            {
+                ModelClass = "SampleModel",
+                DataContextClass = "SampleDataContext"
+            };
+            modelTypesLocator.Setup(m => m.GetType("SampleModel")).Returns(() => { return modelTypes; });
+            modelTypesLocator.Setup(m => m.GetType("SampleDataContext")).Returns(() => { return dataContextTypes; });
+
+            //Act & Assert
+            Exception ex = await Assert.ThrowsAsync<ArgumentException>(
+                async () => await ModelMetadataUtilities.ValidateModelAndGetCodeModelMetadata(
+                    model,
+                    efService.Object,
+                    modelTypesLocator.Object));
+            Assert.Equal("A type with the name SampleModel does not exist", ex.Message);
+
+            // Arrange
+            var modelType = new ModelType()
+            {
+                Name = "SampleModel",
+                FullName = "SampleModel",
+                Namespace = ""
+            };
+
+            modelTypes.Add(modelType);
+            var contextProcessingResult = new ContextProcessingResult()
+            {
+                ContextProcessingStatus = ContextProcessingStatus.ContextAdded,
+                ModelMetadata = null
+            };
+
+            efService.Setup(e => e.GetModelMetadata(model.DataContextClass, modelType))
+                .Returns(Task.FromResult(contextProcessingResult));
+
+            //Act
+            var result = await ModelMetadataUtilities.ValidateModelAndGetMetadata(
+                    model,
+                    efService.Object,
+                    modelTypesLocator.Object);
+
+            //Assert
+            Assert.Equal(contextProcessingResult.ContextProcessingStatus, result.ContextProcessingResult.ContextProcessingStatus);
+            Assert.Equal(modelType, result.ModelType);
+            Assert.Equal(model.DataContextClass, result.DbContextFullName);
+
+            // Arrange
+            var dataContextType = new ModelType()
+            {
+                Name = "SampleDatContext",
+                FullName = "A.B.C.SampleDataContext"
+            };
+            dataContextTypes.Add(dataContextType);
+            efService.Setup(e => e.GetModelMetadata(dataContextType.FullName, modelType))
+                .Returns(Task.FromResult(contextProcessingResult));
+
+            //Act
+            result = await ModelMetadataUtilities.ValidateModelAndGetMetadata(
+                    model,
+                    efService.Object,
+                    modelTypesLocator.Object);
+
+            //Assert
+            Assert.Equal(contextProcessingResult.ContextProcessingStatus, result.ContextProcessingResult.ContextProcessingStatus);
+            Assert.Equal(modelType, result.ModelType);
+            Assert.Equal(dataContextType.FullName, result.DbContextFullName);
+        }
+
+        class TestCommandLineModel : CommonCommandLineModel
+        {
+
+        }
+    }
+}


### PR DESCRIPTION
Changes:
- Add required files based on view generator model. Fixes #257
- Remove duplicated code between View Generator and ControllerWithContextGenerator
- Add support for adding empty view
- Split ViewGenerator into the command line entrypoint and the actual scaffolders so we have a consistent pattern for Controller and View Generation. 
- E2E tests for View Generation. 

TODO: 
 - Rename the ControllerGenerators to Scaffolders to better distinguish between the commandline entry point and the actual scaffolders. 