### PR TITLE
Add required files for the views and razor pages if they don't exist

### DIFF
--- a/src/Microsoft.VisualStudio.Web.CodeGenerators.Mvc/Common/RequiredFileEntity.cs
+++ b/src/Microsoft.VisualStudio.Web.CodeGenerators.Mvc/Common/RequiredFileEntity.cs
@@ -7,7 +7,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc
 {
     public class RequiredFileEntity
     {
-        public RequiredFileEntity(string outputPath, string templateName)
+        public RequiredFileEntity(string outputPath, string templateName, bool isStaticFile = true, dynamic templateModel = null)
         {
             if (string.IsNullOrEmpty(outputPath))
             {
@@ -21,16 +21,22 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc
 
             TemplateName = templateName;
             OutputPath = outputPath;
+            IsStaticFile = isStaticFile;
+            TemplateModel = templateModel;
         }
         
         /// <summary>
         /// Name of the template file.
         /// </summary>
-        public string TemplateName { get; private set; }
+        public string TemplateName { get; }
         
         /// <summary>
         /// Path Relative to the .csproj file
         /// </summary>
-        public string OutputPath { get; private set; }
+        public string OutputPath { get; }
+
+        public bool IsStaticFile { get; }
+
+        public dynamic TemplateModel { get; }
     }
 }

--- a/src/Microsoft.VisualStudio.Web.CodeGenerators.Mvc/Common/RequiredFilesTemplateModel.cs
+++ b/src/Microsoft.VisualStudio.Web.CodeGenerators.Mvc/Common/RequiredFilesTemplateModel.cs
@@ -1,0 +1,13 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc
+{
+    public class RequiredFilesTemplateModel
+    {
+        public string RootNamespace { get; set; }
+        public string AppName { get; set; }
+    }
+}

--- a/src/Microsoft.VisualStudio.Web.CodeGenerators.Mvc/RazorPage/EFModelBasedRazorPageScaffolder.cs
+++ b/src/Microsoft.VisualStudio.Web.CodeGenerators.Mvc/RazorPage/EFModelBasedRazorPageScaffolder.cs
@@ -77,7 +77,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Razor
 
             ModelTypeAndContextModel modelTypeAndContextModel = null;
             var outputPath = ValidateAndGetOutputPath(razorGeneratorModel, outputFileName: razorGeneratorModel.ViewName + Constants.ViewExtension);
-
+            IsRazorPageWireUpNeeded = !RazorPagesFolderExists(razorGeneratorModel.RelativeFolderPath, ApplicationInfo.ApplicationBasePath);
             EFValidationUtil.ValidateEFDependencies(_projectContext.PackageDependencies);
 
             modelTypeAndContextModel = await ModelMetadataUtilities.ValidateModelAndGetEFMetadata(
@@ -96,18 +96,6 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Razor
             {
                 throw new Exception(string.Format("{0} {1}", MessageStrings.ScaffoldingSuccessful_unregistered, MessageStrings.Scaffolding_additionalSteps));
             }
-        }
-
-        protected override IEnumerable<RequiredFileEntity> GetRequiredFiles(RazorPageGeneratorModel viewGeneratorModel)
-        {
-            List<RequiredFileEntity> requiredFiles = new List<RequiredFileEntity>();
-
-            if (viewGeneratorModel.ReferenceScriptLibraries)
-            {
-                requiredFiles.Add(new RequiredFileEntity(Path.Combine("Pages","_ValidationScriptsPartial.cshtml"), @"_ValidationScriptsPartial.cshtml"));
-            }
-
-            return requiredFiles;
         }
 
         internal async Task GenerateViews(RazorPageGeneratorModel razorPageGeneratorModel)
@@ -132,7 +120,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Razor
 
             ModelTypeAndContextModel modelTypeAndContextModel = null;
             string outputPath = ValidateAndGetOutputPath(razorPageGeneratorModel, string.Empty);
-
+            IsRazorPageWireUpNeeded = !RazorPagesFolderExists(razorPageGeneratorModel.RelativeFolderPath, ApplicationInfo.ApplicationBasePath);
             EFValidationUtil.ValidateEFDependencies(_projectContext.PackageDependencies);
 
             modelTypeAndContextModel = await ModelMetadataUtilities.ValidateModelAndGetEFMetadata(

--- a/src/Microsoft.VisualStudio.Web.CodeGenerators.Mvc/RazorPage/EmptyRazorPageScaffolder.cs
+++ b/src/Microsoft.VisualStudio.Web.CodeGenerators.Mvc/RazorPage/EmptyRazorPageScaffolder.cs
@@ -45,16 +45,12 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Razor
             }
 
             var outputPath = ValidateAndGetOutputPath(razorGeneratorModel, outputFileName: razorGeneratorModel.ViewName + Constants.ViewExtension);
+            IsRazorPageWireUpNeeded = !RazorPagesFolderExists(razorGeneratorModel.RelativeFolderPath, ApplicationInfo.ApplicationBasePath);
             var layoutDependencyInstaller = ActivatorUtilities.CreateInstance<MvcLayoutDependencyInstaller>(_serviceProvider);
             await layoutDependencyInstaller.Execute();
 
             await GenerateView(razorGeneratorModel, null, outputPath);
             await layoutDependencyInstaller.InstallDependencies();
-        }
-
-        protected override IEnumerable<RequiredFileEntity> GetRequiredFiles(RazorPageGeneratorModel razorGeneratorModel)
-        {
-            return RequiredFiles;
         }
     }
 }

