### PR TITLE
Unbreak failing tests

### DIFF
--- a/src/Microsoft.VisualStudio.Web.CodeGeneration.Templating/RazorTemplating.cs
+++ b/src/Microsoft.VisualStudio.Web.CodeGeneration.Templating/RazorTemplating.cs
@@ -35,7 +35,15 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.Templating
             var razorProject = RazorProject.Create(Directory.GetCurrentDirectory());
             var razorTemplateEngine = new RazorTemplateEngine(razorEngine, razorProject);
 
-            var razorDocument = RazorCodeDocument.Create(RazorSourceDocument.Create(content, string.Empty));
+            var imports = new RazorSourceDocument[]
+            {
+                RazorSourceDocument.Create(@"
+@using System
+@using System.Threading.Tasks
+", fileName: null),
+            };
+
+            var razorDocument = RazorCodeDocument.Create(RazorSourceDocument.Create(content, string.Empty), imports);
             var generatorResults = razorTemplateEngine.GenerateCode(razorDocument);
 
             if (generatorResults.Diagnostics.Any())

--- a/src/Shared/Cli.Utils/Command.cs
+++ b/src/Shared/Cli.Utils/Command.cs
@@ -33,7 +33,9 @@ namespace Microsoft.Extensions.Internal
             {
                 FileName = commandName,
                 Arguments = ArgumentEscaper.EscapeAndConcatenateArgArrayForProcessStart(args),
-                UseShellExecute = false, 
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
             };
 
             _process = new Process
@@ -69,6 +71,8 @@ namespace Microsoft.Extensions.Internal
             _process.ErrorDataReceived += OnErrorReceived;
 
             _process.Start();
+            _process.BeginOutputReadLine();
+            _process.BeginErrorReadLine();
 
             _process.WaitForExit();
 
@@ -84,12 +88,18 @@ namespace Microsoft.Extensions.Internal
 
         private void OnErrorReceived(object sender, DataReceivedEventArgs e)
         {
-            _stdErrorHandler?.Invoke(e.Data);
+            if (e.Data != null)
+            {
+                _stdErrorHandler?.Invoke(e.Data);
+            }
         }
 
         private void OnOutputReceived(object sender, DataReceivedEventArgs e)
         {
-            _stdOutHandler?.Invoke(e.Data);
+            if (e.Data != null)
+            {
+                _stdOutHandler?.Invoke(e.Data);
+            }
         }
 
         public Command OnOutputLine(Action<string> handler)


### PR DESCRIPTION
The razor engine had a feature that had built in default `using`s for
System and `System.Threading.Tasks`. We're removing that API. You can
either define your own global `using`s and other directives like I did
in this workaround, or just add the necessary namespaces where they are
used.

I also fixed the console output for tests. I'm not sure if was
intentionally not working, but this makes the tests much easier to
diagnose.