### PR TITLE
Use nameof expression in controller RedirectToAction calls

### DIFF
--- a/src/Microsoft.VisualStudio.Web.CodeGenerators.Mvc/Templates/ControllerGenerator/ControllerWithActions.cshtml
+++ b/src/Microsoft.VisualStudio.Web.CodeGenerators.Mvc/Templates/ControllerGenerator/ControllerWithActions.cshtml
@@ -38,7 +38,7 @@ namespace @Model.NamespaceName
             {
                 // TODO: Add insert logic here
 
-                return RedirectToAction("Index");
+                return RedirectToAction(nameof(Index));
             }
             catch
             {
@@ -61,7 +61,7 @@ namespace @Model.NamespaceName
             {
                 // TODO: Add update logic here
 
-                return RedirectToAction("Index");
+                return RedirectToAction(nameof(Index));
             }
             catch
             {
@@ -84,7 +84,7 @@ namespace @Model.NamespaceName
             {
                 // TODO: Add delete logic here
 
-                return RedirectToAction("Index");
+                return RedirectToAction(nameof(Index));
             }
             catch
             {

--- a/src/Microsoft.VisualStudio.Web.CodeGenerators.Mvc/Templates/ControllerGenerator/MvcControllerWithContext.cshtml
+++ b/src/Microsoft.VisualStudio.Web.CodeGenerators.Mvc/Templates/ControllerGenerator/MvcControllerWithContext.cshtml
@@ -136,7 +136,7 @@ namespace @Model.ControllerNamespace
     }
                 @:_context.Add(@Model.ModelVariable);
                 @:await _context.SaveChangesAsync();
-}                return RedirectToAction("Index");
+}                return RedirectToAction(nameof(Index));
             }
 @{
     foreach (var property in relatedProperties.Values)
@@ -199,7 +199,7 @@ namespace @Model.ControllerNamespace
                         throw;
                     }
                 }
-                return RedirectToAction("Index");
+                return RedirectToAction(nameof(Index));
             }
 @{
     foreach (var property in relatedProperties.Values)
@@ -236,7 +236,7 @@ namespace @Model.ControllerNamespace
             var @Model.ModelVariable = await _context.@(entitySetName).SingleOrDefaultAsync(m => m.@primaryKeyName == id);
             _context.@(entitySetName).Remove(@Model.ModelVariable);
             await _context.SaveChangesAsync();
-            return RedirectToAction("Index");
+            return RedirectToAction(nameof(Index));
         }
 
         private bool @(Model.ModelTypeName)Exists(@primaryKeyShortTypeName id)

--- a/test/E2E_Test/Baseline/CarsController.txt
+++ b/test/E2E_Test/Baseline/CarsController.txt
@@ -59,7 +59,7 @@ namespace WebApplication1
             {
                 _context.Add(car);
                 await _context.SaveChangesAsync();
-                return RedirectToAction("Index");
+                return RedirectToAction(nameof(Index));
             }
             return View(car);
         }
@@ -110,7 +110,7 @@ namespace WebApplication1
                         throw;
                     }
                 }
-                return RedirectToAction("Index");
+                return RedirectToAction(nameof(Index));
             }
             return View(car);
         }
@@ -141,7 +141,7 @@ namespace WebApplication1
             var car = await _context.Car.SingleOrDefaultAsync(m => m.CarID == id);
             _context.Car.Remove(car);
             await _context.SaveChangesAsync();
-            return RedirectToAction("Index");
+            return RedirectToAction(nameof(Index));
         }
 
         private bool CarExists(int id)

--- a/test/E2E_Test/Baseline/CarsWithViewController.txt
+++ b/test/E2E_Test/Baseline/CarsWithViewController.txt
@@ -60,7 +60,7 @@ namespace WebApplication1.Areas.Test.Controllers
             {
                 _context.Add(car);
                 await _context.SaveChangesAsync();
-                return RedirectToAction("Index");
+                return RedirectToAction(nameof(Index));
             }
             return View(car);
         }
@@ -111,7 +111,7 @@ namespace WebApplication1.Areas.Test.Controllers
                         throw;
                     }
                 }
-                return RedirectToAction("Index");
+                return RedirectToAction(nameof(Index));
             }
             return View(car);
         }
@@ -142,7 +142,7 @@ namespace WebApplication1.Areas.Test.Controllers
             var car = await _context.Car.SingleOrDefaultAsync(m => m.CarID == id);
             _context.Car.Remove(car);
             await _context.SaveChangesAsync();
-            return RedirectToAction("Index");
+            return RedirectToAction(nameof(Index));
         }
 
         private bool CarExists(int id)

--- a/test/E2E_Test/Baseline/ProductsController.txt
+++ b/test/E2E_Test/Baseline/ProductsController.txt
@@ -62,7 +62,7 @@ namespace WebApplication1
             {
                 _context.Add(product);
                 await _context.SaveChangesAsync();
-                return RedirectToAction("Index");
+                return RedirectToAction(nameof(Index));
             }
             ViewData["ManufacturerID"] = new SelectList(_context.Set<Manufacturer>(), "ManufacturerID", "Name", product.ManufacturerID);
             return View(product);
@@ -115,7 +115,7 @@ namespace WebApplication1
                         throw;
                     }
                 }
-                return RedirectToAction("Index");
+                return RedirectToAction(nameof(Index));
             }
             ViewData["ManufacturerID"] = new SelectList(_context.Set<Manufacturer>(), "ManufacturerID", "Name", product.ManufacturerID);
             return View(product);
@@ -148,7 +148,7 @@ namespace WebApplication1
             var product = await _context.Product.SingleOrDefaultAsync(m => m.ProductID == id);
             _context.Product.Remove(product);
             await _context.SaveChangesAsync();
-            return RedirectToAction("Index");
+            return RedirectToAction(nameof(Index));
         }
 
         private bool ProductExists(int id)

--- a/test/E2E_Test/Baseline/ReadWriteController.txt
+++ b/test/E2E_Test/Baseline/ReadWriteController.txt
@@ -36,7 +36,7 @@ namespace WebApplication1
             {
                 // TODO: Add insert logic here
 
-                return RedirectToAction("Index");
+                return RedirectToAction(nameof(Index));
             }
             catch
             {
@@ -59,7 +59,7 @@ namespace WebApplication1
             {
                 // TODO: Add update logic here
 
-                return RedirectToAction("Index");
+                return RedirectToAction(nameof(Index));
             }
             catch
             {
@@ -82,7 +82,7 @@ namespace WebApplication1
             {
                 // TODO: Add delete logic here
 
-                return RedirectToAction("Index");
+                return RedirectToAction(nameof(Index));
             }
             catch
             {


### PR DESCRIPTION
Use the C# 6 `nameof` expression in the MVC controller action method `RedirectToAction` calls. This makes the scaffolded controllers consistent with the `RedirectToAction` calls used in the project templates (in the aspnet/Templates repo).
@prafullbhosale