### PR TITLE
Replace occurrences of SingleOrDefaultAsync

### DIFF
--- a/src/VS.Web.CG.Mvc/Templates/ControllerGenerator/ApiControllerWithContext.cshtml
+++ b/src/VS.Web.CG.Mvc/Templates/ControllerGenerator/ApiControllerWithContext.cshtml
@@ -50,7 +50,7 @@ namespace @Model.ControllerNamespace
                 return BadRequest(ModelState);
             }
 
-            var @Model.ModelVariable = await _context.@(entitySetName).SingleOrDefaultAsync(m => m.@primaryKeyName == id);
+            var @Model.ModelVariable = await _context.@(entitySetName).FindAsync(id);
 
             if (@Model.ModelVariable == null)
             {
@@ -142,7 +142,7 @@ namespace @Model.ControllerNamespace
                 return BadRequest(ModelState);
             }
 
-            var @Model.ModelVariable = await _context.@(entitySetName).SingleOrDefaultAsync(m => m.@primaryKeyName == id);
+            var @Model.ModelVariable = await _context.@(entitySetName).FindAsync(id);
             if (@Model.ModelVariable == null)
             {
                 return NotFound();

--- a/src/VS.Web.CG.Mvc/Templates/ControllerGenerator/MvcControllerWithContext.cshtml
+++ b/src/VS.Web.CG.Mvc/Templates/ControllerGenerator/MvcControllerWithContext.cshtml
@@ -102,7 +102,7 @@ namespace @Model.ControllerNamespace
             }
 
             var @Model.ModelVariable = await _context.@(entitySetName)@inlineIncludes
-                .SingleOrDefaultAsync(m => m.@primaryKeyName == id);
+                .FindAsync(id);
             if (@Model.ModelVariable == null)
             {
                 return NotFound();
@@ -157,7 +157,7 @@ namespace @Model.ControllerNamespace
                 return NotFound();
             }
 
-            var @Model.ModelVariable = await _context.@(entitySetName).SingleOrDefaultAsync(m => m.@primaryKeyName == id);
+            var @Model.ModelVariable = await _context.@(entitySetName).FindAsync(id);
             if (@Model.ModelVariable == null)
             {
                 return NotFound();
@@ -221,7 +221,7 @@ namespace @Model.ControllerNamespace
             }
 
             var @Model.ModelVariable = await _context.@(entitySetName)@inlineIncludes
