### PR TITLE
Refactor versions to dependencies.props

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -2,4 +2,31 @@
   <PropertyGroup>
     <NetStandardImplicitPackageVersion>1.6.0</NetStandardImplicitPackageVersion>
   </PropertyGroup>
+  <!-- AspNetCore Versions -->
+  <PropertyGroup>
+    <AspNetCoreHostingVersion>1.0.2</AspNetCoreHostingVersion>
+    <KestrelVersion>1.0.3</KestrelVersion>
+    <CommandLineUtilsVersion>1.0.1</CommandLineUtilsVersion>
+    <DotNetInternalAbstractionsVersion>1.0.0</DotNetInternalAbstractionsVersion>
+    <DependencyInjectionVersion>1.0.2</DependencyInjectionVersion>
+    <EntityFrameworkCoreVersion>1.0.3</EntityFrameworkCoreVersion>
+    <FileProvidersVersion>1.0.1</FileProvidersVersion>
+    <PlatformAbstractionsVersion>1.0.0</PlatformAbstractionsVersion>
+    <RazorVersion>1.0.2</RazorVersion>
+  </PropertyGroup>
+  <!-- Partner Versions-->
+  <PropertyGroup>
+    <CodeAnalysisVersion>1.3.0</CodeAnalysisVersion>
+    <MicrosoftBuildVersion>15.1.548</MicrosoftBuildVersion>
+    <NewtonSoftVersion>9.0.1</NewtonSoftVersion>
+    <NuGetFrameworksVersion>4.0.0-*</NuGetFrameworksVersion>
+    <NuGetFrameworksLegacyVersion>3.5.0</NuGetFrameworksLegacyVersion>
+    <SystemAppContextVersion>4.1.0</SystemAppContextVersion>
+    <SystemDiagnosticsContractsVersion>4.0.1</SystemDiagnosticsContractsVersion>
+    <SystemDiagnosticsProcessVersion>4.1.0</SystemDiagnosticsProcessVersion>
+    <SystemRuntimeLoaderVersion>4.0.0</SystemRuntimeLoaderVersion>
+    <SystemRuntimeSerializationPrimitivesVersion>4.1.1</SystemRuntimeSerializationPrimitivesVersion>
+    <SystemSecurityCryptographyAlgorithmsVersion>4.2.0</SystemSecurityCryptographyAlgorithmsVersion>
+    <SystemThreadingTasksParallelVersion>4.0.1</SystemThreadingTasksParallelVersion>
+  </PropertyGroup>
 </Project>

--- a/src/Microsoft.VisualStudio.Web.CodeGeneration.Contracts/Microsoft.VisualStudio.Web.CodeGeneration.Contracts.csproj
+++ b/src/Microsoft.VisualStudio.Web.CodeGeneration.Contracts/Microsoft.VisualStudio.Web.CodeGeneration.Contracts.csproj
@@ -10,6 +10,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonSoftVersion)" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.VisualStudio.Web.CodeGeneration.Core/Microsoft.VisualStudio.Web.CodeGeneration.Core.csproj
+++ b/src/Microsoft.VisualStudio.Web.CodeGeneration.Core/Microsoft.VisualStudio.Web.CodeGeneration.Core.csproj
@@ -12,14 +12,14 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.VisualStudio.Web.CodeGeneration.Templating\Microsoft.VisualStudio.Web.CodeGeneration.Templating.csproj" />
-    <PackageReference Include="Microsoft.Extensions.CommandLineUtils" Version="1.0.1" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="1.0.2" />
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Include="Microsoft.Extensions.CommandLineUtils" Version="$(CommandLineUtilsVersion)" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(DependencyInjectionVersion)" />
+    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonSoftVersion)" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
-    <PackageReference Include="System.Diagnostics.Process" Version="4.1.0" />
-    <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.1.1" />
+    <PackageReference Include="System.Diagnostics.Process" Version="$(SystemDiagnosticsProcessVersion)" />
+    <PackageReference Include="System.Runtime.Serialization.Primitives" Version="$(SystemRuntimeSerializationPrimitivesVersion)" />
   </ItemGroup>
 
   <!--<ItemGroup>

--- a/src/Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore/Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore.csproj
+++ b/src/Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore/Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore.csproj
@@ -13,11 +13,10 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.VisualStudio.Web.CodeGeneration.Core\Microsoft.VisualStudio.Web.CodeGeneration.Core.csproj" />
-    <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="1.0.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="1.0.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="1.0.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="1.0.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="1.0.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="$(EntityFrameworkCoreVersion)" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="$(EntityFrameworkCoreVersion)" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="$(EntityFrameworkCoreVersion)" />
+    <PackageReference Include="System.Diagnostics.Contracts" Version="$(SystemDiagnosticsContractsVersion)" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net451'">

