### PR TITLE
Remove usage of build3 for msbuild projects.

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -32,6 +32,8 @@ cd $PSScriptRoot
 
 $repoFolder = $PSScriptRoot
 $env:REPO_FOLDER = $repoFolder
+# HACK:: Remove when we move to CLI that uses msbuild as the driver.
+$env:USE_3_VERBS = 1;
 
 $koreBuildZip="https://github.com/aspnet/KoreBuild/archive/feature/msbuild.zip"
 if ($env:KOREBUILD_ZIP)

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 repoFolder="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd $repoFolder
+# HACK:: Remove when we move to CLI that uses msbuild as the driver.
+export USE_3_VERBS=1
 
 koreBuildZip="https://github.com/aspnet/KoreBuild/archive/dev.zip"
 if [ ! -z $KOREBUILD_ZIP ]; then

--- a/src/Microsoft.VisualStudio.Web.CodeGeneration.Tools/DotNetBuildCommandHelper.cs
+++ b/src/Microsoft.VisualStudio.Web.CodeGeneration.Tools/DotNetBuildCommandHelper.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using Microsoft.DotNet.Cli.Utils;
@@ -16,7 +17,8 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.Tools
             NuGetFramework framework,
             string buildBasePath)
         {
-            const string buildCommandName = "build";
+            var buildCommandName = "build";
+
             var args = new List<string>()
             {
                 project,
@@ -37,6 +39,13 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.Tools
 
             var stdOutMsgs = new List<string>();
             var stdErrorMsgs = new List<string>();
+
+            // HACK :: Till we upgrade the repo to use msbuild based CLI, use *3 verbs for the tests.
+            if (string.Equals(System.Environment.GetEnvironmentVariable("USE_3_VERBS"), "1", StringComparison.Ordinal)
+                && string.Equals(Path.GetExtension(project), ".csproj", StringComparison.OrdinalIgnoreCase))
+            {
+                buildCommandName = "build3";
+            }
 
             var command = Command.CreateDotNet(
                     buildCommandName,

--- a/src/Microsoft.VisualStudio.Web.CodeGeneration.Tools/DotNetBuildCommandHelper.cs
+++ b/src/Microsoft.VisualStudio.Web.CodeGeneration.Tools/DotNetBuildCommandHelper.cs
@@ -16,6 +16,7 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.Tools
             NuGetFramework framework,
             string buildBasePath)
         {
+            const string buildCommandName = "build";
             var args = new List<string>()
             {
                 project,
@@ -36,11 +37,6 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.Tools
 
             var stdOutMsgs = new List<string>();
             var stdErrorMsgs = new List<string>();
-
-            //TODO Remove this when CLI merges build3 to build.
-            var buildCommandName = Path.GetExtension(project).Equals(".csproj")
-                ? "build3"
-                : "build";
 
             var command = Command.CreateDotNet(
                     buildCommandName,

--- a/src/Microsoft.VisualStudio.Web.CodeGeneration.Tools/project.json
+++ b/src/Microsoft.VisualStudio.Web.CodeGeneration.Tools/project.json
@@ -26,7 +26,6 @@
     }
   },
   "dependencies": {
-    "Microsoft.Build.Runtime": "15.1.319-preview5",
     "Microsoft.DotNet.Cli.Utils": "1.0.0-preview3-*",
     "Microsoft.Extensions.CommandLineUtils": "1.1.0-*",
     "Microsoft.Extensions.DotnetToolDispatcher.Sources": {
@@ -49,8 +48,7 @@
       "type": "build"
     },
     "Microsoft.DotNet.ProjectModel": "1.0.0-rc3-003121",
-    "Newtonsoft.Json": "9.0.1",
-    "NuGet.ProjectModel": "3.6.0-*"
+    "Newtonsoft.Json": "9.0.1"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/test/Microsoft.Extensions.ProjectModel.Tests/project.json
+++ b/test/Microsoft.Extensions.ProjectModel.Tests/project.json
@@ -7,8 +7,6 @@
     }
   },
   "dependencies": {
-    "NuGet.ProjectModel": "3.6.0-*",
-    "NuGet.Frameworks": "3.6.0-*",
     "Microsoft.DotNet.Cli.Utils": "1.0.0-preview3-*",
     "Microsoft.DotNet.InternalAbstractions": "1.0.0-*",
     "Microsoft.DotNet.ProjectModel": "1.0.0-rc3-003121",


### PR DESCRIPTION
- Now that CLI has merged the *3 verbs, no longer need to use `build3` for building msbuild projects.
- Remove MsBuild and NuGet dependency overrides from .Tools package.

Note: The same changes need to flow to feature/msbuild-1.1.0 branch as well. 

@natemcmaster @NTaylorMullen 