--- a/src/Microsoft.VisualStudio.Web.CodeGenerators.Mvc/Templates/RazorPageGenerator/_Layout.cshtml
+++ b/src/Microsoft.VisualStudio.Web.CodeGenerators.Mvc/Templates/RazorPageGenerator/_Layout.cshtml
@@ -1,0 +1,76 @@
+@inherits Microsoft.VisualStudio.Web.CodeGeneration.Templating.RazorTemplateBase
+@{
+    var currentYear = System.DateTime.Now.Year;
+}
+
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>@@ViewData["Title"] - @Model.AppName</title>
+
+    <environment include="Development">
+        <link rel="stylesheet" href="~/lib/bootstrap/dist/css/bootstrap.css" />
+        <link rel="stylesheet" href="~/css/site.css" />
+    </environment>
+    <environment exclude="Development">
+        <link rel="stylesheet" href="https://ajax.aspnetcdn.com/ajax/bootstrap/3.3.7/css/bootstrap.min.css"
+              asp-fallback-href="~/lib/bootstrap/dist/css/bootstrap.min.css"
+              asp-fallback-test-class="sr-only" asp-fallback-test-property="position" asp-fallback-test-value="absolute" />
+        <link rel="stylesheet" href="~/css/site.min.css" asp-append-version="true" />
+    </environment>
+</head>
+<body>
+    <nav class="navbar navbar-inverse navbar-fixed-top">
+        <div class="container">
+            <div class="navbar-header">
+                <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
+                    <span class="sr-only">Toggle navigation</span>
+                    <span class="icon-bar"></span>
+                    <span class="icon-bar"></span>
+                    <span class="icon-bar"></span>
+                </button>
+                <a asp-page="/Index" class="navbar-brand">@Model.AppName</a>
+            </div>
+            <div class="navbar-collapse collapse">
+                <ul class="nav navbar-nav">
+                    <li><a asp-page="/Index">Home</a></li>
+                    <li><a asp-page="/About">About</a></li>
+                    <li><a asp-page="/Contact">Contact</a></li>
+                </ul>
+            </div>
+        </div>
+    </nav>
+    <div class="container body-content">
+        @@RenderBody()
+        <hr />
+        <footer>
+            <p>&copy; @currentYear - @Model.AppName</p>
+        </footer>
+    </div>
+
+    <environment include="Development">
+        <script src="~/lib/jquery/dist/jquery.js"></script>
+        <script src="~/lib/bootstrap/dist/js/bootstrap.js"></script>
+        <script src="~/js/site.js" asp-append-version="true"></script>
+    </environment>
+    <environment exclude="Development">
+        <script src="https://ajax.aspnetcdn.com/ajax/jquery/jquery-2.2.0.min.js"
+                asp-fallback-src="~/lib/jquery/dist/jquery.min.js"
+                asp-fallback-test="window.jQuery"
+                crossorigin="anonymous"
+                integrity="sha384-K+ctZQ+LL8q6tP7I94W+qzQsfRV2a+AfHIi9k8z8l9ggpc8X+Ytst4yBo/hH+8Fk">
+        </script>
+        <script src="https://ajax.aspnetcdn.com/ajax/bootstrap/3.3.7/bootstrap.min.js"
+                asp-fallback-src="~/lib/bootstrap/dist/js/bootstrap.min.js"
+                asp-fallback-test="window.jQuery && window.jQuery.fn && window.jQuery.fn.modal"
+                crossorigin="anonymous"
+                integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa">
+        </script>
+        <script src="~/js/site.min.js" asp-append-version="true"></script>
+    </environment>
+
+    @@RenderSection("Scripts", required: false)
+</body>
+</html>

