### PR TITLE
Increase .travis.yml consistency between repos

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,17 +10,23 @@ addons:
     - libssl-dev
     - libunwind8
     - zlib1g
+env:
+  global:
+    - DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+    - DOTNET_CLI_TELEMETRY_OPTOUT: 1
 mono:
   - 4.0.5
 os:
   - linux
   - osx
-osx-image: xcode7.1
+osx_image: xcode7.1
 branches:
   only:
     - master
     - release
     - dev
     - /^(.*\/)?ci-.*$/
+before_install:
+  - if test "$TRAVIS_OS_NAME" == "osx"; then brew update; brew install openssl; ln -s /usr/local/opt/openssl/lib/libcrypto.1.0.0.dylib /usr/local/lib/; ln -s /usr/local/opt/openssl/lib/libssl.1.0.0.dylib /usr/local/lib/; fi
 script:
   - ./build.sh --quiet verify


### PR DESCRIPTION
- aspnet/Universe#349
- minimize `dotnet` setup time; no need for caching
- install openssl in OSX builds