### PR TITLE
Use nameof expression in controller RedirectToAction calls

### DIFF
--- a/src/Microsoft.VisualStudio.Web.CodeGenerators.Mvc/Templates/ControllerGenerator/ControllerWithActions.cshtml
+++ b/src/Microsoft.VisualStudio.Web.CodeGenerators.Mvc/Templates/ControllerGenerator/ControllerWithActions.cshtml
@@ -38,7 +38,7 @@ namespace @Model.NamespaceName
             {
                 // TODO: Add insert logic here
 
-                return RedirectToAction("Index");
+                return RedirectToAction(nameof(Index));
             }
             catch
             {
@@ -61,7 +61,7 @@ namespace @Model.NamespaceName
             {
                 // TODO: Add update logic here
 
-                return RedirectToAction("Index");
+                return RedirectToAction(nameof(Index));
             }
             catch
             {
@@ -84,7 +84,7 @@ namespace @Model.NamespaceName
             {
                 // TODO: Add delete logic here
 
-                return RedirectToAction("Index");
+                return RedirectToAction(nameof(Index));
             }
             catch
             {

--- a/src/Microsoft.VisualStudio.Web.CodeGenerators.Mvc/Templates/ControllerGenerator/MvcControllerWithContext.cshtml
+++ b/src/Microsoft.VisualStudio.Web.CodeGenerators.Mvc/Templates/ControllerGenerator/MvcControllerWithContext.cshtml
@@ -136,7 +136,7 @@ namespace @Model.ControllerNamespace
     }
                 @:_context.Add(@Model.ModelVariable);
                 @:await _context.SaveChangesAsync();
-}                return RedirectToAction("Index");
+}                return RedirectToAction(nameof(Index));
             }
 @{
     foreach (var property in relatedProperties.Values)
@@ -199,7 +199,7 @@ namespace @Model.ControllerNamespace
                         throw;
                     }
                 }
-                return RedirectToAction("Index");
+                return RedirectToAction(nameof(Index));
             }
 @{
     foreach (var property in relatedProperties.Values)
@@ -236,7 +236,7 @@ namespace @Model.ControllerNamespace
             var @Model.ModelVariable = await _context.@(entitySetName).SingleOrDefaultAsync(m => m.@primaryKeyName == id);
             _context.@(entitySetName).Remove(@Model.ModelVariable);
             await _context.SaveChangesAsync();
-            return RedirectToAction("Index");
+            return RedirectToAction(nameof(Index));
         }
 
         private bool @(Model.ModelTypeName)Exists(@primaryKeyShortTypeName id)

--- a/test/E2E_Test/Compiler/Resources/CarsController.txt
+++ b/test/E2E_Test/Compiler/Resources/CarsController.txt
@@ -63,7 +63,7 @@ namespace TestProject
             {
                 _context.Add(car);
                 await _context.SaveChangesAsync();
-                return RedirectToAction("Index");
+                return RedirectToAction(nameof(Index));
             }
             ViewData["ManufacturerID"] = new SelectList(_context.Set<Manufacturer>(), "ID", "ID", car.ManufacturerID);
             return View(car);
@@ -116,7 +116,7 @@ namespace TestProject
                         throw;
                     }
                 }
-                return RedirectToAction("Index");
+                return RedirectToAction(nameof(Index));
             }
             ViewData["ManufacturerID"] = new SelectList(_context.Set<Manufacturer>(), "ID", "ID", car.ManufacturerID);
             return View(car);
@@ -149,7 +149,7 @@ namespace TestProject
             var car = await _context.Car.SingleOrDefaultAsync(m => m.ID == id);
             _context.Car.Remove(car);
             await _context.SaveChangesAsync();
-            return RedirectToAction("Index");
+            return RedirectToAction(nameof(Index));
         }
 
         private bool CarExists(int id)

--- a/test/E2E_Test/Compiler/Resources/CarsWithViewController.txt
+++ b/test/E2E_Test/Compiler/Resources/CarsWithViewController.txt
@@ -64,7 +64,7 @@ namespace TestProject.Areas.Test.Controllers
             {
                 _context.Add(car);
                 await _context.SaveChangesAsync();
-                return RedirectToAction("Index");
+                return RedirectToAction(nameof(Index));
             }
             ViewData["ManufacturerID"] = new SelectList(_context.Set<Manufacturer>(), "ID", "ID", car.ManufacturerID);
             return View(car);
@@ -117,7 +117,7 @@ namespace TestProject.Areas.Test.Controllers
                         throw;
                     }
                 }
-                return RedirectToAction("Index");
+                return RedirectToAction(nameof(Index));
             }
             ViewData["ManufacturerID"] = new SelectList(_context.Set<Manufacturer>(), "ID", "ID", car.ManufacturerID);
             return View(car);
@@ -150,7 +150,7 @@ namespace TestProject.Areas.Test.Controllers
             var car = await _context.Car.SingleOrDefaultAsync(m => m.ID == id);
             _context.Car.Remove(car);
             await _context.SaveChangesAsync();
-            return RedirectToAction("Index");
+            return RedirectToAction(nameof(Index));
         }
 
         private bool CarExists(int id)

--- a/test/E2E_Test/Compiler/Resources/ProductsController.txt
+++ b/test/E2E_Test/Compiler/Resources/ProductsController.txt
@@ -62,7 +62,7 @@ namespace TestProject
             {
                 _context.Add(product);
                 await _context.SaveChangesAsync();
-                return RedirectToAction("Index");
+                return RedirectToAction(nameof(Index));
             }
             ViewData["ManufacturerID"] = new SelectList(_context.Set<Manufacturer>(), "ManufacturerID", "ManufacturerID", product.ManufacturerID);
             return View(product);
@@ -115,7 +115,7 @@ namespace TestProject
                         throw;
                     }
                 }
-                return RedirectToAction("Index");
+                return RedirectToAction(nameof(Index));
             }
             ViewData["ManufacturerID"] = new SelectList(_context.Set<Manufacturer>(), "ManufacturerID", "ManufacturerID", product.ManufacturerID);
             return View(product);
@@ -148,7 +148,7 @@ namespace TestProject
             var product = await _context.Product.SingleOrDefaultAsync(m => m.ProductID == id);
             _context.Product.Remove(product);
             await _context.SaveChangesAsync();
-            return RedirectToAction("Index");
+            return RedirectToAction(nameof(Index));
         }
 
         private bool ProductExists(int id)

--- a/test/E2E_Test/Compiler/Resources/ReadWriteController.txt
+++ b/test/E2E_Test/Compiler/Resources/ReadWriteController.txt
@@ -36,7 +36,7 @@ namespace TestProject
             {
                 // TODO: Add insert logic here
 
-                return RedirectToAction("Index");
+                return RedirectToAction(nameof(Index));
             }
             catch
             {
@@ -59,7 +59,7 @@ namespace TestProject
             {
                 // TODO: Add update logic here
 
-                return RedirectToAction("Index");
+                return RedirectToAction(nameof(Index));
             }
             catch
             {
@@ -82,7 +82,7 @@ namespace TestProject
             {
                 // TODO: Add delete logic here
 
-                return RedirectToAction("Index");
+                return RedirectToAction(nameof(Index));
             }
             catch
             {


### PR DESCRIPTION
Use the C# 6 `nameof` expression in the MVC controller action method `RedirectToAction` calls. This makes the scaffolded controllers consistent with the `RedirectToAction` calls used in the project templates (in the aspnet/Templates repo).