### PR TITLE
Adapt to changes in Startup class and DbContext discovery

### DIFF
--- a/src/Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore/DbContextEditorServices.cs
+++ b/src/Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore/DbContextEditorServices.cs
@@ -217,7 +217,7 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore
                 if (namedType != null &&
                     namedType.ContainingAssembly.Name == "Microsoft.Extensions.Configuration.Abstractions" &&
                     namedType.ContainingNamespace.ToDisplayString() == "Microsoft.Extensions.Configuration" &&
-                    namedType.Name == "IConfigurationRoot") 
+                    namedType.Name == "IConfiguration") 
                 {
                     return pSymbol;
                 }

--- a/src/Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore/DbContextEditorServices.cs
+++ b/src/Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore/DbContextEditorServices.cs
@@ -58,6 +58,22 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore
             }
 
             var templateName = "NewLocalDbContext.cshtml";
+            return await AddNewContextItemsInternal(templateName, dbContextTemplateModel);
+        }
+
+        public async Task<SyntaxTree> AddNewDbContextFactory(NewDbContextTemplateModel dbContextTemplateModel)
+        {
+            if (dbContextTemplateModel == null)
+            {
+                throw new ArgumentNullException(nameof(dbContextTemplateModel));
+            }
+
+            var templateName = "NewDbContextFactory.cshtml";
+            return await AddNewContextItemsInternal(templateName, dbContextTemplateModel);
+        }
+
+        private async Task<SyntaxTree> AddNewContextItemsInternal(string templateName, NewDbContextTemplateModel dbContextTemplateModel)
+        {
             var templatePath = _filesLocator.GetFilePath(templateName, TemplateFolders);
             Contract.Assert(File.Exists(templatePath));
 
@@ -78,6 +94,7 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore
 
             return CSharpSyntaxTree.ParseText(sourceText);
         }