--- a/src/Microsoft.VisualStudio.Web.CodeGeneration.Msbuild/Microsoft.VisualStudio.Web.CodeGeneration.Msbuild.csproj
+++ b/src/Microsoft.VisualStudio.Web.CodeGeneration.Msbuild/Microsoft.VisualStudio.Web.CodeGeneration.Msbuild.csproj
@@ -19,11 +19,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build" Version="15.1.548" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="15.1.548" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.1.548" />
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-    <PackageReference Include="NuGet.Frameworks" Version="4.0.0-*" />
+    <PackageReference Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildVersion)" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildVersion)" />
+    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonSoftVersion)" />
+    <PackageReference Include="NuGet.Frameworks" Version="$(NuGetFrameworksVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.VisualStudio.Web.CodeGeneration.Templating/Microsoft.VisualStudio.Web.CodeGeneration.Templating.csproj
+++ b/src/Microsoft.VisualStudio.Web.CodeGeneration.Templating/Microsoft.VisualStudio.Web.CodeGeneration.Templating.csproj
@@ -15,8 +15,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Razor" Version="1.0.2" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="1.3.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Razor" Version="$(RazorVersion)" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(CodeAnalysisVersion)" />
   </ItemGroup>
 
   <!--<ItemGroup>

--- a/src/Microsoft.VisualStudio.Web.CodeGeneration.Tools/Microsoft.VisualStudio.Web.CodeGeneration.Tools.csproj
+++ b/src/Microsoft.VisualStudio.Web.CodeGeneration.Tools/Microsoft.VisualStudio.Web.CodeGeneration.Tools.csproj
@@ -24,13 +24,13 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.VisualStudio.Web.CodeGeneration.Contracts\Microsoft.VisualStudio.Web.CodeGeneration.Contracts.csproj" />
-    <PackageReference Include="Microsoft.Build.Runtime" Version="15.1.548" />
-    <PackageReference Include="Microsoft.DotNet.InternalAbstractions" Version="1.0.0" />
-    <PackageReference Include="Microsoft.Extensions.CommandLineUtils" Version="1.0.1" />
-    <PackageReference Include="Microsoft.Extensions.PlatformAbstractions" Version="1.0.0" />
-    <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="1.0.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-    <PackageReference Include="NuGet.Frameworks" Version="3.5.0" />
+    <PackageReference Include="Microsoft.Build.Runtime" Version="$(MicrosoftBuildVersion)" />
+    <PackageReference Include="Microsoft.DotNet.InternalAbstractions" Version="$(DotNetInternalAbstractionsVersion)" />
+    <PackageReference Include="Microsoft.Extensions.CommandLineUtils" Version="$(CommandLineUtilsVersion)" />
+    <PackageReference Include="Microsoft.Extensions.PlatformAbstractions" Version="$(PlatformAbstractionsVersion)" />
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="$(FileProvidersVersion)" />
+    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonSoftVersion)" />
+    <PackageReference Include="NuGet.Frameworks" Version="$(NuGetFrameworksLegacyVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.VisualStudio.Web.CodeGeneration.Utils/Microsoft.VisualStudio.Web.CodeGeneration.Utils.csproj
+++ b/src/Microsoft.VisualStudio.Web.CodeGeneration.Utils/Microsoft.VisualStudio.Web.CodeGeneration.Utils.csproj
@@ -18,17 +18,17 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.VisualStudio.Web.CodeGeneration.Contracts\Microsoft.VisualStudio.Web.CodeGeneration.Contracts.csproj" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="1.3.0" />
-    <PackageReference Include="Microsoft.Extensions.PlatformAbstractions" Version="1.0.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
-    <PackageReference Include="NuGet.Frameworks" Version="3.5.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(CodeAnalysisVersion)" />
+    <PackageReference Include="Microsoft.Extensions.PlatformAbstractions" Version="$(PlatformAbstractionsVersion)" />
+    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonSoftVersion)" />
+    <PackageReference Include="NuGet.Frameworks" Version="$(NuGetFrameworksLegacyVersion)" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
-    <PackageReference Include="System.AppContext" Version="4.1.0" />
-    <PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.2.0" />
-    <PackageReference Include="System.Threading.Tasks.Parallel" Version="4.0.1" />
-    <PackageReference Include="System.Runtime.Loader" Version="4.0.0" />
+    <PackageReference Include="System.AppContext" Version="$(SystemAppContextVersion)" />
+    <PackageReference Include="System.Security.Cryptography.Algorithms" Version="$(SystemSecurityCryptographyAlgorithmsVersion)" />
+    <PackageReference Include="System.Threading.Tasks.Parallel" Version="$(SystemThreadingTasksParallelVersion)" />
+    <PackageReference Include="System.Runtime.Loader" Version="$(SystemRuntimeLoaderVersion)" />
   </ItemGroup>
 
   <!--<ItemGroup>

--- a/src/Microsoft.VisualStudio.Web.CodeGeneration/Microsoft.VisualStudio.Web.CodeGeneration.csproj
+++ b/src/Microsoft.VisualStudio.Web.CodeGeneration/Microsoft.VisualStudio.Web.CodeGeneration.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore\Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore.csproj" />
-    <PackageReference Include="Microsoft.Extensions.CommandLineUtils" Version="1.0.1" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="1.0.2" />
+    <PackageReference Include="Microsoft.Extensions.CommandLineUtils" Version="$(CommandLineUtilsVersion)" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(DependencyInjectionVersion)" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Moving all versions of dependencies to `dependencies.props` to make it easier to update them.

cc @natemcmaster 