### PR TITLE
Update Roslyn workspaces to 2.3.0-beta3

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -11,7 +11,7 @@
   </PropertyGroup>
   <!-- Partner Versions-->
   <PropertyGroup>
-    <CodeAnalysisVersion>2.3.0-beta3-61731-06</CodeAnalysisVersion>
+    <CodeAnalysisVersion>2.3.0-beta3-61814-09</CodeAnalysisVersion>
     <JsonNetVersion>10.0.1</JsonNetVersion>
     <MicrosoftBuildVersion>15.3.0-preview-000388-01</MicrosoftBuildVersion>
     <NuGetFrameworksVersion>4.0.0-*</NuGetFrameworksVersion>

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -11,7 +11,7 @@
   </PropertyGroup>
   <!-- Partner Versions-->
   <PropertyGroup>
-    <CodeAnalysisVersion>2.3.0-beta1</CodeAnalysisVersion>
+    <CodeAnalysisVersion>2.3.0-beta3-61731-06</CodeAnalysisVersion>
     <JsonNetVersion>10.0.1</JsonNetVersion>
     <MicrosoftBuildVersion>15.3.0-preview-000388-01</MicrosoftBuildVersion>
     <NuGetFrameworksVersion>4.0.0-*</NuGetFrameworksVersion>

--- a/src/Microsoft.VisualStudio.Web.CodeGeneration.Core/Microsoft.VisualStudio.Web.CodeGeneration.Core.csproj
+++ b/src/Microsoft.VisualStudio.Web.CodeGeneration.Core/Microsoft.VisualStudio.Web.CodeGeneration.Core.csproj
@@ -6,7 +6,6 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <PackageTags>aspnetcore;codegenerator;scaffolding;visualstudioweb</PackageTags>
-    <AssetTargetFallback>$(AssetTargetFallback);portable-net45+win8</AssetTargetFallback>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.VisualStudio.Web.CodeGeneration.Templating/Microsoft.VisualStudio.Web.CodeGeneration.Templating.csproj
+++ b/src/Microsoft.VisualStudio.Web.CodeGeneration.Templating/Microsoft.VisualStudio.Web.CodeGeneration.Templating.csproj
@@ -6,7 +6,6 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <PackageTags>aspnetcore;codegenerator;scaffolding;visualstudioweb</PackageTags>
-    <AssetTargetFallback>$(AssetTargetFallback);portable-net45+win8</AssetTargetFallback>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.VisualStudio.Web.CodeGeneration/Microsoft.VisualStudio.Web.CodeGeneration.csproj
+++ b/src/Microsoft.VisualStudio.Web.CodeGeneration/Microsoft.VisualStudio.Web.CodeGeneration.csproj
@@ -6,7 +6,6 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <PackageTags>aspnetcore;codegenerator;scaffolding;visualstudioweb</PackageTags>
-    <AssetTargetFallback>$(AssetTargetFallback);portable-net45+win8</AssetTargetFallback>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.VisualStudio.Web.CodeGenerators.Mvc/Microsoft.VisualStudio.Web.CodeGenerators.Mvc.csproj
+++ b/src/Microsoft.VisualStudio.Web.CodeGenerators.Mvc/Microsoft.VisualStudio.Web.CodeGenerators.Mvc.csproj
@@ -6,7 +6,6 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <PackageTags>aspnetcore;aspnetcoremvc;codegenerator;scaffolding;visualstudioweb</PackageTags>
-    <AssetTargetFallback>$(AssetTargetFallback);portable-net45+win8</AssetTargetFallback>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Shared/MsBuildProjectStrings.cs
+++ b/test/Shared/MsBuildProjectStrings.cs
@@ -29,10 +29,6 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration
     <ProjectName>TestProject</ProjectName>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <AssetTargetFallback>$(AssetTargetFallback);portable-net45+win8+wp8+wpa81</AssetTargetFallback>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include=""Microsoft.ApplicationInsights.AspNetCore"" Version=""2.0.0-beta1"" />
     <PackageReference Include=""Microsoft.AspNetCore"" Version=""2.0.0-preview2-*"" />
@@ -71,10 +67,6 @@ public const string RootProjectTxtWithoutEF = @"
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <RootNamespace>Microsoft.TestProject</RootNamespace>
     <ProjectName>TestProject</ProjectName>
-  </PropertyGroup>
-
-  <PropertyGroup>
-    <AssetTargetFallback>$(AssetTargetFallback);portable-net45+win8+wp8+wpa81</AssetTargetFallback>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/TestApps/ModelTypesLocatorTestClassLibrary/ModelTypesLocatorTestClassLibrary.csproj
+++ b/test/TestApps/ModelTypesLocatorTestClassLibrary/ModelTypesLocatorTestClassLibrary.csproj
@@ -2,7 +2,6 @@
   <Import Project="..\..\..\build\common.props" />
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
-    <AssetTargetFallback>$(AssetTargetFallback);portable-net45+win8</AssetTargetFallback>
   </PropertyGroup>
 
 


### PR DESCRIPTION
Removes the need for having AssetTargetFallback

cc @Eilon @mlorbetske 