### PR TITLE
Pin packageversions during test project creation.

### DIFF
--- a/test/Shared/MsBuildProjectStrings.cs
+++ b/test/Shared/MsBuildProjectStrings.cs
@@ -12,8 +12,7 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration
     <packageSources>
         <clear />
         <add key=""local"" value=""" + artifactsDir +  @""" />
-        <add key=""AspNetCoreCiRelease"" value=""https://dotnet.myget.org/F/aspnetcore-ci-dev/api/v3/index.json"" />
-        <add key=""cli-deps"" value=""https://dotnet.myget.org/F/cli-deps/api/v3/index.json"" />
+        <add key=""AspNetCoreCiDev"" value=""https://dotnet.myget.org/F/aspnetcore-ci-dev/api/v3/index.json"" />
         <add key=""NuGet"" value=""https://api.nuget.org/v3/index.json"" />
     </packageSources>
 </configuration>";
@@ -35,25 +34,24 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration
 
   <ItemGroup>
     <PackageReference Include=""Microsoft.ApplicationInsights.AspNetCore"" Version=""2.0.0-beta1"" />
-    <PackageReference Include=""Microsoft.AspNetCore"" Version=""2.0.0-preview3-*"" />
-    <PackageReference Include=""Microsoft.AspNetCore.Mvc"" Version=""2.0.0-preview3-*"" />
-    <PackageReference Include=""Microsoft.AspNetCore.StaticFiles"" Version=""2.0.0-preview3-*"" />
-    <PackageReference Include=""Microsoft.Extensions.Logging.Debug"" Version=""2.0.0-preview3-*"" />
-    <PackageReference Include=""Microsoft.VisualStudio.Web.BrowserLink"" Version=""2.0.0-preview3-*"" />
+    <PackageReference Include=""Microsoft.AspNetCore"" Version=""{0}"" />
+    <PackageReference Include=""Microsoft.AspNetCore.Mvc"" Version=""{0}"" />
+    <PackageReference Include=""Microsoft.AspNetCore.StaticFiles"" Version=""{0}"" />
+    <PackageReference Include=""Microsoft.Extensions.Logging.Debug"" Version=""{0}"" />
+    <PackageReference Include=""Microsoft.VisualStudio.Web.BrowserLink"" Version=""{0}"" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include=""Microsoft.AspNetCore.Authentication.Cookies"" Version=""2.0.0-preview3-*"" />
-    <PackageReference Include=""Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore"" Version=""2.0.0-preview3-*"" />
-    <PackageReference Include=""Microsoft.AspNetCore.Identity.EntityFrameworkCore"" Version=""2.0.0-preview3-*"" />
-    <PackageReference Include=""Microsoft.EntityFrameworkCore.Design"" Version=""2.0.0-preview3-*"" />
-    <PackageReference Include=""Microsoft.EntityFrameworkCore.SqlServer"" Version=""2.0.0-preview3-*"" />
-    <PackageReference Include=""Microsoft.EntityFrameworkCore.SqlServer.Design"" Version=""2.0.0-preview3-*"" />
-    <PackageReference Include=""Microsoft.Extensions.Configuration.UserSecrets"" Version=""2.0.0-preview3-*"" />
-    <PackageReference Include=""Microsoft.VisualStudio.Web.CodeGeneration.Design"" Version=""2.0.0-preview3-*"" />
-    <PackageReference Include=""Microsoft.VisualStudio.Web.CodeGeneration.Tools"" Version=""2.0.0-preview3-*"" />
+    <PackageReference Include=""Microsoft.AspNetCore.Authentication.Cookies"" Version=""{0}"" />
+    <PackageReference Include=""Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore"" Version=""{0}"" />
+    <PackageReference Include=""Microsoft.AspNetCore.Identity.EntityFrameworkCore"" Version=""{0}"" />
+    <PackageReference Include=""Microsoft.EntityFrameworkCore.Design"" Version=""{0}"" />
+    <PackageReference Include=""Microsoft.EntityFrameworkCore.SqlServer"" Version=""{0}"" />
+    <PackageReference Include=""Microsoft.Extensions.Configuration.UserSecrets"" Version=""{0}"" />
+    <PackageReference Include=""Microsoft.VisualStudio.Web.CodeGeneration.Design"" Version=""{1}"" />
+    <PackageReference Include=""Microsoft.VisualStudio.Web.CodeGeneration.Tools"" Version=""{1}"" />
   </ItemGroup>
   <ItemGroup>
-    <DotNetCliToolReference Include=""Microsoft.VisualStudio.Web.CodeGeneration.Tools"" Version=""2.0.0-preview3-*"" />
+    <DotNetCliToolReference Include=""Microsoft.VisualStudio.Web.CodeGeneration.Tools"" Version=""{1}"" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include=""..\Library1\Library1.csproj"" />
@@ -79,20 +77,20 @@ public const string RootProjectTxtWithoutEF = @"
 
   <ItemGroup>
     <PackageReference Include=""Microsoft.ApplicationInsights.AspNetCore"" Version=""2.0.0-beta1"" />
