### PR TITLE
Fix tests for Release configuration.

### DIFF
--- a/test/E2E_Test/AreaScaffolderTests.cs
+++ b/test/E2E_Test/AreaScaffolderTests.cs
@@ -27,6 +27,8 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.E2E_Test
                 "aspnet-codegenerator",
                 "-p",
                 TestProjectPath,
+                "-c",
+                Configuration,
                 "area",
                 "Admin"
                 };

--- a/test/E2E_Test/E2ETestBase.cs
+++ b/test/E2E_Test/E2ETestBase.cs
@@ -14,6 +14,12 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.E2E_Test
 {
     public class E2ETestBase
     {
+        #if RELEASE
+        public const string Configuration = "Release";
+        #else
+        public const string Configuration = "Debug";
+        #endif
+
         public const string E2ESkipReason = "Disabling E2E test";
         public const string codegeneratorToolName = "aspnet-codegenerator";
 

--- a/test/E2E_Test/MvcControllerTest.cs
+++ b/test/E2E_Test/MvcControllerTest.cs
@@ -11,9 +11,9 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.E2E_Test
 {
     public class MvcControllerTest : E2ETestBase
     {
-        private static string[] EMPTY_CONTROLLER_ARGS = new string[] { codegeneratorToolName, "-p", ".", "controller", "--controllerName", "EmptyController" };
-        private static string[] EMPTY_CONTROLLER_WITH_RELATIVE_PATH = new string[] { codegeneratorToolName, "-p", ".", "controller", "--controllerName", "EmptyController", "--relativeFolderPath", "Controllers" };
-        private static string[] READ_WRITE_CONTROLLER = new string[] { codegeneratorToolName, "-p", ".", "controller", "--controllerName", "ActionsController", "--readWriteActions" };
+        private static string[] EMPTY_CONTROLLER_ARGS = new string[] { codegeneratorToolName, "-p", ".", "-c", Configuration, "controller", "--controllerName", "EmptyController" };
+        private static string[] EMPTY_CONTROLLER_WITH_RELATIVE_PATH = new string[] { codegeneratorToolName, "-p", ".", "-c", Configuration, "controller", "--controllerName", "EmptyController", "--relativeFolderPath", "Controllers" };
+        private static string[] READ_WRITE_CONTROLLER = new string[] { codegeneratorToolName, "-p", ".", "-c", Configuration, "controller",  "--controllerName", "ActionsController", "--readWriteActions" };
 
 
         public MvcControllerTest(ITestOutputHelper output)
@@ -61,6 +61,8 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.E2E_Test
                     "aspnet-codegenerator",
                     "-p",
                     TestProjectPath,
+                    "-c",
+                    Configuration,
                     "controller",
                     "--controllerName",
                     "CarsController",
@@ -89,6 +91,8 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.E2E_Test
                     codegeneratorToolName,
                     "-p",
                     TestProjectPath,
+                    "-c",
+                    Configuration,
                     "controller",
                     "--controllerName",
                     "CarsWithViewController",
@@ -129,6 +133,8 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.E2E_Test
                     codegeneratorToolName,
                     "-p",
                     TestProjectPath,
+                    "-c",
+                    Configuration,
                     "controller",
                     "--controllerName",
                     "ProductsController",
@@ -166,6 +172,8 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.E2E_Test
                     codegeneratorToolName,
                     "-p",
                     TestProjectPath,
+                    "-c",
+                    Configuration,
                     "controller",
                     "--controllerName",
                     "ActionsController",

--- a/test/E2E_Test/SimulationModeTests.cs
+++ b/test/E2E_Test/SimulationModeTests.cs
@@ -28,6 +28,8 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.E2E_Test
                     "aspnet-codegenerator",
                     "-p",
                     TestProjectPath,
+                    "-c",
+                    Configuration,
                     "--simulation-mode",
                     "controller",
                     "--controllerName",

--- a/test/E2E_Test/ViewGeneratorTests.cs
+++ b/test/E2E_Test/ViewGeneratorTests.cs
@@ -11,9 +11,9 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.E2E_Test
 {
     public class ViewGeneratorTests : E2ETestBase
     {
-        private static string[] EMPTY_VIEW_ARGS = new string[] { codegeneratorToolName, "-p", ".", "view", "EmptyView", "Empty" };
-        private static string[] VIEW_WITH_DATACONTEXT = new string[] { codegeneratorToolName, "-p", ".", "view", "CarCreate", "Create", "--model", "Library1.Models.Car", "--dataContext", "WebApplication1.Models.CarContext", "--referenceScriptLibraries" };
-        private static string[] VIEW_NO_DATACONTEXT = new string[] { codegeneratorToolName, "-p", ".", "view", "CarDetails", "Details", "--model", "Library1.Models.Car", "--partialView" };
+        private static string[] EMPTY_VIEW_ARGS = new string[] { codegeneratorToolName, "-p", ".", "-c", Configuration, "view", "EmptyView", "Empty" };
+        private static string[] VIEW_WITH_DATACONTEXT = new string[] { codegeneratorToolName, "-p", ".", "-c", Configuration, "view", "CarCreate", "Create", "--model", "Library1.Models.Car", "--dataContext", "WebApplication1.Models.CarContext", "--referenceScriptLibraries" };
+        private static string[] VIEW_NO_DATACONTEXT = new string[] { codegeneratorToolName, "-p", ".", "-c", Configuration, "view", "CarDetails", "Details", "--model", "Library1.Models.Car", "--partialView" };
 
         public ViewGeneratorTests(ITestOutputHelper output) : base(output)
         {

--- a/test/Shared/MsBuildProjectSetupHelper.cs
+++ b/test/Shared/MsBuildProjectSetupHelper.cs
@@ -10,6 +10,12 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration
 {
     internal class MsBuildProjectSetupHelper
     {
+        #if RELEASE
+        public const string Configuration = "Release";
+        #else
+        public const string Configuration = "Debug";
+        #endif
+
         public void SetupProjects(TemporaryFileProvider fileProvider, ITestOutputHelper output, bool fullFramework = false)
         {
             string artifactsDir = null;
@@ -56,7 +62,7 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration
                 throw new InvalidOperationException($"Restore failed with exit code: {result.ExitCode}");
             }
 
-            result = Command.CreateDotNet("build", new string[] {})
+            result = Command.CreateDotNet("build", new string[] {"-c", Configuration})
                 .WithEnvironmentVariable("DOTNET_SKIP_FIRST_TIME_EXPERIENCE", "true")
                 .InWorkingDirectory(path)
                 .OnErrorLine(l => output.WriteLine(l))


### PR DESCRIPTION
Fixes #479 

Scaffolding accepts the configuration parameter and assumes it to be debug by default. 
On CI's since `env.Configuration` is set to `Release`, it causes the build to output stuff into to `bin/release/...` folders. 

A recent change in E2E test project setup caused the builds to be done in the set configuration and scaffolding to be invoked in 'Debug' configuration with `--no-build` flag. 