### PR TITLE
Remove usage of NuGetPackageRoot msbuild property

### DIFF
--- a/src/Microsoft.VisualStudio.Web.CodeGeneration.Msbuild/ProjectContextWriter.cs
+++ b/src/Microsoft.VisualStudio.Web.CodeGeneration.Msbuild/ProjectContextWriter.cs
@@ -44,9 +44,6 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.Msbuild
         public string OutputType { get; set; }
 
         [Build.Framework.Required]
-        public string PackagesDirectory { get; set; }
-
-        [Build.Framework.Required]
         public string Platform { get; set; }
 
         [Build.Framework.Required]
@@ -87,7 +84,7 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.Msbuild
                 EmbededItems = this.EmbeddedItems.Select(i => i.ItemSpec),
                 IsClassLibrary = "Library".Equals(this.OutputType, StringComparison.OrdinalIgnoreCase),
                 PackageDependencies = this.GetPackageDependencies(PackageDependencies),
-                PackagesDirectory = this.PackagesDirectory,
+                //PackagesDirectory = this.PackagesDirectory,
                 Platform = this.Platform,
                 ProjectFullPath = this.ProjectFullPath,
                 ProjectName = this.Name,

--- a/src/Microsoft.VisualStudio.Web.CodeGeneration.Msbuild/Target/build/Microsoft.VisualStudio.Web.CodeGeneration.Tools.targets
+++ b/src/Microsoft.VisualStudio.Web.CodeGeneration.Msbuild/Target/build/Microsoft.VisualStudio.Web.CodeGeneration.Tools.targets
@@ -46,7 +46,6 @@ Outputs the Project Information needed for CodeGeneration to a file.
                           PackageDependencies ="@(_DependenciesDesignTime)"
                           ProjectReferences ="@(ProjectReference)"
                           AssemblyFullPath ="$(TargetPath)"
-                          PackagesDirectory="$(NuGetPackageRoot)"
                           OutputType="$(OutputType)"
                           Platform="$(Platform)"
                           RootNameSpace ="$(RootNamespace)"

--- a/src/Microsoft.VisualStudio.Web.CodeGeneration.Tools/Program.cs
+++ b/src/Microsoft.VisualStudio.Web.CodeGeneration.Tools/Program.cs
@@ -189,7 +189,8 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.Tools
                     dispatchArgs: dependencyArgs,
                     framework: frameworkToUse,
                     configuration: configuration,
-                    projectDirectory: projectDirectory);
+                    projectDirectory: projectDirectory,
+                    assemblyFullPath: context.AssemblyFullPath);
         }
 
         private static IProjectContext GetProjectInformation(string projectPath, string configuration)

--- a/src/Microsoft.VisualStudio.Web.CodeGeneration.Tools/Program.cs
+++ b/src/Microsoft.VisualStudio.Web.CodeGeneration.Tools/Program.cs
@@ -165,7 +165,6 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.Tools
             var targetDir = Path.GetDirectoryName(context.AssemblyFullPath);
             var runtimeConfigPath = Path.Combine(targetDir, context.RuntimeConfig);
             var depsFile = Path.Combine(targetDir, context.DepsFile);
-            var nugetPackageRoot = context.PackagesDirectory;
 
             string dotnetCodeGenInsideManPath = context.CompilationAssemblies
                 .Where(c => Path.GetFileNameWithoutExtension(c.Name)
@@ -186,7 +185,6 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.Tools
             return DotnetToolDispatcher.CreateDispatchCommand(
                     runtimeConfigPath: runtimeConfigPath,
                     depsFile: depsFile,
-                    additionalProbingPaths: new[] { nugetPackageRoot },
                     dependencyToolPath: dotnetCodeGenInsideManPath,
                     dispatchArgs: dependencyArgs,
                     framework: frameworkToUse,

--- a/src/Shared/DotNetDispatcher/DotnetToolDispatcher.cs
+++ b/src/Shared/DotNetDispatcher/DotnetToolDispatcher.cs
@@ -23,7 +23,6 @@ namespace Microsoft.Extensions.Internal
         /// </summary>
         /// <param name="runtimeConfigPath">Full path to the runtimeconfig.json for the user's project.</param>
         /// <param name="depsFile">Full path to the deps.json for the user's project.</param>
-        /// <param name="additionalProbingPaths">Additional search paths for assembly resolution.</param>
         /// <param name="dependencyToolPath">The executable which needs to be invoked.</param>
         /// <param name="dispatchArgs">Arguments to pass to the executable.</param>
         /// <param name="framework"></param>
@@ -32,7 +31,6 @@ namespace Microsoft.Extensions.Internal
         public static Command CreateDispatchCommand(
             string runtimeConfigPath,
             string depsFile,
-            IEnumerable<string> additionalProbingPaths,
             string dependencyToolPath,
             IEnumerable<string> dispatchArgs,
             NuGetFramework framework,
@@ -63,8 +61,6 @@ namespace Microsoft.Extensions.Internal
                     runtimeConfigPath,
                     "--depsfile",
                     depsFile,
-                    "--additionalprobingpath",
-                    string.Join(";", additionalProbingPaths),
                     dependencyToolPath
                 };
 


### PR DESCRIPTION
Two changes: 
- Remove usage of NuGetPackageRoot msbuild property
- For .NETFramework projects, fix the dispatcher to invoke the _inside man_ from the bin directory instead of nuget package folder.

cc @vijayrkn 