-    <PackageReference Include=""Microsoft.AspNetCore"" Version=""2.0.0-preview3-*"" />
-    <PackageReference Include=""Microsoft.AspNetCore.Mvc"" Version=""2.0.0-preview3-*"" />
-    <PackageReference Include=""Microsoft.AspNetCore.StaticFiles"" Version=""2.0.0-preview3-*"" />
-    <PackageReference Include=""Microsoft.Extensions.Logging.Debug"" Version=""2.0.0-preview3-*"" />
-    <PackageReference Include=""Microsoft.VisualStudio.Web.BrowserLink"" Version=""2.0.0-preview3-*"" />
+    <PackageReference Include=""Microsoft.AspNetCore"" Version=""{0}"" />
+    <PackageReference Include=""Microsoft.AspNetCore.Mvc"" Version=""{0}"" />
+    <PackageReference Include=""Microsoft.AspNetCore.StaticFiles"" Version=""{0}"" />
+    <PackageReference Include=""Microsoft.Extensions.Logging.Debug"" Version=""{0}"" />
+    <PackageReference Include=""Microsoft.VisualStudio.Web.BrowserLink"" Version=""{0}"" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include=""Microsoft.AspNetCore.Authentication.Cookies"" Version=""2.0.0-preview3-*"" />
-    <PackageReference Include=""Microsoft.Extensions.Configuration.UserSecrets"" Version=""2.0.0-preview3-*"" />
-    <PackageReference Include=""Microsoft.VisualStudio.Web.CodeGeneration.Design"" Version=""2.0.0-preview3-*"" />
-    <PackageReference Include=""Microsoft.VisualStudio.Web.CodeGeneration.Tools"" Version=""2.0.0-preview3-*"" />
+    <PackageReference Include=""Microsoft.AspNetCore.Authentication.Cookies"" Version=""{0}"" />
+    <PackageReference Include=""Microsoft.Extensions.Configuration.UserSecrets"" Version=""{0}"" />
+    <PackageReference Include=""Microsoft.VisualStudio.Web.CodeGeneration.Design"" Version=""{1}"" />
+    <PackageReference Include=""Microsoft.VisualStudio.Web.CodeGeneration.Tools"" Version=""{1}"" />
   </ItemGroup>
   <ItemGroup>
-    <DotNetCliToolReference Include=""Microsoft.VisualStudio.Web.CodeGeneration.Tools"" Version=""2.0.0-preview3-*"" />
+    <DotNetCliToolReference Include=""Microsoft.VisualStudio.Web.CodeGeneration.Tools"" Version=""{1}"" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include=""..\Library1\Library1.csproj"" />
@@ -120,19 +118,19 @@ public const string RootProjectTxtWithoutEF = @"
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include=""Microsoft.AspNetCore.Diagnostics"" Version=""2.0.0-preview3-*"" />
-    <PackageReference Include=""Microsoft.AspNetCore.Mvc"" Version=""2.0.0-preview3-*"" />
-    <PackageReference Include=""Microsoft.AspNetCore.Server.IISIntegration"" Version=""2.0.0-preview3-*"" />
-    <PackageReference Include=""Microsoft.AspNetCore.Server.Kestrel"" Version=""2.0.0-preview3-*"" />
-    <PackageReference Include=""Microsoft.AspNetCore.StaticFiles"" Version=""2.0.0-preview3-*"" />
-    <PackageReference Include=""Microsoft.Extensions.Configuration.EnvironmentVariables"" Version=""2.0.0-preview3-*"" />
-    <PackageReference Include=""Microsoft.Extensions.Configuration.Json"" Version=""2.0.0-preview3-*"" />
-    <PackageReference Include=""Microsoft.Extensions.Logging"" Version=""2.0.0-preview3-*"" />
-    <PackageReference Include=""Microsoft.Extensions.Logging.Console"" Version=""2.0.0-preview3-*"" />
-    <PackageReference Include=""Microsoft.Extensions.Logging.Debug"" Version=""2.0.0-preview3-*"" />
-    <PackageReference Include=""Microsoft.Extensions.Options.ConfigurationExtensions"" Version=""2.0.0-preview3-*"" />
-    <PackageReference Include=""Microsoft.VisualStudio.Web.CodeGeneration.Design"" Version=""2.0.0-preview3-*"" />
-    <DotNetCliToolReference Include=""Microsoft.VisualStudio.Web.CodeGeneration.Tools"" Version=""2.0.0-preview3-*"" />
+    <PackageReference Include=""Microsoft.AspNetCore.Diagnostics"" Version=""{0}"" />
+    <PackageReference Include=""Microsoft.AspNetCore.Mvc"" Version=""{0}"" />
+    <PackageReference Include=""Microsoft.AspNetCore.Server.IISIntegration"" Version=""{0}"" />
+    <PackageReference Include=""Microsoft.AspNetCore.Server.Kestrel"" Version=""{0}"" />
+    <PackageReference Include=""Microsoft.AspNetCore.StaticFiles"" Version=""{0}"" />
+    <PackageReference Include=""Microsoft.Extensions.Configuration.EnvironmentVariables"" Version=""{0}"" />
+    <PackageReference Include=""Microsoft.Extensions.Configuration.Json"" Version=""{0}"" />
+    <PackageReference Include=""Microsoft.Extensions.Logging"" Version=""{0}"" />
+    <PackageReference Include=""Microsoft.Extensions.Logging.Console"" Version=""{0}"" />
+    <PackageReference Include=""Microsoft.Extensions.Logging.Debug"" Version=""{0}"" />
+    <PackageReference Include=""Microsoft.Extensions.Options.ConfigurationExtensions"" Version=""{0}"" />
+    <PackageReference Include=""Microsoft.VisualStudio.Web.CodeGeneration.Design"" Version=""{1}"" />
+    <DotNetCliToolReference Include=""Microsoft.VisualStudio.Web.CodeGeneration.Tools"" Version=""{1}"" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include=""..\Library1\Library1.csproj"" />


### PR DESCRIPTION
CodeGenerationPackage version is based on the package version created in
this build.
AspNetCorePackage version is based on the version of
'Microsoft.Extensions.FileProviders.Physical' used to build the test
projects.

cc @mlorbetske 