--- a/src/Microsoft.VisualStudio.Web.CodeGenerators.Mvc/Templates/RazorPageGenerator/_ViewImports.cshtml
+++ b/src/Microsoft.VisualStudio.Web.CodeGenerators.Mvc/Templates/RazorPageGenerator/_ViewImports.cshtml
@@ -1,0 +1,4 @@
+@inherits Microsoft.VisualStudio.Web.CodeGeneration.Templating.RazorTemplateBase
+@@using @Model.RootNamespace
+@@namespace @(Model.RootNamespace).Pages
+@@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers

--- a/src/Microsoft.VisualStudio.Web.CodeGenerators.Mvc/Templates/RazorPageGenerator/_ViewStart.cshtml
+++ b/src/Microsoft.VisualStudio.Web.CodeGenerators.Mvc/Templates/RazorPageGenerator/_ViewStart.cshtml
@@ -1,0 +1,3 @@
+@{
+    Layout = "_Layout";
+}

--- a/src/Microsoft.VisualStudio.Web.CodeGenerators.Mvc/Templates/ViewGenerator/_Layout.cshtml
+++ b/src/Microsoft.VisualStudio.Web.CodeGenerators.Mvc/Templates/ViewGenerator/_Layout.cshtml
@@ -1,0 +1,75 @@
+@inherits Microsoft.VisualStudio.Web.CodeGeneration.Templating.RazorTemplateBase
+@{
+    var currentYear = System.DateTime.Now.Year;
+}
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>@@ViewData["Title"] - @Model.AppName</title>
+
+    <environment include="Development">
+        <link rel="stylesheet" href="~/lib/bootstrap/dist/css/bootstrap.css" />
+        <link rel="stylesheet" href="~/css/site.css" />
+    </environment>
+    <environment exclude="Development">
+        <link rel="stylesheet" href="https://ajax.aspnetcdn.com/ajax/bootstrap/3.3.7/css/bootstrap.min.css"
+              asp-fallback-href="~/lib/bootstrap/dist/css/bootstrap.min.css"
+              asp-fallback-test-class="sr-only" asp-fallback-test-property="position" asp-fallback-test-value="absolute" />
+        <link rel="stylesheet" href="~/css/site.min.css" asp-append-version="true" />
+    </environment>
+</head>
+<body>
+    <nav class="navbar navbar-inverse navbar-fixed-top">
+        <div class="container">
+            <div class="navbar-header">
+                <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
+                    <span class="sr-only">Toggle navigation</span>
+                    <span class="icon-bar"></span>
+                    <span class="icon-bar"></span>
+                    <span class="icon-bar"></span>
+                </button>
+                <a asp-area="" asp-controller="Home" asp-action="Index" class="navbar-brand">@Model.AppName</a>
+            </div>
+            <div class="navbar-collapse collapse">
+                <ul class="nav navbar-nav">
+                    <li><a asp-area="" asp-controller="Home" asp-action="Index">Home</a></li>
+                    <li><a asp-area="" asp-controller="Home" asp-action="About">About</a></li>
+                    <li><a asp-area="" asp-controller="Home" asp-action="Contact">Contact</a></li>
+                </ul>
+            </div>
+        </div>
+    </nav>
+    <div class="container body-content">
+        @@RenderBody()
+        <hr />
+        <footer>
+            <p>&copy; @currentYear - @Model.AppName</p>
+        </footer>
+    </div>
+
+    <environment include="Development">
+        <script src="~/lib/jquery/dist/jquery.js"></script>
+        <script src="~/lib/bootstrap/dist/js/bootstrap.js"></script>
+        <script src="~/js/site.js" asp-append-version="true"></script>
+    </environment>
+    <environment exclude="Development">
+        <script src="https://ajax.aspnetcdn.com/ajax/jquery/jquery-2.2.0.min.js"
+                asp-fallback-src="~/lib/jquery/dist/jquery.min.js"
+                asp-fallback-test="window.jQuery"
+                crossorigin="anonymous"
+                integrity="sha384-K+ctZQ+LL8q6tP7I94W+qzQsfRV2a+AfHIi9k8z8l9ggpc8X+Ytst4yBo/hH+8Fk">
+        </script>
+        <script src="https://ajax.aspnetcdn.com/ajax/bootstrap/3.3.7/bootstrap.min.js"
+                asp-fallback-src="~/lib/bootstrap/dist/js/bootstrap.min.js"
+                asp-fallback-test="window.jQuery && window.jQuery.fn && window.jQuery.fn.modal"
+                crossorigin="anonymous"
+                integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa">
+        </script>
+        <script src="~/js/site.min.js" asp-append-version="true"></script>
+    </environment>
+
+    @@RenderSection("Scripts", required: false)
+</body>
+</html>

