### PR TITLE
Use latest runtime version in test projects

### DIFF
--- a/test/Shared/MsBuildProjectStrings.cs
+++ b/test/Shared/MsBuildProjectStrings.cs
@@ -36,6 +36,7 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration
     <RootNamespace>Microsoft.TestProject</RootNamespace>
     <ProjectName>TestProject</ProjectName>
     <NoWarn>NU1605</NoWarn>
+    <RuntimeFrameworkVersion>2.0.0-*</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -76,6 +77,7 @@ public const string RootProjectTxtWithoutEF = @"
     <RootNamespace>Microsoft.TestProject</RootNamespace>
     <ProjectName>TestProject</ProjectName>
     <NoWarn>NU1605</NoWarn>
+    <RuntimeFrameworkVersion>2.0.0-*</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
* Without setting `RuntimeFrameworkVersion` to `2.0.0-*`, projects default to using the runtime version included in the CLI, which may not match the runtime version required by the current build of ASP.NET.  This causes test failures when there are breaking changes between runtime versions.