### PR TITLE
Expose Type and Property information with metadata

### DIFF
--- a/src/VS.Web.CG.EFCore/CodeModelMetadata.cs
+++ b/src/VS.Web.CG.EFCore/CodeModelMetadata.cs
@@ -41,6 +41,14 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore
             _primaryKeys = new IPropertyMetadata[0];
         }
 
+        public Type ModelType
+        {
+            get
+            {
+                return _model;
+            }
+        }
+
         /// <summary>
         /// Always returns empty array as there is no Entity type information
         /// </summary>

--- a/src/VS.Web.CG.EFCore/IModelMetadata.cs
+++ b/src/VS.Web.CG.EFCore/IModelMetadata.cs
@@ -13,5 +13,6 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore
         IPropertyMetadata[] Properties { get; }
         IPropertyMetadata[] PrimaryKeys { get; }
         INavigationMetadata[] Navigations { get; }
+        Type ModelType { get; }
     }
 }

--- a/src/VS.Web.CG.EFCore/IPropertyMetadata.cs
+++ b/src/VS.Web.CG.EFCore/IPropertyMetadata.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Reflection;
+
 namespace Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore
 {
     public interface IPropertyMetadata
@@ -15,5 +17,7 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore
         bool Scaffold { get; set; }
         string ShortTypeName { get; set; }
         string TypeName { get; set; }
+
+        PropertyInfo PropertyInfo { get; set; }
     }
 }

--- a/src/VS.Web.CG.EFCore/ModelMetadata.cs
+++ b/src/VS.Web.CG.EFCore/ModelMetadata.cs
@@ -36,6 +36,14 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore
             EntitySetName = GetEntitySetName(DbContexType, EntityType.ClrType);
         }
 
+
+        public Type ModelType
+        {
+            get
+            {
+                return EntityType.ClrType;
+            }
+        }
         public IEntityType EntityType { get; private set; }
 
         public Type DbContexType { get; private set; }

--- a/src/VS.Web.CG.EFCore/PropertyMetadata.cs
+++ b/src/VS.Web.CG.EFCore/PropertyMetadata.cs
@@ -26,6 +26,7 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore
         public PropertyMetadata(PropertyInfo property)
         {
             Contract.Assert(property != null && property.Name != null && property.PropertyType != null);
+            PropertyInfo = property;
             PropertyName = property.Name;
             TypeName = property.PropertyType.FullName;
 
@@ -66,5 +67,7 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore
         public string ShortTypeName { get; set; }
 
         public string TypeName { get; set; }
+
+        public PropertyInfo PropertyInfo { get; set; }
     }
 }


### PR DESCRIPTION
Fixes #544 

This will help people trying to access `CustomAttributes` on their model and model properties and use them in their own razor templates for scaffolding.