### PR TITLE
Set "TreatWarningsAsErrors" before NuGet restore

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -6,6 +6,7 @@
     <RepositoryUrl>https://github.com/aspnet/scaffolding</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <VersionSuffix Condition="'$(VersionSuffix)'!='' AND '$(BuildNumber)' != ''">$(VersionSuffix)-$(BuildNumber)</VersionSuffix>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <!-- Sign Options -->


### PR DESCRIPTION
* Ensures our build stays clean of NuGet warnings