+
 
         public EditSyntaxTreeResult AddModelToContext(ModelType dbContext, ModelType modelType)
         {

--- a/src/Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore/IDbContextEditorServices.cs
+++ b/src/Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore/IDbContextEditorServices.cs
@@ -10,6 +10,8 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore
     {
         Task<SyntaxTree> AddNewContext(NewDbContextTemplateModel dbContextTemplateModel);
 
+        Task<SyntaxTree> AddNewDbContextFactory(NewDbContextTemplateModel dbContextTemplateModel);
+
         EditSyntaxTreeResult AddModelToContext(ModelType dbContext, ModelType modelType);
 
         EditSyntaxTreeResult EditStartupForNewContext(ModelType startup, string dbContextTypeName, string dbContextNamespace, string dataBaseName);

--- a/src/Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore/NewDbContextTemplateModel.cs
+++ b/src/Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore/NewDbContextTemplateModel.cs
@@ -8,7 +8,7 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore
 {
     public class NewDbContextTemplateModel
     {
-        public NewDbContextTemplateModel(string dbContextName, ModelType modelType)
+        public NewDbContextTemplateModel(string dbContextName, ModelType modelType, ModelType programType)
         {
             if (dbContextName == null)
             {
@@ -20,10 +20,17 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore
                 throw new ArgumentNullException(nameof(modelType));
             }
 
+            if (programType == null)
+            {
+                throw new ArgumentNullException(nameof(programType));
+            }
+
             var modelNamespace = modelType.Namespace;
 
             ModelTypeName = modelType.Name;
             ModelTypeFullName = modelType.FullName;
+            ProgramTypeName = programType.Name;
+            ProgramNamespace = programType.Namespace;
             RequiredNamespaces = new HashSet<string>();
 
             var classNameModel = new ClassNameModel(dbContextName);
@@ -36,6 +43,7 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore
             {
                 RequiredNamespaces.Add(modelNamespace);
             }
+
         }
 
         public string DbContextTypeName { get; private set; }
@@ -44,6 +52,9 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore
 
         public string ModelTypeName { get; private set; }
         public string ModelTypeFullName { get; private set; }
+
+        public string ProgramTypeName { get; private set; }
+        public string ProgramNamespace { get; private set; }
 
         public HashSet<string> RequiredNamespaces { get; private set; }
     }

--- a/src/Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore/Templates/DbContext/NewDbContextFactory.cshtml
+++ b/src/Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore/Templates/DbContext/NewDbContextFactory.cshtml
@@ -15,11 +15,12 @@ using Microsoft.Extensions.DependencyInjection;
 @{
     var factoryClassName = @Model.DbContextTypeName+"Factory";
 }
+
 namespace @Model.DbContextNamespace
 {
     public class @factoryClassName : IDbContextFactory<@Model.DbContextTypeName>
     {
-        public @Model.DbContextTypeName Create(DbContextFactoryOptions options) =>
-            @(Model.ProgramTypeName).BuildWebHost(Array.Empty<string>()).Services.GetRequiredService<@Model.DbContextTypeName>();
+        public @Model.DbContextTypeName Create(string[] args) =>
+            @(Model.ProgramTypeName).BuildWebHost(args).Services.GetRequiredService<@Model.DbContextTypeName>();
     }
 }

--- a/src/Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore/Templates/DbContext/NewDbContextFactory.cshtml
+++ b/src/Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore/Templates/DbContext/NewDbContextFactory.cshtml
@@ -1,0 +1,25 @@
+@inherits Microsoft.VisualStudio.Web.CodeGeneration.Templating.RazorTemplateBase
+@using System.Collections.Generic;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
+@{
+    if (!Model.DbContextNamespace.Equals(Model.ProgramNamespace, StringComparison.Ordinal))
+    {
+@:using @Model.ProgramNamespace;
+    }
+}
+@{
+    var factoryClassName = @Model.DbContextTypeName+"Factory";
+}
+namespace @Model.DbContextNamespace
+{
+    public class @factoryClassName : IDbContextFactory<@Model.DbContextTypeName>
+    {
+        public @Model.DbContextTypeName Create(DbContextFactoryOptions options) =>
+            @(Model.ProgramTypeName).BuildWebHost(Array.Empty<string>()).Services.GetRequiredService<@Model.DbContextTypeName>();
+    }
+}

--- a/test/E2E_Test/Compiler/Resources/Views/CarDetails.txt
+++ b/test/E2E_Test/Compiler/Resources/Views/CarDetails.txt
@@ -5,20 +5,26 @@
     <hr />
     <dl class="dl-horizontal">
         <dt>
+            @Html.DisplayNameFor(model => model.ID)
+        </dt>
+        <dd>
+            @Html.DisplayFor(model => model.ID)
+        </dd>
+        <dt>
             @Html.DisplayNameFor(model => model.Name)
         </dt>
         <dd>
             @Html.DisplayFor(model => model.Name)
         </dd>
         <dt>
-            @Html.DisplayNameFor(model => model.Manufacturer)
+            @Html.DisplayNameFor(model => model.ManufacturerID)
         </dt>
         <dd>
-            @Html.DisplayFor(model => model.Manufacturer.ID)
+            @Html.DisplayFor(model => model.ManufacturerID)
         </dd>
     </dl>
 </div>
 <div>
-    <a asp-action="Edit" asp-route-id="@Model.ID">Edit</a> |
+    @Html.ActionLink("Edit", "Edit", new { /* id = Model.PrimaryKey */ }) |
     <a asp-action="Index">Back to List</a>
 </div>

--- a/test/E2E_Test/MvcControllerTest.cs
+++ b/test/E2E_Test/MvcControllerTest.cs
@@ -121,7 +121,7 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.E2E_Test
         {
             using (var fileProvider = new TemporaryFileProvider())
             {
-                new MsBuildProjectSetupHelper().SetupProjects(fileProvider, Output, true);
+                new MsBuildProjectSetupHelper().SetupProjects(fileProvider, Output, false);
                 TestProjectPath = Path.Combine(fileProvider.Root, "Root");
                 Directory.SetCurrentDirectory(TestProjectPath);
                 var args = new string[]

--- a/test/Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore.Test/compiler/resources/Startup_Empty_Method_RegisterContext_After.txt
+++ b/test/Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore.Test/compiler/resources/Startup_Empty_Method_RegisterContext_After.txt
@@ -11,6 +11,6 @@ namespace WebAppNamespace
             servicesVar.AddDbContext<MyContext>(options =>
                     options.UseSqlServer(ConfigurationProp.GetConnectionString("MyContext")));
         }
-        public IConfigurationRoot ConfigurationProp { get; set; }
+        public IConfiguration ConfigurationProp { get; set; }
     }
 }

--- a/test/Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore.Test/compiler/resources/Startup_Empty_Method_RegisterContext_Before.txt
+++ b/test/Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore.Test/compiler/resources/Startup_Empty_Method_RegisterContext_Before.txt
@@ -6,6 +6,6 @@ namespace WebAppNamespace
         public void ConfigureServices(IServiceCollection servicesVar)
         {
         }
-        public IConfigurationRoot ConfigurationProp { get; set; }
+        public IConfiguration ConfigurationProp { get; set; }
     }
 }