--- a/src/Microsoft.VisualStudio.Web.CodeGenerators.Mvc/Templates/ViewGenerator/_ViewImports.cshtml
+++ b/src/Microsoft.VisualStudio.Web.CodeGenerators.Mvc/Templates/ViewGenerator/_ViewImports.cshtml
@@ -1,0 +1,3 @@
+@inherits Microsoft.VisualStudio.Web.CodeGeneration.Templating.RazorTemplateBase
+@@using @Model.RootNamespace
+@@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers

--- a/src/Microsoft.VisualStudio.Web.CodeGenerators.Mvc/Templates/ViewGenerator/_ViewStart.cshtml
+++ b/src/Microsoft.VisualStudio.Web.CodeGenerators.Mvc/Templates/ViewGenerator/_ViewStart.cshtml
@@ -1,0 +1,3 @@
+@{
+    Layout = "_Layout";
+}

--- a/src/Microsoft.VisualStudio.Web.CodeGenerators.Mvc/View/EFModelBasedViewScaffolder.cs
+++ b/src/Microsoft.VisualStudio.Web.CodeGenerators.Mvc/View/EFModelBasedViewScaffolder.cs
@@ -63,6 +63,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.View
 
             ModelTypeAndContextModel modelTypeAndContextModel = null;
             var outputPath = ValidateAndGetOutputPath(viewGeneratorModel, outputFileName: viewGeneratorModel.ViewName + Constants.ViewExtension);
+            IsViewWireUpNeeded = !ViewsFolderExists(viewGeneratorModel.RelativeFolderPath, ApplicationInfo.ApplicationBasePath);
 
             EFValidationUtil.ValidateEFDependencies(_projectContext.PackageDependencies);
 
@@ -82,18 +83,6 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.View
             {
                 throw new Exception(string.Format("{0} {1}", MessageStrings.ScaffoldingSuccessful_unregistered, MessageStrings.Scaffolding_additionalSteps));
             }
-        }
-
-        protected override IEnumerable<RequiredFileEntity> GetRequiredFiles(ViewGeneratorModel viewGeneratorModel)
-        {
-            List<RequiredFileEntity> requiredFiles = new List<RequiredFileEntity>();
-
-            if (viewGeneratorModel.ReferenceScriptLibraries)
-            {
-                requiredFiles.Add(new RequiredFileEntity(@"Views/Shared/_ValidationScriptsPartial.cshtml", @"_ValidationScriptsPartial.cshtml"));
-            }
-
-            return requiredFiles;
         }
 
         /// <summary>
