### PR TITLE
Add patch feed

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -2,6 +2,7 @@
 <configuration>
   <packageSources>
     <clear />
+    <add key="Patch" value="https://dotnet.myget.org/F/dotnet-2017-09-servicing/api/v3/index.json" />
     <add key="AspNetCore" value="https://dotnet.myget.org/F/aspnetcore-master/api/v3/index.json" />
     <add key="AspNetCoreTools" value="https://dotnet.myget.org/F/aspnetcore-tools/api/v3/index.json" />
     <add key="NuGet" value="https://api.nuget.org/v3/index.json" />


### PR DESCRIPTION
I was seeing some test failures in 2.0.1:
```
[13:52:49] :	 [Step 2/2]      Restoring packages for /home/aspnetagent/buildAgent/temp/buildTmp/tmpfiles/c46165e7-3a80-4a55-a5f9-acc341c400b7/Library1/Library1.csproj...
[13:52:49] :	 [Step 2/2]      Restoring packages for /home/aspnetagent/buildAgent/temp/buildTmp/tmpfiles/c46165e7-3a80-4a55-a5f9-acc341c400b7/Root/Test.csproj...
[13:52:49] :	 [Step 2/2]      Restoring packages for /home/aspnetagent/buildAgent/temp/buildTmp/tmpfiles/c46165e7-3a80-4a55-a5f9-acc341c400b7/Root/Test.csproj...
[13:52:49] :	 [Step 2/2]      Generating MSBuild file /home/aspnetagent/buildAgent/temp/buildTmp/tmpfiles/c46165e7-3a80-4a55-a5f9-acc341c400b7/Library1/obj/Library1.csproj.nuget.g.props.
[13:52:49] :	 [Step 2/2]      Generating MSBuild file /home/aspnetagent/buildAgent/temp/buildTmp/tmpfiles/c46165e7-3a80-4a55-a5f9-acc341c400b7/Library1/obj/Library1.csproj.nuget.g.targets.
[13:52:49] :	 [Step 2/2]      Restore completed in 571.98 ms for /home/aspnetagent/buildAgent/temp/buildTmp/tmpfiles/c46165e7-3a80-4a55-a5f9-acc341c400b7/Library1/Library1.csproj.
[13:52:49] :	 [Step 2/2]      Restore completed in 1.69 sec for /home/aspnetagent/buildAgent/temp/buildTmp/tmpfiles/c46165e7-3a80-4a55-a5f9-acc341c400b7/Root/Test.csproj.
[13:52:49] :	 [Step 2/2]    /home/aspnetagent/buildAgent/temp/buildTmp/tmpfiles/c46165e7-3a80-4a55-a5f9-acc341c400b7/Root/Test.csproj : error NU1102: Unable to find package Microsoft.NETCore.App with version (>= 2.0.1)
[13:52:49] :	 [Step 2/2]    /home/aspnetagent/buildAgent/temp/buildTmp/tmpfiles/c46165e7-3a80-4a55-a5f9-acc341c400b7/Root/Test.csproj : error NU1102:   - Found 14 version(s) in nuget.org [ Nearest version: 2.0.0 ]
[13:52:49] :	 [Step 2/2]    /home/aspnetagent/buildAgent/temp/buildTmp/tmpfiles/c46165e7-3a80-4a55-a5f9-acc341c400b7/Root/Test.csproj : error NU1102:   - Found 1 version(s) in Dependencies [ Nearest version: 2.0.0 ]
[13:52:49] :	 [Step 2/2]    /home/aspnetagent/buildAgent/temp/buildTmp/tmpfiles/c46165e7-3a80-4a55-a5f9-acc341c400b7/Root/Test.csproj : error NU1102:   - Found 0 version(s) in local
[13:52:49] :	 [Step 2/2]    /home/aspnetagent/buildAgent/temp/buildTmp/tmpfiles/c46165e7-3a80-4a55-a5f9-acc341c400b7/Root/Test.csproj : error NU1102:   - Found 0 version(s) in Artifacts
[13:52:49] :	 [Step 2/2]    /home/aspnetagent/buildAgent/temp/buildTmp/tmpfiles/c46165e7-3a80-4a55-a5f9-acc341c400b7/Root/Test.csproj : error NU1102:   - Found 0 version(s) in AspNetCore
[13:52:49] :	 [Step 2/2]    /home/aspnetagent/buildAgent/temp/buildTmp/tmpfiles/c46165e7-3a80-4a55-a5f9-acc341c400b7/Root/Test.csproj : error NU1102:   - Found 0 version(s) in AspNetCoreTools
[13:52:49] :	 [Step 2/2]      Generating MSBuild file /home/aspnetagent/buildAgent/temp/buildTmp/tmpfiles/c46165e7-3a80-4a55-a5f9-acc341c400b7/Root/obj/Test.csproj.nuget.g.props.
[13:52:49] :	 [Step 2/2]      Generating MSBuild file /home/aspnetagent/buildAgent/temp/buildTmp/tmpfiles/c46165e7-3a80-4a55-a5f9-acc341c400b7/Root/obj/Test.csproj.nuget.g.targets.
[13:52:49] :	 [Step 2/2]      Restore failed in 4.15 sec for /home/aspnetagent/buildAgent/temp/buildTmp/tmpfiles/c46165e7-3a80-4a55-a5f9-acc341c400b7/Root/Test.csproj.
[13:52:49] :	 [Step 2/2]   
```

It seems like there are package dependencies on Microsoft.NetCore.App which I though was strange but was able to fix by adding the new feed. Is this the right fix @pranavkm ?