### PR TITLE
Fix configuration for x86 net451 build for CodeGeneration.Design

### DIFF
--- a/src/Microsoft.VisualStudio.Web.CodeGeneration.Design/project.json
+++ b/src/Microsoft.VisualStudio.Web.CodeGeneration.Design/project.json
@@ -9,6 +9,18 @@
     ],
     "xmlDoc": true
   },
+  "configurations": {
+    "debug_x86": {
+      "buildOptions": {
+        "platform": "anycpu32bitpreferred"
+      }
+    },
+    "release_x86": {
+      "buildOptions": {
+        "platform": "anycpu32bitpreferred"
+      }
+    }
+  },
   "description": "Code Generation tool for ASP.NET Core. Contains the dotnet-aspnet-codegenerator command used for generating controllers and views. ",
   "dependencies": {
     "Microsoft.VisualStudio.Web.CodeGenerators.Mvc": "1.0.0-*"


### PR DESCRIPTION
The _inside man_ needs to be able to run on x86 machines when user is on x86 machine. 
This is being repacked already as part of https://github.com/aspnet/Scaffolding/blob/pb/fixArchitecture/makefile.shade#L26-L83

cc @natemcmaster 