### PR TITLE
Remove containing assembly check for DbSet<> type.

### DIFF
--- a/src/Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore/DbContextEditorServices.cs
+++ b/src/Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore/DbContextEditorServices.cs
@@ -260,8 +260,6 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore
             {
                 var namedType = pSymbol.Type as INamedTypeSymbol; //When can this go wrong?
                 if (namedType != null && namedType.IsGenericType && !namedType.IsUnboundGenericType &&
-                    namedType.ContainingAssembly.Name == "Microsoft.EntityFrameworkCore" &&
-                    namedType.ContainingNamespace.ToDisplayString() == "Microsoft.EntityFrameworkCore" &&
                     namedType.Name == "DbSet")
                 {
                     // Can we check for equality of typeSymbol itself?


### PR DESCRIPTION
If the DbContext type is in a dependent project/assembly, the containing assembly for DbSet type is returned as that project/ assembly. 

This causes scaffolding to try to add an additional DbSet property and fail. 

Fixes #365 