@@ -125,6 +114,8 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.View
             {
                 baseOutputPath = ApplicationInfo.ApplicationBasePath;
             }
+
+            IsViewWireUpNeeded = !ViewsFolderExists(baseOutputPath, ApplicationInfo.ApplicationBasePath);
 
             foreach (var entry in viewsAndTemplates)
             {

--- a/src/Microsoft.VisualStudio.Web.CodeGenerators.Mvc/View/EmptyViewScaffolder.cs
+++ b/src/Microsoft.VisualStudio.Web.CodeGenerators.Mvc/View/EmptyViewScaffolder.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.Web.CodeGeneration;
 using Microsoft.VisualStudio.Web.CodeGeneration.Contracts.ProjectModel;
@@ -44,16 +45,13 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.View
             }
 
             var outputPath = ValidateAndGetOutputPath(viewGeneratorModel, outputFileName: viewGeneratorModel.ViewName + Constants.ViewExtension);
+            IsViewWireUpNeeded = !ViewsFolderExists(viewGeneratorModel.RelativeFolderPath, ApplicationInfo.ApplicationBasePath);
+
             var layoutDependencyInstaller = ActivatorUtilities.CreateInstance<MvcLayoutDependencyInstaller>(_serviceProvider);
             await layoutDependencyInstaller.Execute();
 
             await GenerateView(viewGeneratorModel, null, outputPath);
             await layoutDependencyInstaller.InstallDependencies();
-        }
-
-        protected override IEnumerable<RequiredFileEntity> GetRequiredFiles(ViewGeneratorModel viewGeneratorModel)
-        {
-            return RequiredFiles;
         }
     }
 }

--- a/src/Microsoft.VisualStudio.Web.CodeGenerators.Mvc/View/ModelBasedViewScaffolder.cs
+++ b/src/Microsoft.VisualStudio.Web.CodeGenerators.Mvc/View/ModelBasedViewScaffolder.cs
@@ -62,6 +62,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.View
 
             ModelTypeAndContextModel modelTypeAndContextModel = null;
             var outputPath = ValidateAndGetOutputPath(viewGeneratorModel, outputFileName: viewGeneratorModel.ViewName + Constants.ViewExtension);
+            IsViewWireUpNeeded = !ViewsFolderExists(viewGeneratorModel.RelativeFolderPath, ApplicationInfo.ApplicationBasePath);
 
             modelTypeAndContextModel = await ModelMetadataUtilities.ValidateModelAndGetCodeModelMetadata(viewGeneratorModel, _codeModelService, _modelTypesLocator);
 
@@ -70,18 +71,6 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.View
 
             await GenerateView(viewGeneratorModel, modelTypeAndContextModel, outputPath);
             await layoutDependencyInstaller.InstallDependencies();
-        }
-
-        protected override IEnumerable<RequiredFileEntity> GetRequiredFiles(ViewGeneratorModel viewGeneratorModel)
-        {
-            List<RequiredFileEntity> requiredFiles = new List<RequiredFileEntity>();
-
-            if (viewGeneratorModel.ReferenceScriptLibraries)
-            {
-                requiredFiles.Add(new RequiredFileEntity(@"Views/Shared/_ValidationScriptsPartial.cshtml", @"_ValidationScriptsPartial.cshtml"));
-            }
-
-            return requiredFiles;
         }
     }
 }

--- a/test/E2E_Test/Compiler/Resources/RazorPages/_Layout.txt
+++ b/test/E2E_Test/Compiler/Resources/RazorPages/_Layout.txt
@@ -1,13 +1,9 @@
-@inherits Microsoft.VisualStudio.Web.CodeGeneration.Templating.RazorTemplateBase
-@{
-    var currentYear = System.DateTime.Now.Year;
-}
 <!DOCTYPE html>
 <html>
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>@@ViewData["Title"] - @Model.AppName</title>
+    <title>@ViewData["Title"] - TestProject</title>
 
     <environment include="Development">
         <link rel="stylesheet" href="~/lib/bootstrap/dist/css/bootstrap.css" />