-                .SingleOrDefaultAsync(m => m.@primaryKeyName == id);
+                .FindAsync(id);
             if (@Model.ModelVariable == null)
             {
                 return NotFound();
@@ -235,7 +235,7 @@ namespace @Model.ControllerNamespace
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> DeleteConfirmed(@primaryKeyShortTypeName id)
         {
-            var @Model.ModelVariable = await _context.@(entitySetName).SingleOrDefaultAsync(m => m.@primaryKeyName == id);
+            var @Model.ModelVariable = await _context.@(entitySetName).FindAsync(id);
             _context.@(entitySetName).Remove(@Model.ModelVariable);
             await _context.SaveChangesAsync();
             return RedirectToAction(nameof(Index));

--- a/src/VS.Web.CG.Mvc/Templates/ControllerGenerator/MvcControllerWithContext.cshtml
+++ b/src/VS.Web.CG.Mvc/Templates/ControllerGenerator/MvcControllerWithContext.cshtml
@@ -102,7 +102,7 @@ namespace @Model.ControllerNamespace
             }
 
             var @Model.ModelVariable = await _context.@(entitySetName)@inlineIncludes
-                .FindAsync(id);
+                .FirstOrDefaultAsync(m => m.@primaryKeyName == id);
             if (@Model.ModelVariable == null)
             {
                 return NotFound();
@@ -221,7 +221,7 @@ namespace @Model.ControllerNamespace
             }
 
             var @Model.ModelVariable = await _context.@(entitySetName)@inlineIncludes
-                .FindAsync(id);
+                .FirstOrDefaultAsync(m => m.@primaryKeyName == id);
             if (@Model.ModelVariable == null)
             {
                 return NotFound();

--- a/src/VS.Web.CG.Mvc/Templates/RazorPageGenerator/DeletePageModel.cshtml
+++ b/src/VS.Web.CG.Mvc/Templates/RazorPageGenerator/DeletePageModel.cshtml
@@ -53,7 +53,7 @@ namespace @Model.NamespaceName
                 return NotFound();
             }
 
-            @Model.ViewDataTypeShortName = await _context.@(Model.ModelTypeName)@(inlineIncludes).FindAsync(id);
+            @Model.ViewDataTypeShortName = await _context.@(Model.ModelTypeName)@(inlineIncludes).FirstOrDefaultAsync(m => m.@primaryKeyName == id);
 
             if (@Model.ViewDataTypeShortName == null)
             {

--- a/src/VS.Web.CG.Mvc/Templates/RazorPageGenerator/DeletePageModel.cshtml
+++ b/src/VS.Web.CG.Mvc/Templates/RazorPageGenerator/DeletePageModel.cshtml
@@ -53,7 +53,7 @@ namespace @Model.NamespaceName
                 return NotFound();
             }
 
-            @Model.ViewDataTypeShortName = await _context.@(Model.ModelTypeName)@(inlineIncludes).SingleOrDefaultAsync(m => m.@primaryKeyName == id);
+            @Model.ViewDataTypeShortName = await _context.@(Model.ModelTypeName)@(inlineIncludes).FindAsync(id);
 
             if (@Model.ViewDataTypeShortName == null)
             {

--- a/src/VS.Web.CG.Mvc/Templates/RazorPageGenerator/DetailsPageModel.cshtml
+++ b/src/VS.Web.CG.Mvc/Templates/RazorPageGenerator/DetailsPageModel.cshtml
@@ -52,7 +52,7 @@ namespace @Model.NamespaceName
                 return NotFound();
             }
 
-            @Model.ViewDataTypeShortName = await _context.@(Model.ModelTypeName)@(inlineIncludes).SingleOrDefaultAsync(m => m.@(primaryKeyName) == id);
+            @Model.ViewDataTypeShortName = await _context.@(Model.ModelTypeName)@(inlineIncludes).FindAsync(id);
 
             if (@Model.ViewDataTypeShortName == null)
             {

--- a/src/VS.Web.CG.Mvc/Templates/RazorPageGenerator/DetailsPageModel.cshtml
+++ b/src/VS.Web.CG.Mvc/Templates/RazorPageGenerator/DetailsPageModel.cshtml
@@ -52,7 +52,7 @@ namespace @Model.NamespaceName
                 return NotFound();
             }
 
-            @Model.ViewDataTypeShortName = await _context.@(Model.ModelTypeName)@(inlineIncludes).FindAsync(id);
+            @Model.ViewDataTypeShortName = await _context.@(Model.ModelTypeName)@(inlineIncludes).FirstOrDefaultAsync(m => m.@(primaryKeyName) == id);
 
             if (@Model.ViewDataTypeShortName == null)
             {

--- a/src/VS.Web.CG.Mvc/Templates/RazorPageGenerator/EditPageModel.cshtml
+++ b/src/VS.Web.CG.Mvc/Templates/RazorPageGenerator/EditPageModel.cshtml
@@ -54,7 +54,7 @@ namespace @Model.NamespaceName
                 return NotFound();
             }
 
-            @Model.ViewDataTypeShortName = await _context.@(Model.ModelTypeName)@(inlineIncludes).FindAsync(id);
+            @Model.ViewDataTypeShortName = await _context.@(Model.ModelTypeName)@(inlineIncludes).FirstOrDefaultAsync(m => m.@(primaryKeyName) == id);
 
             if (@Model.ViewDataTypeShortName == null)
             {

--- a/src/VS.Web.CG.Mvc/Templates/RazorPageGenerator/EditPageModel.cshtml
+++ b/src/VS.Web.CG.Mvc/Templates/RazorPageGenerator/EditPageModel.cshtml
@@ -54,7 +54,7 @@ namespace @Model.NamespaceName
                 return NotFound();
             }
 
-            @Model.ViewDataTypeShortName = await _context.@(Model.ModelTypeName)@(inlineIncludes).SingleOrDefaultAsync(m => m.@(primaryKeyName) == id);
+            @Model.ViewDataTypeShortName = await _context.@(Model.ModelTypeName)@(inlineIncludes).FindAsync(id);
 
             if (@Model.ViewDataTypeShortName == null)
             {

--- a/test/E2E_Test/Compiler/Resources/CarsController.txt
+++ b/test/E2E_Test/Compiler/Resources/CarsController.txt
@@ -36,7 +36,7 @@ namespace TestProject
 
             var car = await _context.Car
                 .Include(c => c.Manufacturer)
-                .FindAsync(id);
+                .FirstOrDefaultAsync(m => m.ID == id);
             if (car == null)
             {
                 return NotFound();
@@ -132,7 +132,7 @@ namespace TestProject
 
             var car = await _context.Car
                 .Include(c => c.Manufacturer)
-                .FindAsync(id);
+                .FirstOrDefaultAsync(m => m.ID == id);
             if (car == null)
             {
                 return NotFound();

--- a/test/E2E_Test/Compiler/Resources/CarsController.txt
+++ b/test/E2E_Test/Compiler/Resources/CarsController.txt
@@ -36,7 +36,7 @@ namespace TestProject
 
             var car = await _context.Car
                 .Include(c => c.Manufacturer)
-                .SingleOrDefaultAsync(m => m.ID == id);
+                .FindAsync(id);
             if (car == null)
             {
                 return NotFound();
@@ -77,7 +77,7 @@ namespace TestProject
                 return NotFound();
             }
 
-            var car = await _context.Car.SingleOrDefaultAsync(m => m.ID == id);
+            var car = await _context.Car.FindAsync(id);
             if (car == null)
             {
                 return NotFound();
@@ -132,7 +132,7 @@ namespace TestProject
 
             var car = await _context.Car
                 .Include(c => c.Manufacturer)
-                .SingleOrDefaultAsync(m => m.ID == id);
+                .FindAsync(id);
             if (car == null)
             {
                 return NotFound();
@@ -146,7 +146,7 @@ namespace TestProject
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> DeleteConfirmed(string id)
         {
-            var car = await _context.Car.SingleOrDefaultAsync(m => m.ID == id);
+            var car = await _context.Car.FindAsync(id);
             _context.Car.Remove(car);
             await _context.SaveChangesAsync();
             return RedirectToAction(nameof(Index));

--- a/test/E2E_Test/Compiler/Resources/CarsWithViewController.txt
+++ b/test/E2E_Test/Compiler/Resources/CarsWithViewController.txt
@@ -37,7 +37,7 @@ namespace TestProject.Areas.Test.Controllers
 
             var car = await _context.Car
                 .Include(c => c.Manufacturer)
-                .FindAsync(id);
+                .FirstOrDefaultAsync(m => m.ID == id);
             if (car == null)
             {
                 return NotFound();
@@ -133,7 +133,7 @@ namespace TestProject.Areas.Test.Controllers
 
             var car = await _context.Car
                 .Include(c => c.Manufacturer)
-                .FindAsync(id);
+                .FirstOrDefaultAsync(m => m.ID == id);
             if (car == null)
             {
                 return NotFound();

--- a/test/E2E_Test/Compiler/Resources/CarsWithViewController.txt
+++ b/test/E2E_Test/Compiler/Resources/CarsWithViewController.txt
@@ -37,7 +37,7 @@ namespace TestProject.Areas.Test.Controllers
 
             var car = await _context.Car
                 .Include(c => c.Manufacturer)
-                .SingleOrDefaultAsync(m => m.ID == id);
+                .FindAsync(id);
             if (car == null)
             {
                 return NotFound();
@@ -78,7 +78,7 @@ namespace TestProject.Areas.Test.Controllers
                 return NotFound();
             }
 
-            var car = await _context.Car.SingleOrDefaultAsync(m => m.ID == id);
+            var car = await _context.Car.FindAsync(id);
             if (car == null)
             {
                 return NotFound();
@@ -133,7 +133,7 @@ namespace TestProject.Areas.Test.Controllers
 
             var car = await _context.Car
                 .Include(c => c.Manufacturer)
-                .SingleOrDefaultAsync(m => m.ID == id);
+                .FindAsync(id);
             if (car == null)
             {
                 return NotFound();
@@ -147,7 +147,7 @@ namespace TestProject.Areas.Test.Controllers
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> DeleteConfirmed(string id)
         {
-            var car = await _context.Car.SingleOrDefaultAsync(m => m.ID == id);
+            var car = await _context.Car.FindAsync(id);
             _context.Car.Remove(car);
             await _context.SaveChangesAsync();
             return RedirectToAction(nameof(Index));

--- a/test/E2E_Test/Compiler/Resources/ProductsController.txt
+++ b/test/E2E_Test/Compiler/Resources/ProductsController.txt
@@ -35,7 +35,7 @@ namespace TestProject
 
             var product = await _context.Product
                 .Include(p => p.Manufacturer)
-                .SingleOrDefaultAsync(m => m.ProductID == id);
+                .FindAsync(id);
             if (product == null)
             {
                 return NotFound();
@@ -76,7 +76,7 @@ namespace TestProject
                 return NotFound();
             }
 
-            var product = await _context.Product.SingleOrDefaultAsync(m => m.ProductID == id);
+            var product = await _context.Product.FindAsync(id);
             if (product == null)
             {
                 return NotFound();
@@ -131,7 +131,7 @@ namespace TestProject
 
             var product = await _context.Product
                 .Include(p => p.Manufacturer)
-                .SingleOrDefaultAsync(m => m.ProductID == id);
+                .FindAsync(id);
             if (product == null)
             {
                 return NotFound();
@@ -145,7 +145,7 @@ namespace TestProject
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> DeleteConfirmed(int id)
         {
-            var product = await _context.Product.SingleOrDefaultAsync(m => m.ProductID == id);
+            var product = await _context.Product.FindAsync(id);
             _context.Product.Remove(product);
             await _context.SaveChangesAsync();
             return RedirectToAction(nameof(Index));

--- a/test/E2E_Test/Compiler/Resources/ProductsController.txt
+++ b/test/E2E_Test/Compiler/Resources/ProductsController.txt
@@ -35,7 +35,7 @@ namespace TestProject
 
             var product = await _context.Product
                 .Include(p => p.Manufacturer)
-                .FindAsync(id);
+                .FirstOrDefaultAsync(m => m.ProductID == id);
             if (product == null)
             {
                 return NotFound();
@@ -131,7 +131,7 @@ namespace TestProject
 
             var product = await _context.Product
                 .Include(p => p.Manufacturer)
-                .FindAsync(id);
+                .FirstOrDefaultAsync(m => m.ProductID == id);
             if (product == null)
             {
                 return NotFound();

--- a/test/E2E_Test/Compiler/Resources/RazorPages/Crud/DeleteCs.txt
+++ b/test/E2E_Test/Compiler/Resources/RazorPages/Crud/DeleteCs.txt
@@ -30,7 +30,7 @@ namespace TestProject
             }
 
             Car = await _context.Car
-                .Include(c => c.Manufacturer).FindAsync(id);
+                .Include(c => c.Manufacturer).FirstOrDefaultAsync(m => m.ID == id);
 
             if (Car == null)
             {

--- a/test/E2E_Test/Compiler/Resources/RazorPages/Crud/DeleteCs.txt
+++ b/test/E2E_Test/Compiler/Resources/RazorPages/Crud/DeleteCs.txt
@@ -30,7 +30,7 @@ namespace TestProject
             }
 
             Car = await _context.Car
-                .Include(c => c.Manufacturer).SingleOrDefaultAsync(m => m.ID == id);
+                .Include(c => c.Manufacturer).FindAsync(id);
 
             if (Car == null)
             {

--- a/test/E2E_Test/Compiler/Resources/RazorPages/Crud/DetailsCs.txt
+++ b/test/E2E_Test/Compiler/Resources/RazorPages/Crud/DetailsCs.txt
@@ -29,7 +29,7 @@ namespace TestProject
             }
 
             Car = await _context.Car
-                .Include(c => c.Manufacturer).FindAsync(id);
+                .Include(c => c.Manufacturer).FirstOrDefaultAsync(m => m.ID == id);
 
             if (Car == null)
             {

--- a/test/E2E_Test/Compiler/Resources/RazorPages/Crud/DetailsCs.txt
+++ b/test/E2E_Test/Compiler/Resources/RazorPages/Crud/DetailsCs.txt
@@ -29,7 +29,7 @@ namespace TestProject
             }
 
             Car = await _context.Car
-                .Include(c => c.Manufacturer).SingleOrDefaultAsync(m => m.ID == id);
+                .Include(c => c.Manufacturer).FindAsync(id);
 
             if (Car == null)
             {

--- a/test/E2E_Test/Compiler/Resources/RazorPages/Crud/EditCs.txt
+++ b/test/E2E_Test/Compiler/Resources/RazorPages/Crud/EditCs.txt
@@ -31,7 +31,7 @@ namespace TestProject
             }
 
             Car = await _context.Car
-                .Include(c => c.Manufacturer).FindAsync(id);
+                .Include(c => c.Manufacturer).FirstOrDefaultAsync(m => m.ID == id);
 
             if (Car == null)
             {

--- a/test/E2E_Test/Compiler/Resources/RazorPages/Crud/EditCs.txt
+++ b/test/E2E_Test/Compiler/Resources/RazorPages/Crud/EditCs.txt
@@ -31,7 +31,7 @@ namespace TestProject
             }
 
             Car = await _context.Car
-                .Include(c => c.Manufacturer).SingleOrDefaultAsync(m => m.ID == id);
+                .Include(c => c.Manufacturer).FindAsync(id);
 
             if (Car == null)
             {


### PR DESCRIPTION
Fixes #300 

Make use of `FindAsync` instead of `SingleOrDefaultAsync` in the scaffolding templates. Fixes the root cause of the problem identified by @ajcvickers in https://github.com/aspnet/Docs/pull/4253.

@divega Please review.