### PR TITLE
Enable package downgrade warnings

### DIFF
--- a/test/Shared/MsBuildProjectStrings.cs
+++ b/test/Shared/MsBuildProjectStrings.cs
@@ -35,7 +35,6 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <RootNamespace>Microsoft.TestProject</RootNamespace>
     <ProjectName>TestProject</ProjectName>
-    <NoWarn>NU1605</NoWarn>
     <RuntimeFrameworkVersion>{2}</RuntimeFrameworkVersion>
   </PropertyGroup>
 
@@ -76,7 +75,6 @@ public const string RootProjectTxtWithoutEF = @"
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <RootNamespace>Microsoft.TestProject</RootNamespace>
     <ProjectName>TestProject</ProjectName>
-    <NoWarn>NU1605</NoWarn>
     <RuntimeFrameworkVersion>{2}</RuntimeFrameworkVersion>
   </PropertyGroup>
 
@@ -116,7 +114,6 @@ public const string RootProjectTxtWithoutEF = @"
     <OutputPath>bin\$(Configuration)</OutputPath>
     <RuntimeIdentifier>win7-x64</RuntimeIdentifier>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
-    <NoWarn>NU1605</NoWarn>
     <RuntimeFrameworkVersion>{2}</RuntimeFrameworkVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
- All package downgrade warnings should be currently fixed, and we want tests to fail for any new downgrade warnings.
- Resolves https://github.com/aspnet/Scaffolding/issues/533