### PR TITLE
Float version of Microsoft.DotNet.ProjectModel

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -21,7 +21,7 @@
     <TestSdkVersion>15.3.0-*</TestSdkVersion>
     <MoqVersion>4.7.49</MoqVersion>
     <XunitVersion>2.3.0-beta2-*</XunitVersion>
-    <DotNetProjectModelVersion>1.0.0-rc3-003121</DotNetProjectModelVersion>
+    <DotNetProjectModelVersion>1.0.0-*</DotNetProjectModelVersion>
   </PropertyGroup>
   <!-- MSBuild used by CLI currently uses the 9.0.1 version. -->
   <PropertyGroup>


### PR DESCRIPTION
- Microsoft.DotNet.ProjectModel is only used by tests, so we should float the version to automatically test the latest version published to nuget.org