### PR TITLE
Load project dependencies by name instead of path in EFServices.

### DIFF
--- a/src/Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore/EntityFrameworkServices.cs
+++ b/src/Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore/EntityFrameworkServices.cs
@@ -324,7 +324,10 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore
                 {
                     try
                     {
-                        var dAssembly = _loader.LoadFromPath(dependencies.Current.ResolvedPath);
+                        // Since we are running in the project's dependency context, loading assemblies
+                        // by name just works.
+                        var dAssemblyName = new AssemblyName(Path.GetFileNameWithoutExtension(dependencies.Current.ResolvedPath));
+                        var dAssembly = _loader.LoadFromName(dAssemblyName);
                         modelType = dAssembly.GetType(modelTypeName);
                     }
                     catch (Exception ex)

--- a/test/E2E_Test/MvcControllerTest.cs
+++ b/test/E2E_Test/MvcControllerTest.cs
@@ -48,7 +48,7 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.E2E_Test
             }
         }
 
-        [Fact (Skip="Disable tests that need loading assemblies")]
+        [Fact]
         public void TestControllerWithContext()
         {
             using (var fileProvider = new TemporaryFileProvider())
@@ -76,7 +76,7 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.E2E_Test
             }
         }
 
-        [Fact (Skip="Disable tests that need loading assemblies")]
+        [Fact]
         public void TestControllerWithContext_WithViews()
         {
             using (var fileProvider = new TemporaryFileProvider())
@@ -115,7 +115,7 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.E2E_Test
             }
         }
 
-        [Fact (Skip="Disable tests that need loading assemblies")]
+        [Fact]
         public void TestControllerWithContext_WithForeignKey()
         {
             using (var fileProvider = new TemporaryFileProvider())

--- a/test/E2E_Test/ViewGeneratorTests.cs
+++ b/test/E2E_Test/ViewGeneratorTests.cs
@@ -26,9 +26,8 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.E2E_Test
                 return new[]
                 {
                     new object[] { Path.Combine("Views", "EmptyView.txt"), "EmptyView.cshtml", EMPTY_VIEW_ARGS },
-                    // Disable tests that require loading assemblies on CI.
-                    //new object[] { Path.Combine("Views", "CarCreate.txt"), "CarCreate.cshtml", VIEW_WITH_DATACONTEXT },
-                    //new object[] { Path.Combine("Views", "CarDetails.txt"),"CarDetails.cshtml", VIEW_NO_DATACONTEXT }
+                    new object[] { Path.Combine("Views", "CarCreate.txt"), "CarCreate.cshtml", VIEW_WITH_DATACONTEXT },
+                    new object[] { Path.Combine("Views", "CarDetails.txt"),"CarDetails.cshtml", VIEW_NO_DATACONTEXT }
                 };
             }
         }


### PR DESCRIPTION
Trying to fix the test issue on CI, where E2E tests fail while trying to load project dependencies. 

cc @natemcmaster 