### PR TITLE
Stop producing Microsoft.VisualStudio.Web.CodeGeneration.Msbuild

### DIFF
--- a/NuGetPackageVerifier.json
+++ b/NuGetPackageVerifier.json
@@ -16,12 +16,6 @@
       }
     }
   },
-  "adx-nonshipping": {
-    "rules": [],
-    "packages": {
-      "Microsoft.VisualStudio.Web.CodeGeneration.Msbuild": {}
-    }
-  },
   "Default": {
     "rules": [
       "DefaultCompositeRule"

--- a/src/Microsoft.VisualStudio.Web.CodeGeneration.Msbuild/Microsoft.VisualStudio.Web.CodeGeneration.Msbuild.csproj
+++ b/src/Microsoft.VisualStudio.Web.CodeGeneration.Msbuild/Microsoft.VisualStudio.Web.CodeGeneration.Msbuild.csproj
@@ -5,10 +5,8 @@
   <PropertyGroup>
     <Description>MSBuild task (EvaluateProjectInfoForCodeGeneration) used by Microsoft.VisualStudio.Web.CodeGeneration.Tools</Description>
     <TargetFrameworks>net46;netstandard1.6</TargetFrameworks>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <NoWarn>$(NoWarn);CS1591</NoWarn>
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
-    <PackageTags>aspnetcore;codegenerator;scaffolding;visualstudioweb</PackageTags>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
These binaries are shipped in the .Tools package. We don't need the .MSbuild package.