### PR TITLE
Pb/fix razor templating

### DIFF
--- a/src/Microsoft.VisualStudio.Web.CodeGeneration.Templating/Microsoft.VisualStudio.Web.CodeGeneration.Templating.csproj
+++ b/src/Microsoft.VisualStudio.Web.CodeGeneration.Templating/Microsoft.VisualStudio.Web.CodeGeneration.Templating.csproj
@@ -15,6 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Razor.Language" Version="$(AspNetCoreVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.Extensions" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(CodeAnalysisVersion)" />
   </ItemGroup>
 

--- a/src/Microsoft.VisualStudio.Web.CodeGeneration.Templating/Microsoft.VisualStudio.Web.CodeGeneration.Templating.csproj
+++ b/src/Microsoft.VisualStudio.Web.CodeGeneration.Templating/Microsoft.VisualStudio.Web.CodeGeneration.Templating.csproj
@@ -14,7 +14,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Razor.Language" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.Extensions" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(CodeAnalysisVersion)" />
   </ItemGroup>

--- a/src/Microsoft.VisualStudio.Web.CodeGeneration.Templating/RazorTemplateBase.cs
+++ b/src/Microsoft.VisualStudio.Web.CodeGeneration.Templating/RazorTemplateBase.cs
@@ -62,5 +62,15 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.Templating
                 writer.Write(content.ToString());
             }
         }
+
+        public void BeginContext(int position, int length, bool x)
+        {
+            // Do Nothing.
+        }
+
+        public void EndContext()
+        {
+            // Do Nothing.
+        }
     }
 }

--- a/src/Microsoft.VisualStudio.Web.CodeGeneration.Templating/RazorTemplating.cs
+++ b/src/Microsoft.VisualStudio.Web.CodeGeneration.Templating/RazorTemplating.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Mvc.Razor.Extensions;
 using Microsoft.VisualStudio.Web.CodeGeneration.Templating.Compilation;
 
 namespace Microsoft.VisualStudio.Web.CodeGeneration.Templating
@@ -28,7 +29,10 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.Templating
         public async Task<TemplateResult> RunTemplateAsync(string content,
             dynamic templateModel)
         {
-            var razorEngine = RazorEngine.Create();
+            var razorEngine = RazorEngine.Create((builder) =>
+            {
+                 RazorExtensions.Register(builder);
+            });
 
             // Don't care about the RazorProject as we already have the content of the .cshtml file 
             // and don't need to deal with imports.
@@ -40,10 +44,10 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.Templating
                 RazorSourceDocument.Create(@"
 @using System
 @using System.Threading.Tasks
-", fileName: null),
+", fileName: null)
             };
 
-            var razorDocument = RazorCodeDocument.Create(RazorSourceDocument.Create(content, string.Empty), imports);
+            var razorDocument = RazorCodeDocument.Create(RazorSourceDocument.Create(content, "Template"), imports);
             var generatorResults = razorTemplateEngine.GenerateCode(razorDocument);
 
             if (generatorResults.Diagnostics.Any())
@@ -55,7 +59,6 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.Templating
                     ProcessingException = new TemplateProcessingException(messages, generatorResults.GeneratedCode)
                 };
             }
-
             var templateResult = _compilationService.Compile(generatorResults.GeneratedCode);
             if (templateResult.Messages.Any())
             {

--- a/test/Shared/MsBuildProjectSetupHelper.cs
+++ b/test/Shared/MsBuildProjectSetupHelper.cs
@@ -73,7 +73,6 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration
 
         private void RestoreAndBuild(string path, ITestOutputHelper output)
         {
-
             var result = Command.CreateDotNet("restore",
                 new string[] {})
                 .WithEnvironmentVariable("DOTNET_SKIP_FIRST_TIME_EXPERIENCE", "true")
@@ -84,7 +83,7 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration
 
             if (result.ExitCode !=0)
             {
-                throw new InvalidOperationException($"Restore failed with exit code: {result.ExitCode}");
+                throw new InvalidOperationException($"Restore failed with exit code: {result.ExitCode} :: Dotnet path: {DotNetMuxer.MuxerPathOrDefault()}");
             }
 
             result = Command.CreateDotNet("build", new string[] {"-c", Configuration})

--- a/test/Shared/MsBuildProjectStrings.cs
+++ b/test/Shared/MsBuildProjectStrings.cs
@@ -7,6 +7,7 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration
     {
         public static string GetNugetConfigTxt(string artifactsDir)
         {
+            // TODO: Remove dotnet-core feed.
             return @"
 <configuration>
     <packageSources>
@@ -14,6 +15,7 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration
         <add key=""local"" value=""" + artifactsDir +  @""" />
         <add key=""AspNetCoreCiDev"" value=""https://dotnet.myget.org/F/aspnetcore-ci-dev/api/v3/index.json"" />
         <add key=""NuGet"" value=""https://api.nuget.org/v3/index.json"" />
+        <add key=""dotnet-core"" value=""https://dotnet.myget.org/F/dotnet-core/v3/index.json"" />
     </packageSources>
 </configuration>";
         }

--- a/test/Shared/MsBuildProjectStrings.cs
+++ b/test/Shared/MsBuildProjectStrings.cs
@@ -7,7 +7,6 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration
     {
         public static string GetNugetConfigTxt(string artifactsDir)
         {
-            // TODO: Remove dotnet-core feed.
             return @"
 <configuration>
     <packageSources>
@@ -15,7 +14,6 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration
         <add key=""local"" value=""" + artifactsDir +  @""" />
         <add key=""AspNetCoreCiDev"" value=""https://dotnet.myget.org/F/aspnetcore-ci-dev/api/v3/index.json"" />
         <add key=""NuGet"" value=""https://api.nuget.org/v3/index.json"" />
-        <add key=""dotnet-core"" value=""https://dotnet.myget.org/F/dotnet-core/v3/index.json"" />
     </packageSources>
 </configuration>";
         }
@@ -28,6 +26,7 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <RootNamespace>Microsoft.TestProject</RootNamespace>
     <ProjectName>TestProject</ProjectName>
+    <NoWarn>NU1605</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -71,6 +70,7 @@ public const string RootProjectTxtWithoutEF = @"
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <RootNamespace>Microsoft.TestProject</RootNamespace>
     <ProjectName>TestProject</ProjectName>
+    <NoWarn>NU1605</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -113,6 +113,7 @@ public const string RootProjectTxtWithoutEF = @"
     <OutputPath>bin\$(Configuration)</OutputPath>
     <RuntimeIdentifier>win7-x64</RuntimeIdentifier>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <NoWarn>NU1605</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
React to changes in Razor template engine. 

Note: Had to add `<NoWarn>NU1605</NoWarn>` to the generated test projects. 
For some weird reason, the test project ends up with an implicit reference of `Microsoft.NetCore.App` with a lower version than what the `Microsoft.VisualStudio.Web.CodeGeneration.Design` gets. 

Filing an issue to remove the `NoWarn`


cc @mlorbetske @ryanbrandenburg 