### PR TITLE
[2.0.0-preview1] Re-add a reference to System.Reflection.TypeExtensions

### DIFF
--- a/src/Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore/Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore.csproj
+++ b/src/Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore/Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore.csproj
@@ -21,6 +21,7 @@
        -->
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="$(AspNetCoreVersion)" PrivateAssets="All" />
     <PackageReference Include="System.Diagnostics.Contracts" Version="$(CoreFxVersion)" />
+    <PackageReference Include="System.Reflection.TypeExtensions" Version="$(CoreFxVersion)" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net46'">


### PR DESCRIPTION
It was removed from Microsoft.EntityFrameworkCore.Design.