@@ -30,7 +26,7 @@
                     <span class="icon-bar"></span>
                     <span class="icon-bar"></span>
                 </button>
-                <a asp-page="/Index" class="navbar-brand">@Model.AppName</a>
+                <a asp-page="/Index" class="navbar-brand">TestProject</a>
             </div>
             <div class="navbar-collapse collapse">
                 <ul class="nav navbar-nav">
@@ -42,10 +38,10 @@
         </div>
     </nav>
     <div class="container body-content">
-        @@RenderBody()
+        @RenderBody()
         <hr />
         <footer>
-            <p>&copy; @currentYear - @Model.AppName</p>
+            <p>&copy; 2017 - TestProject</p>
         </footer>
     </div>
 
@@ -70,6 +66,6 @@
         <script src="~/js/site.min.js" asp-append-version="true"></script>
     </environment>
 
-    @@RenderSection("Scripts", required: false)
+    @RenderSection("Scripts", required: false)
 </body>
 </html>

--- a/test/E2E_Test/Compiler/Resources/RazorPages/_ViewImports.txt
+++ b/test/E2E_Test/Compiler/Resources/RazorPages/_ViewImports.txt
@@ -1,0 +1,3 @@
+@using TestProject
+@namespace TestProject.Pages
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers

--- a/test/E2E_Test/Compiler/Resources/RazorPages/_ViewStart.txt
+++ b/test/E2E_Test/Compiler/Resources/RazorPages/_ViewStart.txt
@@ -1,0 +1,3 @@
+@{
+    Layout = "_Layout";
+}

--- a/test/E2E_Test/Compiler/Resources/Views/_Layout.txt
+++ b/test/E2E_Test/Compiler/Resources/Views/_Layout.txt
@@ -1,13 +1,9 @@
-@inherits Microsoft.VisualStudio.Web.CodeGeneration.Templating.RazorTemplateBase
-@{
-    var currentYear = System.DateTime.Now.Year;
-}
 <!DOCTYPE html>
 <html>
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>@@ViewData["Title"] - @Model.AppName</title>
+    <title>@ViewData["Title"] - TestProject</title>
 
     <environment include="Development">
         <link rel="stylesheet" href="~/lib/bootstrap/dist/css/bootstrap.css" />
@@ -30,22 +26,22 @@
                     <span class="icon-bar"></span>
                     <span class="icon-bar"></span>
                 </button>
-                <a asp-page="/Index" class="navbar-brand">@Model.AppName</a>
+                <a asp-area="" asp-controller="Home" asp-action="Index" class="navbar-brand">TestProject</a>
             </div>
             <div class="navbar-collapse collapse">
                 <ul class="nav navbar-nav">
-                    <li><a asp-page="/Index">Home</a></li>
-                    <li><a asp-page="/About">About</a></li>
-                    <li><a asp-page="/Contact">Contact</a></li>
+                    <li><a asp-area="" asp-controller="Home" asp-action="Index">Home</a></li>
+                    <li><a asp-area="" asp-controller="Home" asp-action="About">About</a></li>
+                    <li><a asp-area="" asp-controller="Home" asp-action="Contact">Contact</a></li>
                 </ul>
             </div>
         </div>
     </nav>
     <div class="container body-content">
-        @@RenderBody()
+        @RenderBody()
         <hr />
         <footer>
-            <p>&copy; @currentYear - @Model.AppName</p>
+            <p>&copy; 2017 - TestProject</p>
         </footer>
     </div>
 
@@ -70,6 +66,6 @@
         <script src="~/js/site.min.js" asp-append-version="true"></script>
     </environment>
 
-    @@RenderSection("Scripts", required: false)
+    @RenderSection("Scripts", required: false)
 </body>
 </html>

--- a/test/E2E_Test/Compiler/Resources/Views/_ViewImports.txt
+++ b/test/E2E_Test/Compiler/Resources/Views/_ViewImports.txt
@@ -1,0 +1,2 @@
+@using Microsoft.TestProject
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers

--- a/test/E2E_Test/Compiler/Resources/Views/_ViewStart.txt
+++ b/test/E2E_Test/Compiler/Resources/Views/_ViewStart.txt
@@ -1,0 +1,3 @@
+@{
+    Layout = "_Layout";
+}

