### PR TITLE
Use EF Design APIs to get DbContext instance from user code.

### DIFF
--- a/src/Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore/ReflectedTypesProvider.cs
+++ b/src/Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore/ReflectedTypesProvider.cs
@@ -1,0 +1,193 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Collections.Generic;
+using System.Reflection;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.Extensions.ProjectModel;
+using Microsoft.VisualStudio.Web.CodeGeneration.DotNet;
+
+namespace Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore 
+{
+    internal class ReflectedTypesProvider
+    {
+        private ILogger _logger;
+        private ICodeGenAssemblyLoadContext _loader;
+        private Compilation _compilation;
+        private CompilationResult _compilationResult;
+        private IProjectContext _projectContext;
+
+        public ReflectedTypesProvider(Compilation compilation,
+             Func<Compilation, Compilation> compilationModificationFunc,
+             IProjectContext projectContext,
+             ICodeGenAssemblyLoadContext loader,
+             ILogger logger)
+        {
+            if (compilation ==null)
+            {
+                throw new ArgumentNullException(nameof(compilation));
+            }
+
+            if (loader == null)
+            {
+                throw new ArgumentNullException(nameof(loader));
+            }
+
+            if (projectContext == null)
+            {
+                throw new ArgumentNullException(nameof(projectContext));
+            }
+
+            _projectContext = projectContext;
+            _logger = logger;
+            _loader = loader;
+            _compilation = compilationModificationFunc == null
+                 ? compilation
+                 : compilationModificationFunc(compilation);
+            _compilationResult = GetCompilationResult(_compilation);
+        }
+
+        private CompilationResult GetCompilationResult(Compilation compilation)
+        {
+            // Need these #ifdefs as coreclr needs the assembly name to be different to be loaded from stream.  
+            // On NET451 if the assembly name is different, MVC fails to load the assembly as it is not found on disk.
+
+#if NET451
+            var newAssemblyName = Path.GetFileNameWithoutExtension(compilation.AssemblyName);
+#else
+            var newAssemblyName = Path.GetRandomFileName();
+#endif
+
+            var newCompilation = compilation
+                .WithAssemblyName(newAssemblyName)
+                .WithOptions(new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+            var result = CommonUtilities.GetAssemblyFromCompilation(_loader, newCompilation);
+            return result;
+        }
+
+        public Type GetReflectedType(string modelType)
+        {
+            return GetReflectedType(modelType, false);
+        }
+
+        public Type GetReflectedType(string modelType, bool lookInDependencies)
+        {
+            if(string.IsNullOrEmpty(modelType))
+            {
+                throw new ArgumentNullException(nameof(modelType));
+            }
+
+            if (_compilationResult == null
+                || !_compilationResult.Success)
+            {
+                // If the compilation was not successful, just return null.
+                return null;
+            }
+
+            Type modelReflectedType = null;
+            try
+            {
+                modelReflectedType = _compilationResult.Assembly?.GetType(modelType);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogMessage(ex.Message, LogMessageLevel.Error);
+            }
+
+            if (modelReflectedType == null && lookInDependencies)
+            {
+                // Need to look in the dependencies of this project now.
+                var dependencies = _projectContext.CompilationAssemblies.GetEnumerator();
+                while (modelReflectedType == null && dependencies.MoveNext())
+                {
+                    try
+                    {
+                        // Since we are running in the project's dependency context, loading assemblies
+                        // by name just works.
+                        var dAssemblyName = new AssemblyName(Path.GetFileNameWithoutExtension(dependencies.Current.ResolvedPath));
+                        var dAssembly = _loader.LoadFromName(dAssemblyName);
+                        modelReflectedType = dAssembly.GetType(modelType);
+                    }
+                    catch (Exception ex)
+                    {
+                        // This is a best effort approach. If we cannot load an assembly for any reason, 
+                        // just ignore it and look for the type in the next one.
+                        _logger.LogMessage(ex.Message, LogMessageLevel.Trace);
+                        continue;
+                    }
+                    
+                }
+            }
+
+            return modelReflectedType;
+        }
+
+        public IEnumerable<string> GetCompilationErrors()
+        {
+            return _compilationResult?.ErrorMessages;
+        }
+
+        // Look for the model type in the current project. 
+        // If its not found in the current project, look in the dependencies.
+        private Type GetTypeFromAssembly(string modelTypeName, Assembly assembly, bool lookInDependencies)
+        {
+            if (_compilationResult == null
+                || !_compilationResult.Success)
+            {
+                // If the compilation was not successful, just return null.
+                return null;
+            }
+
+            if(string.IsNullOrEmpty(modelTypeName))
+            {
+                throw new ArgumentNullException(nameof(modelTypeName));
+            }
+
+            if(assembly == null)
+            {
+                throw new ArgumentNullException(nameof(assembly));
+            }
+
+            Type modelType = null;
+            try
+            {
+                modelType = assembly.GetType(modelTypeName);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogMessage(ex.Message, LogMessageLevel.Error);
+            }
+
+            if (modelType == null && lookInDependencies)
+            {
+                // Need to look in the dependencies of this project now.
+                var dependencies = _projectContext.CompilationAssemblies.GetEnumerator();
+                while (modelType == null && dependencies.MoveNext())
+                {
+                    try
+                    {
+                        // Since we are running in the project's dependency context, loading assemblies
+                        // by name just works.
+                        var dAssemblyName = new AssemblyName(Path.GetFileNameWithoutExtension(dependencies.Current.ResolvedPath));
+                        var dAssembly = _loader.LoadFromName(dAssemblyName);
+                        modelType = dAssembly.GetType(modelTypeName);
+                    }
+                    catch (Exception ex)
+                    {
+                        // This is a best effort approach. If we cannot load an assembly for any reason, 
+                        // just ignore it and look for the type in the next one.
+                        _logger.LogMessage(ex.Message, LogMessageLevel.Trace);
+                        continue;
+                    }
+                    
+                }
+            }
+
+            return modelType;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore/project.json
+++ b/src/Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore/project.json
@@ -13,6 +13,7 @@
     "Microsoft.AspNetCore.Hosting": "1.0.0",
     "Microsoft.AspNetCore.Server.Kestrel": "1.0.1",
     "Microsoft.EntityFrameworkCore": "1.0.1",
+    "Microsoft.EntityFrameworkCore.Design": "1.0.1",
     "Microsoft.EntityFrameworkCore.SqlServer": "1.0.1",
     "Microsoft.VisualStudio.Web.CodeGeneration.Core": "1.0.0-*",
     "NETStandard.Library": "1.6.0"

--- a/test/E2E_Test/MvcControllerTest.cs
+++ b/test/E2E_Test/MvcControllerTest.cs
@@ -120,7 +120,7 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.E2E_Test
         {
             using (var fileProvider = new TemporaryFileProvider())
             {
-                new MsBuildProjectSetupHelper().SetupProjects(fileProvider, Output);
+                new MsBuildProjectSetupHelper().SetupProjects(fileProvider, Output, true);
                 TestProjectPath = Path.Combine(fileProvider.Root, "Root");
                 Directory.SetCurrentDirectory(TestProjectPath);
                 var args = new string[]

--- a/test/Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore.Test/ReflectedTypesProviderTests.cs
+++ b/test/Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore.Test/ReflectedTypesProviderTests.cs
@@ -1,0 +1,113 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.ProjectModel;
+using Microsoft.VisualStudio.Web.CodeGeneration.Utils;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore.Test
+{
+    public class ReflectedTypesProviderTests
+    {
+        private TestAssemblyLoadContext _loader;
+        private ILogger _logger;
+        private ITestOutputHelper _output;
+        private IProjectContext _projectContext;
+        private MsBuildProjectSetupHelper _projectSetupHelper;
+        private RoslynWorkspace _workspace;
+
+        public ReflectedTypesProviderTests(ITestOutputHelper output)
+        {
+            _output = output;
+            _projectSetupHelper = new MsBuildProjectSetupHelper();
+        }
+
+        [Fact (Skip = "Disable tests on CI that need to load assemblies")]
+        public void TestGetReflectedType()
+        {
+            using (var fileProvider = new TemporaryFileProvider())
+            {
+                SetupProjectInformation(fileProvider);
+
+                var compilation = _workspace.CurrentSolution.Projects
+                    .First()
+                    .GetCompilationAsync()
+                    .Result;
+
+                Func<CodeAnalysis.Compilation, CodeAnalysis.Compilation> func = (c) =>
+                {
+                    return c;
+                };
+
+                var reflectedTypesProvider = new ReflectedTypesProvider(
+                    compilation,
+                    func,
+                    _projectContext,
+                    _loader,
+                    _logger);
+
+                var carType = reflectedTypesProvider.GetReflectedType("Library1.Models.Car", false);
+                Assert.Null(carType);
+
+                carType = reflectedTypesProvider.GetReflectedType("Library1.Models.Car", true);
+                Assert.NotNull(carType);
+            }
+        }
+
+        [Fact]
+        public void TestGetReflectedType_FailedCompilation()
+        {
+            using (var fileProvider = new TemporaryFileProvider())
+            {
+                SetupProjectInformation(fileProvider);
+
+                var compilation = _workspace.CurrentSolution.Projects
+                    .First()
+                    .GetCompilationAsync()
+                    .Result;
+
+                Func<CodeAnalysis.Compilation, CodeAnalysis.Compilation> func = (c) =>
+                {
+                    return c.WithReferences(null);
+                };
+
+                var reflectedTypesProvider = new ReflectedTypesProvider(
+                    compilation,
+                    func,
+                    _projectContext,
+                    _loader,
+                    _logger);
+
+                var carType = reflectedTypesProvider.GetReflectedType("Library1.Models.Car", true);
+                Assert.Null(carType);
+
+                var compilationErrors = reflectedTypesProvider.GetCompilationErrors();
+                Assert.NotNull(compilationErrors);
+            }
+        }
+
+        private void SetupProjectInformation(TemporaryFileProvider fileProvider)
+        {
+            _projectSetupHelper.SetupProjects(fileProvider, _output);
+
+            var path = Path.Combine(fileProvider.Root, "Root", "Test.csproj");
+            _projectContext = GetProjectInformation(path);
+            _workspace = new RoslynWorkspace(_projectContext);
+            _loader = new TestAssemblyLoadContext(_projectContext);
+            _logger = new ConsoleLogger();
+        }
+
+        private IProjectContext GetProjectInformation(string path)
+        {
+            var rootContext = new MsBuildProjectContextBuilder(path, "Dummy")
+                .Build();
+            return rootContext;
+        }
+    }
+}

--- a/test/Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore.Test/TestAssemblyLoadContext.cs
+++ b/test/Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore.Test/TestAssemblyLoadContext.cs
@@ -23,7 +23,7 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore.Test
         }
         public Assembly LoadFromName(AssemblyName AssemblyName)
         {
-            var path = _projectContext.CompilationAssemblies.First(c => c.Name == AssemblyName.Name).ResolvedPath;
+            var path = _projectContext.CompilationAssemblies.First(c => Path.GetFileNameWithoutExtension(c.Name) == AssemblyName.Name).ResolvedPath;
             return AssemblyLoadContext.Default.LoadFromAssemblyPath(path);
         }
 

--- a/test/Shared/MsBuildProjectSetupHelper.cs
+++ b/test/Shared/MsBuildProjectSetupHelper.cs
@@ -10,7 +10,7 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration
 {
     internal class MsBuildProjectSetupHelper
     {
-        public void SetupProjects(TemporaryFileProvider fileProvider, ITestOutputHelper output)
+        public void SetupProjects(TemporaryFileProvider fileProvider, ITestOutputHelper output, bool fullFramework = false)
         {
             string artifactsDir = null;
             var current = new DirectoryInfo(AppContext.BaseDirectory);
@@ -28,7 +28,8 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration
             Directory.CreateDirectory(Path.Combine(fileProvider.Root, "Library1"));
             fileProvider.Add("Nuget.config", MsBuildProjectStrings.GetNugetConfigTxt(artifactsDir));
 
-            fileProvider.Add($"Root/{MsBuildProjectStrings.RootProjectName}", MsBuildProjectStrings.RootProjectTxt);
+            var rootProjectTxt = fullFramework ? MsBuildProjectStrings.RootNet45ProjectTxt : MsBuildProjectStrings.RootProjectTxt;
+            fileProvider.Add($"Root/{MsBuildProjectStrings.RootProjectName}", rootProjectTxt);
             fileProvider.Add($"Root/Startup.cs", MsBuildProjectStrings.StartupTxt);
             fileProvider.Add($"Root/{MsBuildProjectStrings.ProgramFileName}", MsBuildProjectStrings.ProgramFileText);
 

--- a/test/Shared/MsBuildProjectStrings.cs
+++ b/test/Shared/MsBuildProjectStrings.cs
@@ -51,12 +51,60 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration
     <PackageReference Include=""Microsoft.Extensions.Logging.Debug"" Version=""1.0.0"" />
     <PackageReference Include=""Microsoft.Extensions.Options.ConfigurationExtensions"" Version=""1.0.0"" />
     <PackageReference Include=""Microsoft.VisualStudio.Web.CodeGeneration.Design"" Version=""1.0.0-*"" />
+    <PackageReference Include=""Microsoft.VisualStudio.Web.CodeGeneration.Tools"" Version=""1.0.0-*"" />
     <DotNetCliToolReference Include=""Microsoft.VisualStudio.Web.CodeGeneration.Tools"" Version=""1.0.0-*"" />
     <PackageReference Include=""Microsoft.NET.Sdk"" Version=""1.0.0-alpha-20161029-1"" PrivateAssets=""All"" />
     <PackageReference Include=""Microsoft.NETCore.App"" Version=""1.0.1"" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include=""..\Library1\Library1.csproj"" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include = ""xyz.dll"" />
+  </ItemGroup>
+  <Import Project=""$(MSBuildToolsPath)\Microsoft.CSharp.targets"" />
+</Project>
+";
+
+        public const string RootNet45ProjectTxt = @"
+<Project ToolsVersion=""14.0"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+  <Import Project=""$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props"" />
+
+  <PropertyGroup>
+    <RootNamespace>Microsoft.TestProject</RootNamespace>
+    <ProjectName>TestProject</ProjectName>
+    <OutputType>EXE</OutputType>
+    <TargetFrameworks>net452</TargetFrameworks>
+    <OutputPath>bin\$(Configuration)</OutputPath>
+    <RuntimeIdentifier>win7-x64</RuntimeIdentifier>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include=""**\*.cs"" Exclude=""Excluded.cs"" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include=""Microsoft.AspNetCore.Diagnostics"" Version=""1.0.0"" />
+    <PackageReference Include=""Microsoft.AspNetCore.Mvc"" Version=""1.0.0"" />
+    <PackageReference Include=""Microsoft.AspNetCore.Server.IISIntegration"" Version=""1.0.0"" />
+    <PackageReference Include=""Microsoft.AspNetCore.Server.Kestrel"" Version=""1.0.1"" />
+    <PackageReference Include=""Microsoft.AspNetCore.StaticFiles"" Version=""1.0.0"" />
+    <PackageReference Include=""Microsoft.Extensions.Configuration.EnvironmentVariables"" Version=""1.0.0"" />
+    <PackageReference Include=""Microsoft.Extensions.Configuration.Json"" Version=""1.0.0"" />
+    <PackageReference Include=""Microsoft.Extensions.Logging"" Version=""1.0.0"" />
+    <PackageReference Include=""Microsoft.Extensions.Logging.Console"" Version=""1.0.0"" />
+    <PackageReference Include=""Microsoft.Extensions.Logging.Debug"" Version=""1.0.0"" />
+    <PackageReference Include=""Microsoft.Extensions.Options.ConfigurationExtensions"" Version=""1.0.0"" />
+    <PackageReference Include=""Microsoft.VisualStudio.Web.CodeGeneration.Design"" Version=""1.0.0-*"" />
+    <DotNetCliToolReference Include=""Microsoft.VisualStudio.Web.CodeGeneration.Tools"" Version=""1.0.0-*"" />
+    <PackageReference Include=""Microsoft.NET.Sdk"" Version=""1.0.0-alpha-20161029-1"" PrivateAssets=""All"" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include=""..\Library1\Library1.csproj"" />
+    <Reference Include=""System"" />
+    <Reference Include=""System.Data"" />
+    <Reference Include=""System.ComponentModel.DataAnnotations"" />
+    <Reference Include=""Microsoft.CSharp"" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include = ""xyz.dll"" />
@@ -135,7 +183,7 @@ namespace Test
     <RootNamespace>Microsoft.Library</RootNamespace>
     <ProjectName>Library1</ProjectName>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>netstandard1.6</TargetFrameworks>
+    <TargetFrameworks>netstandard1.6;net451</TargetFrameworks>
     <OutputPath>bin\$(Configuration)</OutputPath>
   </PropertyGroup>
 
@@ -147,9 +195,14 @@ namespace Test
     <PackageReference Include=""Microsoft.NET.Sdk"" Version=""1.0.0-alpha-20161029-1"" />
     <PackageReference Include=""NETStandard.Library"" Version=""1.6"" />
   </ItemGroup>
+  <ItemGroup Condition=""'$(TargetFramework)' == 'net451' "">
+    <Reference Include=""System"" />
+    <Reference Include=""System.Data"" />
+  </ItemGroup>
   <Import Project=""$(MSBuildToolsPath)\Microsoft.CSharp.targets"" />
 </Project>
 ";
+
 
         public const string ProductTxt = @"
 using System;


### PR DESCRIPTION
Instead of trying to host user's app to get the DbContext, while scaffolding, let EF run its magic.

Fixes #339 
cc @mlorbetske, @bricelam 
