### PR TITLE
Add explicit dependency to prevent conflict

### DIFF
--- a/test/Microsoft.Extensions.ProjectModel.Tests/Microsoft.Extensions.ProjectModel.Tests.csproj
+++ b/test/Microsoft.Extensions.ProjectModel.Tests/Microsoft.Extensions.ProjectModel.Tests.csproj
@@ -25,6 +25,10 @@
     <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="xunit" Version="$(XunitVersion)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XunitVersion)" />
+
+    <!-- Required to prevent a conflict warning between Microsoft.VisualStudio.Web.CodeGeneration.Contracts and Microsoft.DotNet.ProjectModel. -->
+    <!-- Can be removed once Microsoft.DotNet.ProjectModel moves to Newtonsoft.Json 10.0.1 -->
+    <PackageReference Include="Newtonsoft.Json" Version="$(JsonNetVersion)" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This is to prevent the `warning MSB3277`'s we've been seeing in Universe.