### PR TITLE
Print stack trace for exceptions on stdout instead of stderr

### DIFF
--- a/src/Microsoft.VisualStudio.Web.CodeGeneration/CodeGenCommand.cs
+++ b/src/Microsoft.VisualStudio.Web.CodeGeneration/CodeGenCommand.cs
@@ -54,7 +54,7 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration
                     ex = ex.InnerException;
                 }
                 _logger.LogMessage(ex.Message, LogMessageLevel.Error);
-                _logger.LogMessage(ex.StackTrace, LogMessageLevel.Error);
+                _logger.LogMessage(ex.StackTrace);
             }
             return 0;
         }


### PR DESCRIPTION
This will prevent the stack trace from showing up on Visual Studio error dialogs, but will be available in the output window. 

**Before**: 

![image](https://cloud.githubusercontent.com/assets/1521254/22269054/a4bad634-e23e-11e6-91cd-7577d4343084.png)

**After**: 

![image](https://cloud.githubusercontent.com/assets/1521254/22268999/76d022ce-e23e-11e6-829a-6ad9d05eb54f.png)