--- a/test/Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore.Test/compiler/resources/Startup_RegisterContext_After.txt
+++ b/test/Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore.Test/compiler/resources/Startup_RegisterContext_After.txt
@@ -6,7 +6,7 @@ namespace WebAppNamespace
 {
     public class Startup
     {
-        public Microsoft.Extensions.Configuration.IConfigurationRoot ConfigurationProp { get; set; }
+        public Microsoft.Extensions.Configuration.IConfiguration ConfigurationProp { get; set; }
 
         public void ConfigureServices(IServiceCollection servicesVar)
         {

--- a/test/Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore.Test/compiler/resources/Startup_RegisterContext_Before.txt
+++ b/test/Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore.Test/compiler/resources/Startup_RegisterContext_Before.txt
@@ -4,7 +4,7 @@ namespace WebAppNamespace
 {
     public class Startup
     {
-        public Microsoft.Extensions.Configuration.IConfigurationRoot ConfigurationProp { get; set; }
+        public Microsoft.Extensions.Configuration.IConfiguration ConfigurationProp { get; set; }
 
         public void ConfigureServices(IServiceCollection servicesVar)
         {

--- a/test/Shared/MsBuildProjectStrings.cs
+++ b/test/Shared/MsBuildProjectStrings.cs
@@ -260,10 +260,11 @@ namespace WebApplication1
             BuildWebHost(args).Run();
         }
 
-        public static IWebHost BuildWebHost(string[] args) => WebHost
-            .CreateDefaultBuilder(args)
-            .UseStartup<Startup>()
-            .Build();
+        public static IWebHost BuildWebHost(string[] args) =>
+            WebHost
+                .CreateDefaultBuilder(args)
+                .UseStartup<Startup>()
+                .Build();
     }
 }
 ";

--- a/test/Shared/MsBuildProjectStrings.cs
+++ b/test/Shared/MsBuildProjectStrings.cs
@@ -12,8 +12,8 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration
     <packageSources>
         <clear />
         <add key=""local"" value=""" + artifactsDir +  @""" />
-        <add key=""AspNetCoreCiDev"" value=""https://dotnet.myget.org/F/aspnetcore-ci-dev/api/v3/index.json"" />
-        <add key=""dotnet-core"" value=""https://dotnet.myget.org/F/dotnet-core/api/v3/index.json"" />
+        <add key=""AspNetCore"" value=""https://dotnet.myget.org/F/aspnetcore-ci-release/api/v3/index.json"" />
+        <add key=""cli-deps"" value=""https://dotnet.myget.org/F/cli-deps/api/v3/index.json"" />
         <add key=""NuGet"" value=""https://api.nuget.org/v3/index.json"" />
     </packageSources>
 </configuration>";

--- a/test/Shared/MsBuildProjectStrings.cs
+++ b/test/Shared/MsBuildProjectStrings.cs
@@ -158,16 +158,12 @@ namespace WebApplication1
 {
     public class Startup
     {
-        public Startup(IHostingEnvironment env)
+        public Startup(IConfiguration configuration)
         {
-            var builder = new ConfigurationBuilder()
-                .SetBasePath(env.ContentRootPath)
-                .AddJsonFile(""appsettings.json"", optional: true, reloadOnChange: true);
-                //.AddJsonFile($""appsettings.{env.EnvironmentName}.json"", optional: true);
-            Configuration = builder.Build();
+            Configuration = configuration;
         }
 
-        public IConfigurationRoot Configuration { get; }
+        public IConfiguration Configuration { get; }
 
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
@@ -177,7 +173,7 @@ namespace WebApplication1
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
+        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
         {
             app.UseStaticFiles();
             CS7_method(out var i);
@@ -246,16 +242,31 @@ namespace WebApplication1
 ";
         public const string ProgramFileName = "Program.cs";
         public const string ProgramFileText = @"using System;
-namespace Test
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace WebApplication1
 {
     public class Program
     {
         public static void Main(string[] args)
         {
-            Console.WriteLine(""Hello"");
+            BuildWebHost(args).Run();
         }
+
+        public static IWebHost BuildWebHost(string[] args) => WebHost
+            .CreateDefaultBuilder(args)
+            .UseStartup<Startup>()
+            .Build();
     }
-}";
+}
+";
 
 
         public const string LibraryProjectName = "Library1.csproj";


### PR DESCRIPTION
 - Change IConfigurationRoot -> IConfiguration in DbContextServices.
 - Fix test project setup to use new Startup and Program class content.

Address #464 


- Scaffolding now adds a new `DbContextFactory` for a new DbContext generated by scaffolding.

Address #467
cc @Eilon 
