### PR TITLE
Mark CommandLineUtils.Sources as private dependency

### DIFF
--- a/src/Microsoft.VisualStudio.Web.CodeGeneration.Tools/Microsoft.VisualStudio.Web.CodeGeneration.Tools.csproj
+++ b/src/Microsoft.VisualStudio.Web.CodeGeneration.Tools/Microsoft.VisualStudio.Web.CodeGeneration.Tools.csproj
@@ -25,7 +25,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.VisualStudio.Web.CodeGeneration.Contracts\Microsoft.VisualStudio.Web.CodeGeneration.Contracts.csproj" />
     <PackageReference Include="Microsoft.Build.Runtime" Version="$(MicrosoftBuildVersion)" />
-    <PackageReference Include="Microsoft.Extensions.CommandLineUtils.Sources" Version="$(AspNetCoreVersion)" />
+    <PackageReference Include="Microsoft.Extensions.CommandLineUtils.Sources" Version="$(AspNetCoreVersion)" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="$(JsonNetVersion)" />
     <PackageReference Include="NuGet.Frameworks" Version="$(NuGetFrameworksVersion)" />


### PR DESCRIPTION
Fixes #474 

cc @Eilon @mlorbetske 