### PR TITLE
Show Help based on parameterDefinition files.

### DIFF
--- a/src/Microsoft.VisualStudio.Web.CodeGeneration.Tools/ParamDefinition.cs
+++ b/src/Microsoft.VisualStudio.Web.CodeGeneration.Tools/ParamDefinition.cs
@@ -1,0 +1,21 @@
+namespace Microsoft.VisualStudio.Web.CodeGeneration.Tools
+{
+    public class ParamDefinition
+    {
+        public string Alias { get; set; }
+        public string Description { get; set; }
+        public Parameter[] Arguments { get;set; }
+        public OptionParameter[] Options { get; set; }
+    }
+
+    public class Parameter
+    {
+        public string Name { get; set; }
+        public string Description { get; set; }
+    }
+
+    public class OptionParameter : Parameter
+    {
+        public string ShortName { get; set; }
+    }
+}

--- a/src/Microsoft.VisualStudio.Web.CodeGeneration.Tools/Resources.Designer.cs
+++ b/src/Microsoft.VisualStudio.Web.CodeGeneration.Tools/Resources.Designer.cs
@@ -78,7 +78,15 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.Tools {
                 return ResourceManager.GetString("AppDesc", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        /// Looks up a localized string similar to Available generators:.
+        /// </summary>
+        internal static string AvailableGeneratorsHeader {
+            get {
+                return ResourceManager.GetString("AvailableGeneratorsHeader", resourceCulture);
+            }
+        }
         /// <summary>
         ///   Looks up a localized string similar to Available frameworks in project: {0}.
         /// </summary>
@@ -123,6 +131,33 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.Tools {
                 return ResourceManager.GetString("ConnectToServerError", resourceCulture);
             }
         }
+
+        /// <summary>
+        /// Looks up a localized string similar to Name of the generator. Check available generators below..
+        /// </summary>
+        internal static string GeneratorArgumentDesc {
+            get {
+                return ResourceManager.GetString("GeneratorArgumentDesc", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        /// Looks up a localized string similar to Generator Arguments:.
+        /// </summary>
+        internal static string GeneratorArgsHeader {
+            get {
+                return ResourceManager.GetString("GeneratorArgsHeader", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        /// Looks up a localized string similar to Generator Options:.
+        /// </summary>
+        internal static string GeneratorOptionsHeader {
+            get {
+                return ResourceManager.GetString("GeneratorOptionsHeader", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to &apos;{0}&apos; is not a Valid MSBuild project file..
@@ -133,6 +168,14 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.Tools {
             }
         }
         
+        /// <summary>
+        /// Looks up a localized string similar to No code generator found with the name &apos;{0}&apos;.
+        /// </summary>
+        internal static string NoCodeGeneratorFound {
+            get {
+                return ResourceManager.GetString("NoCodeGeneratorFound", resourceCulture);
+            }
+        }
         /// <summary>
         ///   Looks up a localized string similar to Could not find a compatible framework to execute..
         /// </summary>
@@ -160,6 +203,14 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.Tools {
             }
         }
         
+        /// <summary>
+        /// Looks up a localized string similar to Selected Code Generator: {0}.
+        /// </summary>
+        internal static string SelectedCodeGeneratorStr {
+            get {
+                return ResourceManager.GetString("SelectedCodeGeneratorStr", resourceCulture);
+            }
+        }
         /// <summary>
         ///   Looks up a localized string similar to Specifies whether to persist any file changes..
         /// </summary>

--- a/src/Microsoft.VisualStudio.Web.CodeGeneration.Tools/Resources.resx
+++ b/src/Microsoft.VisualStudio.Web.CodeGeneration.Tools/Resources.resx
@@ -123,6 +123,9 @@
   <data name="AppDesc" xml:space="preserve">
     <value>Code generation for Asp.net Core</value>
   </data>
+  <data name="AvailableGeneratorsHeader" xml:space="preserve">
+    <value>Available generators:</value>
+  </data>
   <data name="AvailableFrameworks" xml:space="preserve">
     <value>Available frameworks in project: {0}</value>
   </data>
@@ -138,8 +141,20 @@
   <data name="ConnectToServerError" xml:space="preserve">
     <value>Could not connect to port {0}.</value>
   </data>
+  <data name="GeneratorArgumentDesc" xml:space="preserve">
+    <value>Name of the generator. Check available generators below.</value>
+  </data>
+  <data name="GeneratorArgsHeader" xml:space="preserve">
+    <value>Generator Arguments:</value>
+  </data>
+  <data name="GeneratorOptionsHeader" xml:space="preserve">
+    <value>Generator Options:</value>
+  </data>
   <data name="InvalidMsBuildProjectFile" xml:space="preserve">
     <value>'{0}' is not a Valid MSBuild project file.</value>
+  </data>
+  <data name="NoCodeGeneratorFound" xml:space="preserve">
+    <value>No code generator found with the name '{0}'.</value>
   </data>
   <data name="NoCompatibleFrameworks" xml:space="preserve">
     <value>Could not find a compatible framework to execute.</value>
@@ -149,6 +164,9 @@
   </data>
   <data name="ProjectPathOptionDesc" xml:space="preserve">
     <value>Path to .csproj file in the project.</value>
+  </data>
+  <data name="SelectedCodeGeneratorStr" xml:space="preserve">
+    <value>Selected Code Generator: {0}</value>
   </data>
   <data name="SimulationModeOptionDesc" xml:space="preserve">
     <value>Specifies whether to persist any file changes.</value>

--- a/src/Microsoft.VisualStudio.Web.CodeGeneration.Tools/ScaffoldingApp.cs
+++ b/src/Microsoft.VisualStudio.Web.CodeGeneration.Tools/ScaffoldingApp.cs
@@ -1,0 +1,176 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using Microsoft.Extensions.CommandLineUtils;
+using Microsoft.VisualStudio.Web.CodeGeneration.Contracts.ProjectModel;
+using Newtonsoft.Json;
+
+namespace Microsoft.VisualStudio.Web.CodeGeneration.Tools
+{
+    internal class ScaffoldingApp: CommandLineApplication
+    {
+        private const string APPNAME = "aspnet-codegenerator";
+        private static readonly string paramDefinitionFilePath = Path.Combine("Generators", "ParameterDefinitions");
+        public ScaffoldingApp(bool throwOnUnexpectedArg)
+            : base(throwOnUnexpectedArg)
+        {
+            Name = APPNAME;
+            Description = Resources.AppDesc;
+            GeneratorArgument = this.Argument("generator", Resources.GeneratorArgumentDesc);
+            ProjectPath = this.Option("-p|--project", Resources.ProjectPathOptionDesc, CommandOptionType.SingleValue);
+            PackagesPath = this.Option("-n|--nuget-package-dir", "", CommandOptionType.SingleValue);
+            AppConfiguration =this.Option("-c|--configuration", Resources.ConfigurationOptionDesc, CommandOptionType.SingleValue);
+            Framework = this.Option("-tfm|--target-framework", Resources.TargetFrameworkOptionDesc, CommandOptionType.SingleValue);
+            BuildBasePath = this.Option("-b|--build-base-path", "", CommandOptionType.SingleValue);
+            NoBuild = this.Option("--no-build", "", CommandOptionType.NoValue);
+        }
+
+        public IProjectContext ProjectContext { get; set; }
+
+        public CommandOption ProjectPath { get; }
+        public CommandOption PackagesPath { get; }
+        public CommandOption AppConfiguration { get; }
+        public CommandOption Framework { get; }
+        public CommandOption BuildBasePath { get; }
+        public CommandOption NoBuild { get; }
+
+        public CommandArgument GeneratorArgument { get; }
+
+
+        public override string GetHelpText(string commandName=null)
+        {
+            string helpText = base.GetHelpText(commandName);
+            StringBuilder sb = new StringBuilder();
+
+            // Search for NuGetPackages with CodeGenerationPackages.
+            if (ProjectContext != null)
+            {
+                var nuGetPackages = ProjectContext.PackageDependencies.Select(d => d.Path);
+                var paramDefinitionsCache = BuildParamDefinitionCache(nuGetPackages);
+
+                if (!string.IsNullOrEmpty(GeneratorArgument.Value))
+                {
+                    sb.AppendLine();
+                    sb.AppendLine(string.Format(Resources.SelectedCodeGeneratorStr, GeneratorArgument.Value));
+                    ParamDefinition generatorParamDef = null;
+                    if (paramDefinitionsCache.TryGetValue(GeneratorArgument.Value, out generatorParamDef))
+                    {
+                        sb.AppendLine(BuildHelpForGenerator(generatorParamDef));
+                    }
+                    else
+                    {
+                        // Generator not available.
+                        sb.AppendLine(string.Format(Resources.NoCodeGeneratorFound, GeneratorArgument.Value));
+                        sb.AppendLine(GetHelpTextForAvailableGenerators(paramDefinitionsCache));
+                    }
+                }
+                else
+                {
+                    sb.AppendLine(GetHelpTextForAvailableGenerators(paramDefinitionsCache));
+                }
+
+                sb.Insert(0, helpText);
+            }
+            else
+            {
+                Debug.Fail("Project Context was not set. Cannot search for generators to display help.");
+            }
+
+            return sb.ToString();
+        }
+
+        private static string GetHelpTextForAvailableGenerators(Dictionary<string, ParamDefinition> paramDefinitionsCache)
+        {
+            StringBuilder sb = new StringBuilder();
+            sb.AppendLine();
+            sb.AppendLine(Resources.AvailableGeneratorsHeader);
+            var maxLenGeneratorName = paramDefinitionsCache.Max(p => p.Key.Length);
+            var formatStr = "  {0,-"+maxLenGeneratorName+"}: {1}";
+            foreach(var paramDef in paramDefinitionsCache.Values)
+            {
+                sb.AppendLine(string.Format(formatStr, paramDef.Alias, paramDef.Description));
+            }
+
+            return sb.ToString();
+        }
+
+        private static string BuildHelpForGenerator( ParamDefinition generatorParamDef)
+        {
+            StringBuilder sb = new StringBuilder();
+            if (generatorParamDef.Arguments != null && generatorParamDef.Arguments.Any())
+            {
+                sb.AppendLine();
+                sb.AppendLine(Resources.GeneratorArgsHeader);
+                var maxLenArgument = generatorParamDef.Arguments.Max(a => a.Name.Length);
+                var formatStr = "  {0,-"+maxLenArgument+"} : {1}";
+                foreach (var arg in generatorParamDef.Arguments)
+                {
+                    sb.AppendLine(string.Format(formatStr, arg.Name, arg.Description));
+                }
+            }
+
+            if (generatorParamDef.Options != null && generatorParamDef.Options.Any())
+            {
+                sb.AppendLine();
+                sb.AppendLine(Resources.GeneratorOptionsHeader);
+                var maxLenOption = generatorParamDef.Options.Max(o => o.Name.Length + o.ShortName.Length) + 4;
+                var formatStr = "  {0,-"+maxLenOption+"} : {1}";
+                
+                foreach (var opt in generatorParamDef.Options)
+                {
+                    if (string.IsNullOrEmpty(opt.ShortName))
+                    {
+                        sb.AppendLine(string.Format(formatStr, "--"+opt.Name, opt.Description));
+                    }
+                    else
+                    {
+                        sb.AppendLine(string.Format(formatStr, "--"+opt.Name+"|-"+opt.ShortName, opt.Description));
+                    }
+                }
+            }
+
+            return sb.ToString();
+        }
+
+        private static Dictionary<string, ParamDefinition> BuildParamDefinitionCache(IEnumerable<string> nuGetPackages)
+        {
+            Dictionary<string, ParamDefinition> paramDefinitionsCache = new Dictionary<string, ParamDefinition>(StringComparer.OrdinalIgnoreCase);
+            foreach (var path in nuGetPackages)
+            {
+                var generatorParamDir = Path.Combine(path, paramDefinitionFilePath);
+                if (Directory.Exists(generatorParamDir))
+                {
+                    try
+                    {
+                        var paramDefinitionFiles = Directory.EnumerateFiles(generatorParamDir, "*.json", SearchOption.TopDirectoryOnly);
+                        if (paramDefinitionFiles == null)
+                        {
+                            continue;
+                        }
+                        foreach (var paramFile in paramDefinitionFiles)
+                        {
+                            var json = File.ReadAllText(paramFile);
+                            var paramDefinition = JsonConvert.DeserializeObject<ParamDefinition>(json);
+                            paramDefinitionsCache[paramDefinition.Alias] = paramDefinition;
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        // Do not want to fail if there is a problem with the json file.
+                        Debug.Fail(ex.Message);
+                        continue;
+                    }
+                }
+            }
+            return paramDefinitionsCache;
+        }
+    }
+
+}

--- a/src/Microsoft.VisualStudio.Web.CodeGeneration.Tools/ToolCommandLineHelper.cs
+++ b/src/Microsoft.VisualStudio.Web.CodeGeneration.Tools/ToolCommandLineHelper.cs
@@ -79,5 +79,8 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.Tools
         }
 
         internal static bool IsNoBuild(string[] args) => args.Contains(NO_BUILD, StringComparer.OrdinalIgnoreCase);
+
+        internal static bool IsHelpArgument(string[] args) => args.Any(a => a.Equals("-h", StringComparison.OrdinalIgnoreCase)
+                                                                         || a.Equals("--help", StringComparison.OrdinalIgnoreCase));
     }
 }

--- a/src/Microsoft.VisualStudio.Web.CodeGenerators.Mvc/Microsoft.VisualStudio.Web.CodeGenerators.Mvc.csproj
+++ b/src/Microsoft.VisualStudio.Web.CodeGenerators.Mvc/Microsoft.VisualStudio.Web.CodeGenerators.Mvc.csproj
@@ -15,6 +15,7 @@
     <None Pack="true" Include="Templates\Startup\*" PackagePath="Templates\Startup\" />
     <None Pack="true" Include="Templates\StaticFiles\*" PackagePath="Templates\StaticFiles\" />
     <None Pack="true" Include="Templates\ViewGenerator\*" PackagePath="Templates\ViewGenerator\" />
+    <None Pack="true" Include="ParameterDefinitions\*" PackagePath="Generators\ParameterDefinitions\" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.VisualStudio.Web.CodeGenerators.Mvc/ParameterDefinitions/area.json
+++ b/src/Microsoft.VisualStudio.Web.CodeGenerators.Mvc/ParameterDefinitions/area.json
@@ -1,0 +1,11 @@
+{
+    "Alias": "area",
+    "Description": "Generates an MVC Area.",
+    "Arguments": [
+        {
+            "Name": "Name",
+            "Description": "Name of the Area to generate"
+        }
+    ],
+    "Options": [ ]
+}

--- a/src/Microsoft.VisualStudio.Web.CodeGenerators.Mvc/ParameterDefinitions/controller.json
+++ b/src/Microsoft.VisualStudio.Web.CodeGenerators.Mvc/ParameterDefinitions/controller.json
@@ -1,0 +1,74 @@
+{
+    "Alias": "controller",
+    "Description": "Generates a controller.",
+    "Arguments": [
+
+    ],
+    "Options": [
+        {
+            "Name": "controllerName",
+            "ShortName": "name",
+            "Description": "Name of the controller"
+        },
+        {
+            "Name": "useAsyncActions",
+            "ShortName": "async",
+            "Description": "Switch to indicate whether to generate async controller actions"
+        },
+        {
+            "Name": "noViews",
+            "ShortName": "nv",
+            "Description": "Switch to indicate whether to generate CRUD views"
+        },
+        {
+            "Name": "restWithNoViews",
+            "ShortName": "api",
+            "Description": "Specify this switch to generate a Controller with REST style API, noViews is assumed and any view related options are ignored"
+        },
+        {
+            "Name": "readWriteActions",
+            "ShortName": "actions",
+            "Description": "Specify this switch to generate Controller with read/write actions when a Model class is not used"
+        },
+        {
+            "Name": "model",
+            "ShortName": "m",
+            "Description": "Model class to use"
+        },
+        {
+            "Name": "dataContext",
+            "ShortName": "dc",
+            "Description": "DbContext class to use"
+        },
+        {
+            "Name": "referenceScriptLibraries",
+            "ShortName": "scripts",
+            "Description": "Switch to specify whether to reference script libraries in the generated views"
+        },
+        {
+            "Name": "layout",
+            "ShortName": "l",
+            "Description": "Custom Layout page to use"
+        },
+        {
+            "Name": "useDefaultLayout",
+            "ShortName": "udl",
+            "Description": "Switch to specify that default layout should be used for the views"
+        },
+        {
+            "Name": "force",
+            "ShortName": "f",
+            "Description": "Use this option to overwrite existing files"
+        },
+        {
+            "Name": "relativeFolderPath",
+            "ShortName": "outDir",
+            "Description": "Specify the relative output folder path from project where the file needs to be generated, if not specified, file will be generated in the project folder"
+        },
+        {
+            "Name": "controllerNamespace",
+            "ShortName": "namespace",
+            "Description": "Specify the name of the namespace to use for the generated controller"
+        }
+    ]
+}

--- a/src/Microsoft.VisualStudio.Web.CodeGenerators.Mvc/ParameterDefinitions/view.json
+++ b/src/Microsoft.VisualStudio.Web.CodeGenerators.Mvc/ParameterDefinitions/view.json
@@ -1,0 +1,61 @@
+{
+    "Alias": "view",
+    "Description": "Generates a view.",
+    "Arguments": [
+        {
+            "Name": "viewName",
+            "Description": "Name of the view"
+        },
+        {
+            "Name": "templateName",
+            "Description": "The view template to use, supported view templates: 'Empty|Create|Edit|Delete|Details|List'"
+        }
+    ],
+    "Options": [
+        {
+            "Name": "model",
+            "ShortName": "m",
+            "Description": "Model class to use"
+        },
+        {
+            "Name": "dataContext",
+            "ShortName": "dc",
+            "Description": "DbContext class to use"
+        },
+        {
+            "Name": "referenceScriptLibraries",
+            "ShortName": "scripts",
+            "Description": "Switch to specify whether to reference script libraries in the generated views"
+        },
+        {
+            "Name": "layout",
+            "ShortName": "l",
+            "Description": "Custom Layout page to use"
+        },
+        {
+            "Name": "useDefaultLayout",
+            "ShortName": "udl",
+            "Description": "Switch to specify that default layout should be used for the views"
+        },
+        {
+            "Name": "force",
+            "ShortName": "f",
+            "Description": "Use this option to overwrite existing files"
+        },
+        {
+            "Name": "relativeFolderPath",
+            "ShortName": "outDir",
+            "Description": "Specify the relative output folder path from project where the file needs to be generated, if not specified, file will be generated in the project folder"
+        },
+        {
+            "Name": "controllerNamespace",
+            "ShortName": "namespace",
+            "Description": "Specify the name of the namespace to use for the generated controller"
+        },
+        {
+            "Name": "partialView",
+            "ShortName": "partial",
+            "Description": "Generate a partial view, other layout options (-l and -udl) are ignored if this is specified"
+        }
+    ]
+}

--- a/src/Shared/General/ConsoleLogger.cs
+++ b/src/Shared/General/ConsoleLogger.cs
@@ -7,6 +7,7 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration
 {
     public class ConsoleLogger : ILogger
     {
+        private static bool isTrace = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("codegen_trace"));
         private object _syncObject = new object();
 
         public void LogMessage(string message)
@@ -22,11 +23,11 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration
                 {
                     Console.Error.WriteLine(message);
                 }
-                else if (level == LogMessageLevel.Trace)
+                else if (level == LogMessageLevel.Trace && isTrace)
                 {
-                    Console.Out.WriteLine(message);
+                    Console.Out.WriteLine($"[Trace]: {message}");
                 }
-                else
+                else if (level == LogMessageLevel.Information)
                 {
                     Console.Out.WriteLine(message);
                 }


### PR DESCRIPTION
The Package `Microsoft.VisualStudio.Web.CodeGenerators.Mvc` carries the `ParameterDefinition` files for each of the code generators.

The CLI tool `dotnet-aspnet-codegenerator` scans the NuGet dependencies of the project to find out which ones have these files and displays help based on that. 

This allows showing help and discovering generators in the CLI tool without having to dispatch to the inside man.


### Sample invocations: 

```
>dotnet aspnet-codegenerator -h

Usage: aspnet-codegenerator [arguments] [options]

Arguments:
  generator  Name of the generator. Check available generators below.

Options:
  -p|--project             Path to .csproj file in the project.
  -n|--nuget-package-dir
  -c|--configuration       Configuration for the project (Possible values: Debug/ Release)
  -tfm|--target-framework  Target Framework to use. (Short folder name of the tfm. eg. net46)
  -b|--build-base-path
  --no-build

Available generators:
  area      : Generates an MVC Area.
  controller: Generates a controller.
  view      : Generates a view.
  
```

```
>dotnet aspnet-codegenerator controller -h

Usage: aspnet-codegenerator [arguments] [options]

Arguments:
  generator  Name of the generator. Check available generators below.

Options:
  -p|--project             Path to .csproj file in the project.
  -n|--nuget-package-dir
  -c|--configuration       Configuration for the project (Possible values: Debug/ Release)
  -tfm|--target-framework  Target Framework to use. (Short folder name of the tfm. eg. net46)
  -b|--build-base-path
  --no-build

Selected Code Generator: controller

Generator Options:
  --controllerName|-name              : Name of the controller
  --useAsyncActions|-async            : Switch to indicate whether to generate async controller actions
  --noViews|-nv                       : Switch to indicate whether to generate CRUD views
  --restWithNoViews|-api              : Specify this switch to generate a Controller with REST style API, noViews is assumed and any view related options are ignored
  --readWriteActions|-actions         : Specify this switch to generate Controller with read/write actions when a Model class is not used
  --model|-m                          : Model class to use
  --dataContext|-dc                   : DbContext class to use
  --referenceScriptLibraries|-scripts : Switch to specify whether to reference script libraries in the generated views
  --layout|-l                         : Custom Layout page to use
  --useDefaultLayout|-udl             : Switch to specify that default layout should be used for the views
  --force|-f                          : Use this option to overwrite existing files
  --relativeFolderPath|-outDir        : Specify the relative output folder path from project where the file needs to be generated, if not specified, file will be generated in the project folder
  --controllerNamespace|-namespace    : Specify the name of the namespace to use for the generated controller
```
```
>dotnet aspnet-codegenerator blah -h

Usage: aspnet-codegenerator [arguments] [options]

Arguments:
  generator  Name of the generator. Check available generators below.

Options:
  -p|--project             Path to .csproj file in the project.
  -n|--nuget-package-dir
  -c|--configuration       Configuration for the project (Possible values: Debug/ Release)
  -tfm|--target-framework  Target Framework to use. (Short folder name of the tfm. eg. net46)
  -b|--build-base-path
  --no-build

Selected Code Generator: blah
No code generator found with the name 'blah'.

Available generators:
  area      : Generates an MVC Area.
  controller: Generates a controller.
  view      : Generates a view.
```