--- a/test/E2E_Test/RazorPageScaffolderTests.cs
+++ b/test/E2E_Test/RazorPageScaffolderTests.cs
@@ -91,7 +91,7 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.E2E_Test
         }
 
         [Theory, MemberData(nameof(TestData))]
-        public void TestViewGenerator(string[] baselineFiles, string[] generatedFilePaths, string[] args)
+        public void TestRazorPageGenerator(string[] baselineFiles, string[] generatedFilePaths, string[] args)
         {
             using (var fileProvider = new TemporaryFileProvider())
             {
@@ -103,6 +103,34 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.E2E_Test
                     var generatedFilePath = Path.Combine(TestProjectPath, generatedFilePaths[i]);
                     VerifyFileAndContent(generatedFilePath, baselineFiles[i]);
                 }
+            }
+        }
+
+        [Fact]
+        public void TestRazorPageGenerator_AddRequiredFiles()
+        {
+            using (var fileProvider = new TemporaryFileProvider())
+            {
+                var args = new string[]
+                {
+                    codegeneratorToolName,
+                    "-p",
+                    ".",
+                    "-c",
+                    Configuration,
+                    "razorpage",
+                    "EmptyPage",
+                    "Empty",
+                    "-udl",
+                    "-scripts"
+                };
+
+                new MsBuildProjectSetupHelper().SetupProjects(fileProvider, Output);
+                TestProjectPath = Path.Combine(fileProvider.Root, "Root");
+                Scaffold(args, TestProjectPath);
+                VerifyFileAndContent(Path.Combine(TestProjectPath, "Pages", "_ViewStart.cshtml"), Path.Combine("RazorPages", "_ViewStart.txt"));
+                VerifyFileAndContent(Path.Combine(TestProjectPath, "Pages", "_ViewImports.cshtml"), Path.Combine("RazorPages", "_ViewImports.txt"));
+                VerifyFileAndContent(Path.Combine(TestProjectPath, "Pages", "_Layout.cshtml"), Path.Combine("RazorPages", "_Layout.txt"));
             }
         }
     }

--- a/test/E2E_Test/ViewGeneratorTests.cs
+++ b/test/E2E_Test/ViewGeneratorTests.cs
@@ -43,6 +43,35 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.E2E_Test
                 Scaffold(args, TestProjectPath);
                 generatedFilePath = Path.Combine(TestProjectPath, generatedFilePath);
                 VerifyFileAndContent(generatedFilePath, baselineFile);
+                
+            }
+        }
+
+        [Fact]
+        public void TestViewGenerator_AddRequiredFiles()
+        {
+            using (var fileProvider = new TemporaryFileProvider())
+            {
+                var args = new string[]
+                {
+                    codegeneratorToolName,
+                    "-p",
+                    ".",
+                    "-c",
+                    Configuration,
+                    "view",
+                    "EmptyView",
+                    "Empty",
+                    "-udl",
+                    "-scripts"
+                };
+
+                new MsBuildProjectSetupHelper().SetupProjects(fileProvider, Output);
+                TestProjectPath = Path.Combine(fileProvider.Root, "Root");
+                Scaffold(args, TestProjectPath);
+                VerifyFileAndContent(Path.Combine(TestProjectPath, "Views", "_ViewStart.cshtml"), Path.Combine("Views", "_ViewStart.txt"));
+                VerifyFileAndContent(Path.Combine(TestProjectPath, "Views", "_ViewImports.cshtml"), Path.Combine("Views", "_ViewImports.txt"));
+                VerifyFileAndContent(Path.Combine(TestProjectPath, "Views", "Shared", "_Layout.cshtml"), Path.Combine("Views", "_Layout.txt"));
             }
         }
     }


### PR DESCRIPTION
For View scaffolding, if the `Views` folder doesn't exist in the project yet, scaffolding will now add a `_ViewImports.cshtml` (and optionally `_ViewStart.cshtml` and `_Layout.cshtml`) files to the project.

Similarly for Razor Page scaffolding as well additional files will be scaffolded. 