### PR TITLE
Generate the test projects at build

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -1,9 +1,15 @@
 ﻿<Project>
   <PropertyGroup>
-    <InternalAspNetCoreSdkPackageVersion>2.0.2-beta-15516</InternalAspNetCoreSdkPackageVersion>
+    <InternalAspNetCoreSdkPackageVersion>2.0.2-beta-15522</InternalAspNetCoreSdkPackageVersion>
+    <MicrosoftApplicationInsightsAspNetCorePackageVersion>2.1.1</MicrosoftApplicationInsightsAspNetCorePackageVersion>
+    <MicrosoftAspNetCoreAuthenticationCookiesPackageVersion>2.0.1-rtm-83</MicrosoftAspNetCoreAuthenticationCookiesPackageVersion>
+    <MicrosoftAspNetCoreDiagnosticsEntityFrameworkCorePackageVersion>2.0.1-rtm-83</MicrosoftAspNetCoreDiagnosticsEntityFrameworkCorePackageVersion>
+    <MicrosoftAspNetCoreDiagnosticsPackageVersion>2.0.1-rtm-83</MicrosoftAspNetCoreDiagnosticsPackageVersion>
     <MicrosoftAspNetCoreHostingPackageVersion>2.0.1-rtm-83</MicrosoftAspNetCoreHostingPackageVersion>
+    <MicrosoftAspNetCoreIdentityEntityFrameworkCorePackageVersion>2.0.1-rtm-83</MicrosoftAspNetCoreIdentityEntityFrameworkCorePackageVersion>
     <MicrosoftAspNetCoreMvcPackageVersion>2.0.1-rtm-83</MicrosoftAspNetCoreMvcPackageVersion>
     <MicrosoftAspNetCoreMvcRazorExtensionsPackageVersion>2.0.1-rtm-83</MicrosoftAspNetCoreMvcRazorExtensionsPackageVersion>
+    <MicrosoftAspNetCorePackageVersion>2.0.1-rtm-83</MicrosoftAspNetCorePackageVersion>
     <MicrosoftAspNetCoreServerIISIntegrationPackageVersion>2.0.1-rtm-83</MicrosoftAspNetCoreServerIISIntegrationPackageVersion>
     <MicrosoftAspNetCoreServerKestrelPackageVersion>2.0.1-rtm-83</MicrosoftAspNetCoreServerKestrelPackageVersion>
     <MicrosoftAspNetCoreStaticFilesPackageVersion>2.0.1-rtm-83</MicrosoftAspNetCoreStaticFilesPackageVersion>
@@ -19,15 +25,21 @@
     <MicrosoftEntityFrameworkCoreSqlServerPackageVersion>2.0.1-rtm-83</MicrosoftEntityFrameworkCoreSqlServerPackageVersion>
     <MicrosoftExtensionsCommandLineUtilsSourcesPackageVersion>2.0.0</MicrosoftExtensionsCommandLineUtilsSourcesPackageVersion>
     <MicrosoftExtensionsConfigurationAbstractionsPackageVersion>2.0.0</MicrosoftExtensionsConfigurationAbstractionsPackageVersion>
+    <MicrosoftExtensionsConfigurationEnvironmentVariablesPackageVersion>2.0.0</MicrosoftExtensionsConfigurationEnvironmentVariablesPackageVersion>
+    <MicrosoftExtensionsConfigurationJsonPackageVersion>2.0.0</MicrosoftExtensionsConfigurationJsonPackageVersion>
+    <MicrosoftExtensionsConfigurationUserSecretsPackageVersion>2.0.0</MicrosoftExtensionsConfigurationUserSecretsPackageVersion>
     <MicrosoftExtensionsDependencyInjectionPackageVersion>2.0.0</MicrosoftExtensionsDependencyInjectionPackageVersion>
     <MicrosoftExtensionsFileProvidersEmbeddedPackageVersion>2.0.0</MicrosoftExtensionsFileProvidersEmbeddedPackageVersion>
     <MicrosoftExtensionsFileProvidersPhysicalPackageVersion>2.0.0</MicrosoftExtensionsFileProvidersPhysicalPackageVersion>
     <MicrosoftExtensionsLoggingConsolePackageVersion>2.0.0</MicrosoftExtensionsLoggingConsolePackageVersion>
     <MicrosoftExtensionsLoggingDebugPackageVersion>2.0.0</MicrosoftExtensionsLoggingDebugPackageVersion>
+    <MicrosoftExtensionsLoggingPackageVersion>2.0.0</MicrosoftExtensionsLoggingPackageVersion>
+    <MicrosoftExtensionsOptionsConfigurationExtensionsPackageVersion>2.0.0</MicrosoftExtensionsOptionsConfigurationExtensionsPackageVersion>
     <MicrosoftNETTestSdkPackageVersion>15.3.0</MicrosoftNETTestSdkPackageVersion>
+    <MicrosoftVisualStudioWebBrowserLinkPackageVersion>2.0.1-rtm-83</MicrosoftVisualStudioWebBrowserLinkPackageVersion>
+    <MoqPackageVersion>4.7.49</MoqPackageVersion>
     <NewtonsoftJsonRuntimePackageVersion>10.0.1</NewtonsoftJsonRuntimePackageVersion>
     <NewtonsoftJsonToolingPackageVersion>9.0.1</NewtonsoftJsonToolingPackageVersion>
-    <MoqPackageVersion>4.7.49</MoqPackageVersion>
     <NuGetFrameworksPackageVersion>4.0.0</NuGetFrameworksPackageVersion>
     <XunitPackageVersion>2.3.0-beta2-build3683</XunitPackageVersion>
     <XunitRunnerVisualStudioPackageVersion>2.3.0-beta2-build1317</XunitRunnerVisualStudioPackageVersion>

--- a/test/Directory.Build.targets
+++ b/test/Directory.Build.targets
@@ -58,8 +58,8 @@
       TemplateFile="$(TestProjectTemplateFile)"
       Properties="$(TestProjectProperties)"
       OutputPath="$(GeneratedTestProjectFile)">
-      <Output TaskParameter="FileWrites" ItemName="FileWrites" />
-      <Output TaskParameter="FileWrites" ItemName="Compile" />
+      <Output TaskParameter="OutputPath" ItemName="FileWrites" />
+      <Output TaskParameter="OutputPath" ItemName="Compile" />
     </Sdk_GenerateFileFromTemplate>
 
   </Target>

--- a/test/Directory.Build.targets
+++ b/test/Directory.Build.targets
@@ -1,0 +1,66 @@
+<Project>
+  <Import Project="..\Directory.Build.targets" />
+
+  <PropertyGroup>
+    <TestProjectTemplateFile>$(MSBuildThisFileDirectory)shared\MsBuildProjectStrings.cs.in</TestProjectTemplateFile>
+    <GeneratedTestProjectFile>$(IntermediateOutputPath)MSBuildProjectStrings.cs</GeneratedTestProjectFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="$(TestProjectTemplateFile)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <TestProjectGenInputs Include="$(ProjectAssetsFile)" />
+    <TestProjectGenInputs Include="$(MSBuildAllProjects)" />
+    <TestProjectGenInputs Include="$(TestProjectTemplateFile)" />
+    <TestProjectGenInputs Include="$(MSBuildThisFileDirectory)..\build\dependencies.props" />
+    <TestProjectGenInputs Include="$(MSBuildThisFileDirectory)..\build\sources.props" />
+    <TestProjectGenInputs Include="$(DotNetPackageVersionPropsPath)" Condition=" '$(DotNetPackageVersionPropsPath)' != '' " />
+    <TestProjectGenInputs Include="$(DotNetRestoreSourcePropsPath)" Condition=" '$(DotNetRestoreSourcePropsPath)' != '' " />
+  </ItemGroup>
+
+  <Target Name="GenerateTestProject" BeforeTargets="CoreCompile" Inputs="@(TestProjectGenInputs)" Outputs="$(GeneratedTestProjectFile)">
+    <PropertyGroup>
+      <RestoreSources>
+        $(RestoreSources);
+        $(MSBuildThisFileDirectory)..\artifacts\build;
+      </RestoreSources>
+      <TestProjectProperties>
+        RestoreSources=$([MSBuild]::Escape($(RestoreSources.Trim())));
+        RuntimeFrameworkVersion=$(RuntimeFrameworkVersion);
+        MicrosoftApplicationInsightsAspNetCorePackageVersion=$(MicrosoftApplicationInsightsAspNetCorePackageVersion);
+        MicrosoftAspNetCoreAuthenticationCookiesPackageVersion=$(MicrosoftAspNetCoreAuthenticationCookiesPackageVersion);
+        MicrosoftAspNetCoreDiagnosticsEntityFrameworkCorePackageVersion=$(MicrosoftAspNetCoreDiagnosticsEntityFrameworkCorePackageVersion);
+        MicrosoftAspNetCoreDiagnosticsPackageVersion=$(MicrosoftAspNetCoreDiagnosticsPackageVersion);
+        MicrosoftAspNetCoreIdentityEntityFrameworkCorePackageVersion=$(MicrosoftAspNetCoreIdentityEntityFrameworkCorePackageVersion);
+        MicrosoftAspNetCoreMvcPackageVersion=$(MicrosoftAspNetCoreMvcPackageVersion);
+        MicrosoftAspNetCorePackageVersion=$(MicrosoftAspNetCorePackageVersion);
+        MicrosoftAspNetCoreServerIISIntegrationPackageVersion=$(MicrosoftAspNetCoreServerIISIntegrationPackageVersion);
+        MicrosoftAspNetCoreServerKestrelPackageVersion=$(MicrosoftAspNetCoreServerKestrelPackageVersion);
+        MicrosoftAspNetCoreStaticFilesPackageVersion=$(MicrosoftAspNetCoreStaticFilesPackageVersion);
+        MicrosoftEntityFrameworkCoreDesignPackageVersion=$(MicrosoftEntityFrameworkCoreDesignPackageVersion);
+        MicrosoftEntityFrameworkCoreSqlServerPackageVersion=$(MicrosoftEntityFrameworkCoreSqlServerPackageVersion);
+        MicrosoftExtensionsConfigurationEnvironmentVariablesPackageVersion=$(MicrosoftExtensionsConfigurationEnvironmentVariablesPackageVersion);
+        MicrosoftExtensionsConfigurationJsonPackageVersion=$(MicrosoftExtensionsConfigurationJsonPackageVersion);
+        MicrosoftExtensionsConfigurationUserSecretsPackageVersion=$(MicrosoftExtensionsConfigurationUserSecretsPackageVersion);
+        MicrosoftExtensionsLoggingConsolePackageVersion=$(MicrosoftExtensionsLoggingConsolePackageVersion);
+        MicrosoftExtensionsLoggingDebugPackageVersion=$(MicrosoftExtensionsLoggingDebugPackageVersion);
+        MicrosoftExtensionsLoggingPackageVersion=$(MicrosoftExtensionsLoggingPackageVersion);
+        MicrosoftExtensionsOptionsConfigurationExtensionsPackageVersion=$(MicrosoftExtensionsOptionsConfigurationExtensionsPackageVersion);
+        MicrosoftVisualStudioWebBrowserLinkPackageVersion=$(MicrosoftVisualStudioWebBrowserLinkPackageVersion);
+        MicrosoftVisualStudioWebCodeGenerationDesignPackageVersion=$(Version);
+        MicrosoftVisualStudioWebCodeGenerationToolsPackageVersion=$(Version);
+      </TestProjectProperties>
+    </PropertyGroup>
+
+    <Sdk_GenerateFileFromTemplate
+      TemplateFile="$(TestProjectTemplateFile)"
+      Properties="$(TestProjectProperties)"
+      OutputPath="$(GeneratedTestProjectFile)">
+      <Output TaskParameter="FileWrites" ItemName="FileWrites" />
+      <Output TaskParameter="FileWrites" ItemName="Compile" />
+    </Sdk_GenerateFileFromTemplate>
+
+  </Target>
+</Project>

--- a/test/Shared/MsBuildProjectSetupHelper.cs
+++ b/test/Shared/MsBuildProjectSetupHelper.cs
@@ -21,42 +21,13 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration
 
         private static object _syncObj = new object();
 
-        private string AspNetCoreVersion
-        {
-            get
-            {
-                var aspnetCoreLib = DependencyContext
-                    .Default
-                    .CompileLibraries
-                    .FirstOrDefault(l => l.Name.StartsWith("Microsoft.Extensions.FileProviders.Abstractions", StringComparison.OrdinalIgnoreCase));
-
-                return aspnetCoreLib?.Version;
-            }
-        }
-
-        private string RuntimeFrameworkVersion =>
-            DependencyContext
-                .Default
-                .RuntimeLibraries
-                .FirstOrDefault(l => l.Name.StartsWith("Microsoft.NETCore.App", StringComparison.OrdinalIgnoreCase))
-                ?.Version;
-
-        private string CodeGenerationVersion
-        {
-            get
-            {
-                var informationalVersionAttr = this.GetType().Assembly.GetCustomAttributes(typeof(AssemblyInformationalVersionAttribute), false).First();
-                return ((AssemblyInformationalVersionAttribute)informationalVersionAttr).InformationalVersion;
-            }
-        }
-
         public void SetupProjects(TemporaryFileProvider fileProvider, ITestOutputHelper output, bool fullFramework = false)
         {
             Directory.CreateDirectory(Path.Combine(fileProvider.Root, "Root"));
             Directory.CreateDirectory(Path.Combine(fileProvider.Root, "Library1"));
-            
+
             var rootProjectTxt = fullFramework ? MsBuildProjectStrings.RootNet45ProjectTxt : MsBuildProjectStrings.RootProjectTxt;
-            fileProvider.Add($"Root/{MsBuildProjectStrings.RootProjectName}", string.Format(rootProjectTxt, AspNetCoreVersion, CodeGenerationVersion, RuntimeFrameworkVersion, "2.0.1-*"));
+            fileProvider.Add($"Root/{MsBuildProjectStrings.RootProjectName}", rootProjectTxt);
             fileProvider.Add($"Root/Startup.cs", MsBuildProjectStrings.StartupTxt);
             fileProvider.Add($"Root/{MsBuildProjectStrings.ProgramFileName}", MsBuildProjectStrings.ProgramFileText);
 
@@ -99,9 +70,9 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration
         {
             Directory.CreateDirectory(Path.Combine(fileProvider.Root, "Root"));
             Directory.CreateDirectory(Path.Combine(fileProvider.Root, "Library1"));
-            
+
             var rootProjectTxt = MsBuildProjectStrings.RootProjectTxtWithoutEF;
-            fileProvider.Add($"Root/{MsBuildProjectStrings.RootProjectName}", string.Format(rootProjectTxt, AspNetCoreVersion, CodeGenerationVersion, RuntimeFrameworkVersion, "2.0.1-*"));
+            fileProvider.Add($"Root/{MsBuildProjectStrings.RootProjectName}", rootProjectTxt);
             fileProvider.Add($"Root/Startup.cs", MsBuildProjectStrings.StartupTxtWithoutEf);
             fileProvider.Add($"Root/{MsBuildProjectStrings.ProgramFileName}", MsBuildProjectStrings.ProgramFileText);
 

--- a/test/Shared/MsBuildProjectStrings.cs.in
+++ b/test/Shared/MsBuildProjectStrings.cs.in
@@ -102,7 +102,6 @@ public const string RootProjectTxtWithoutEF = @"
     <RuntimeIdentifier>win7-x64</RuntimeIdentifier>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <NoWarn>NU1605</NoWarn>
-    <RuntimeFrameworkVersion>{2}</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Shared/MsBuildProjectStrings.cs.in
+++ b/test/Shared/MsBuildProjectStrings.cs.in
@@ -10,45 +10,37 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration
     {
         public const string RootProjectName = "Test.csproj";
         public const string RootProjectTxt = @"
-<Project ToolsVersion=""15.0"" Sdk=""Microsoft.NET.Sdk.Web"">
+<Project Sdk=""Microsoft.NET.Sdk.Web"">
 
   <PropertyGroup>
-    <RestoreSources>$(DotNetRestoreSources)</RestoreSources>
-    <RestoreSources Condition=""'$(DotNetBuildOffline)' != 'true'"">
-      $(RestoreSources);
-      https://dotnet.myget.org/F/aspnet-2-0-2-october2017-patch/api/v3/index.json;
-      https://dotnet.myget.org/F/aspnetcore-master/api/v3/index.json;
-      https://dotnet.myget.org/F/aspnetcore-tools/api/v3/index.json;
-      https://api.nuget.org/v3/index.json;
-    </RestoreSources>
-
+    <RestoreSources>${RestoreSources}</RestoreSources>
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <RootNamespace>Microsoft.TestProject</RootNamespace>
     <ProjectName>TestProject</ProjectName>
     <NoWarn>NU1605</NoWarn>
-    <RuntimeFrameworkVersion>{2}</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>${RuntimeFrameworkVersion}</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include=""Microsoft.ApplicationInsights.AspNetCore"" Version=""2.1.1"" />
-    <PackageReference Include=""Microsoft.AspNetCore"" Version=""{3}"" />
-    <PackageReference Include=""Microsoft.AspNetCore.Mvc"" Version=""{3}"" />
-    <PackageReference Include=""Microsoft.AspNetCore.StaticFiles"" Version=""{3}"" />
-    <PackageReference Include=""Microsoft.Extensions.Logging.Debug"" Version=""{0}"" />
-    <PackageReference Include=""Microsoft.VisualStudio.Web.BrowserLink"" Version=""{3}"" />
+    <PackageReference Include=""Microsoft.ApplicationInsights.AspNetCore"" Version=""${MicrosoftApplicationInsightsAspNetCorePackageVersion}"" />
+    <PackageReference Include=""Microsoft.AspNetCore"" Version=""${MicrosoftAspNetCorePackageVersion}"" />
+    <PackageReference Include=""Microsoft.AspNetCore.Mvc"" Version=""${MicrosoftAspNetCoreMvcPackageVersion}"" />
+    <PackageReference Include=""Microsoft.AspNetCore.StaticFiles"" Version=""${MicrosoftAspNetCoreStaticFilesPackageVersion}"" />
+    <PackageReference Include=""Microsoft.Extensions.Logging.Debug"" Version=""${MicrosoftExtensionsLoggingDebugPackageVersion}"" />
+    <PackageReference Include=""Microsoft.VisualStudio.Web.BrowserLink"" Version=""${MicrosoftVisualStudioWebBrowserLinkPackageVersion}"" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include=""Microsoft.AspNetCore.Authentication.Cookies"" Version=""{3}"" />
-    <PackageReference Include=""Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore"" Version=""{3}"" />
-    <PackageReference Include=""Microsoft.AspNetCore.Identity.EntityFrameworkCore"" Version=""{3}"" />
-    <PackageReference Include=""Microsoft.EntityFrameworkCore.Design"" Version=""{3}"" />
-    <PackageReference Include=""Microsoft.EntityFrameworkCore.SqlServer"" Version=""{3}"" />
-    <PackageReference Include=""Microsoft.Extensions.Configuration.UserSecrets"" Version=""{0}"" />
-    <PackageReference Include=""Microsoft.VisualStudio.Web.CodeGeneration.Design"" Version=""{1}"" />
-    <PackageReference Include=""Microsoft.VisualStudio.Web.CodeGeneration.Tools"" Version=""{1}"" />
+    <PackageReference Include=""Microsoft.AspNetCore.Authentication.Cookies"" Version=""${MicrosoftAspNetCoreAuthenticationCookiesPackageVersion}"" />
+    <PackageReference Include=""Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore"" Version=""${MicrosoftAspNetCoreDiagnosticsEntityFrameworkCorePackageVersion}"" />
+    <PackageReference Include=""Microsoft.AspNetCore.Identity.EntityFrameworkCore"" Version=""${MicrosoftAspNetCoreIdentityEntityFrameworkCorePackageVersion}"" />
+    <PackageReference Include=""Microsoft.EntityFrameworkCore.Design"" Version=""${MicrosoftEntityFrameworkCoreDesignPackageVersion}"" />
+    <PackageReference Include=""Microsoft.EntityFrameworkCore.SqlServer"" Version=""${MicrosoftEntityFrameworkCoreSqlServerPackageVersion}"" />
+    <PackageReference Include=""Microsoft.Extensions.Configuration.UserSecrets"" Version=""${MicrosoftExtensionsConfigurationUserSecretsPackageVersion}"" />
+    <PackageReference Include=""Microsoft.VisualStudio.Web.CodeGeneration.Design"" Version=""${MicrosoftVisualStudioWebCodeGenerationDesignPackageVersion}"" />
+    <PackageReference Include=""Microsoft.VisualStudio.Web.CodeGeneration.Tools"" Version=""${MicrosoftVisualStudioWebCodeGenerationToolsPackageVersion}"" />
   </ItemGroup>
   <ItemGroup>
-    <DotNetCliToolReference Include=""Microsoft.VisualStudio.Web.CodeGeneration.Tools"" Version=""{1}"" />
+    <DotNetCliToolReference Include=""Microsoft.VisualStudio.Web.CodeGeneration.Tools"" Version=""${MicrosoftVisualStudioWebCodeGenerationToolsPackageVersion}"" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include=""..\Library1\Library1.csproj"" />
@@ -63,38 +55,30 @@ public const string RootProjectTxtWithoutEF = @"
 <Project ToolsVersion=""15.0"" Sdk=""Microsoft.NET.Sdk.Web"">
 
   <PropertyGroup>
-    <RestoreSources>$(DotNetRestoreSources)</RestoreSources>
-    <RestoreSources Condition=""'$(DotNetBuildOffline)' != 'true'"">
-      $(RestoreSources);
-      https://dotnet.myget.org/F/aspnet-2-0-2-october2017-patch/api/v3/index.json;
-      https://dotnet.myget.org/F/aspnetcore-master/api/v3/index.json;
-      https://dotnet.myget.org/F/aspnetcore-tools/api/v3/index.json;
-      https://api.nuget.org/v3/index.json;
-    </RestoreSources>
-
+    <RestoreSources>${RestoreSources}</RestoreSources>
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <RootNamespace>Microsoft.TestProject</RootNamespace>
     <ProjectName>TestProject</ProjectName>
     <NoWarn>NU1605</NoWarn>
-    <RuntimeFrameworkVersion>{2}</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>${RuntimeFrameworkVersion}</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include=""Microsoft.ApplicationInsights.AspNetCore"" Version=""2.1.1"" />
-    <PackageReference Include=""Microsoft.AspNetCore"" Version=""{3}"" />
-    <PackageReference Include=""Microsoft.AspNetCore.Mvc"" Version=""{3}"" />
-    <PackageReference Include=""Microsoft.AspNetCore.StaticFiles"" Version=""{3}"" />
-    <PackageReference Include=""Microsoft.Extensions.Logging.Debug"" Version=""{0}"" />
-    <PackageReference Include=""Microsoft.VisualStudio.Web.BrowserLink"" Version=""{3}"" />
+    <PackageReference Include=""Microsoft.ApplicationInsights.AspNetCore"" Version=""${MicrosoftApplicationInsightsAspNetCorePackageVersion}"" />
+    <PackageReference Include=""Microsoft.AspNetCore"" Version=""${MicrosoftAspNetCorePackageVersion}"" />
+    <PackageReference Include=""Microsoft.AspNetCore.Mvc"" Version=""${MicrosoftAspNetCoreMvcPackageVersion}"" />
+    <PackageReference Include=""Microsoft.AspNetCore.StaticFiles"" Version=""${MicrosoftAspNetCoreStaticFilesPackageVersion}"" />
+    <PackageReference Include=""Microsoft.Extensions.Logging.Debug"" Version=""${MicrosoftExtensionsLoggingDebugPackageVersion}"" />
+    <PackageReference Include=""Microsoft.VisualStudio.Web.BrowserLink"" Version=""${MicrosoftVisualStudioWebBrowserLinkPackageVersion}"" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include=""Microsoft.AspNetCore.Authentication.Cookies"" Version=""{3}"" />
-    <PackageReference Include=""Microsoft.Extensions.Configuration.UserSecrets"" Version=""{0}"" />
-    <PackageReference Include=""Microsoft.VisualStudio.Web.CodeGeneration.Design"" Version=""{1}"" />
-    <PackageReference Include=""Microsoft.VisualStudio.Web.CodeGeneration.Tools"" Version=""{1}"" />
+    <PackageReference Include=""Microsoft.AspNetCore.Authentication.Cookies"" Version=""${MicrosoftAspNetCoreAuthenticationCookiesPackageVersion}"" />
+    <PackageReference Include=""Microsoft.Extensions.Configuration.UserSecrets"" Version=""${MicrosoftExtensionsConfigurationUserSecretsPackageVersion}"" />
+    <PackageReference Include=""Microsoft.VisualStudio.Web.CodeGeneration.Design"" Version=""${MicrosoftVisualStudioWebCodeGenerationDesignPackageVersion}"" />
+    <PackageReference Include=""Microsoft.VisualStudio.Web.CodeGeneration.Tools"" Version=""${MicrosoftVisualStudioWebCodeGenerationToolsPackageVersion}"" />
   </ItemGroup>
   <ItemGroup>
-    <DotNetCliToolReference Include=""Microsoft.VisualStudio.Web.CodeGeneration.Tools"" Version=""{1}"" />
+    <DotNetCliToolReference Include=""Microsoft.VisualStudio.Web.CodeGeneration.Tools"" Version=""${MicrosoftVisualStudioWebCodeGenerationToolsPackageVersion}"" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include=""..\Library1\Library1.csproj"" />
@@ -108,14 +92,7 @@ public const string RootProjectTxtWithoutEF = @"
         public const string RootNet45ProjectTxt = @"
 <Project Sdk=""Microsoft.NET.Sdk"">
   <PropertyGroup>
-    <RestoreSources>$(DotNetRestoreSources)</RestoreSources>
-    <RestoreSources Condition=""'$(DotNetBuildOffline)' != 'true'"">
-      $(RestoreSources);
-      https://dotnet.myget.org/F/aspnet-2-0-2-october2017-patch/api/v3/index.json;
-      https://dotnet.myget.org/F/aspnetcore-master/api/v3/index.json;
-      https://dotnet.myget.org/F/aspnetcore-tools/api/v3/index.json;
-      https://api.nuget.org/v3/index.json;
-    </RestoreSources>
+    <RestoreSources>${RestoreSources}</RestoreSources>
 
     <RootNamespace>Microsoft.TestProject</RootNamespace>
     <ProjectName>TestProject</ProjectName>
@@ -133,19 +110,19 @@ public const string RootProjectTxtWithoutEF = @"
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include=""Microsoft.AspNetCore.Diagnostics"" Version=""{3}"" />
-    <PackageReference Include=""Microsoft.AspNetCore.Mvc"" Version=""{3}"" />
-    <PackageReference Include=""Microsoft.AspNetCore.Server.IISIntegration"" Version=""{3}"" />
-    <PackageReference Include=""Microsoft.AspNetCore.Server.Kestrel"" Version=""{3}"" />
-    <PackageReference Include=""Microsoft.AspNetCore.StaticFiles"" Version=""{3}"" />
-    <PackageReference Include=""Microsoft.Extensions.Configuration.EnvironmentVariables"" Version=""{0}"" />
-    <PackageReference Include=""Microsoft.Extensions.Configuration.Json"" Version=""{0}"" />
-    <PackageReference Include=""Microsoft.Extensions.Logging"" Version=""{0}"" />
-    <PackageReference Include=""Microsoft.Extensions.Logging.Console"" Version=""{0}"" />
-    <PackageReference Include=""Microsoft.Extensions.Logging.Debug"" Version=""{0}"" />
-    <PackageReference Include=""Microsoft.Extensions.Options.ConfigurationExtensions"" Version=""{0}"" />
-    <PackageReference Include=""Microsoft.VisualStudio.Web.CodeGeneration.Design"" Version=""{1}"" />
-    <DotNetCliToolReference Include=""Microsoft.VisualStudio.Web.CodeGeneration.Tools"" Version=""{1}"" />
+    <PackageReference Include=""Microsoft.AspNetCore.Diagnostics"" Version=""${MicrosoftAspNetCoreDiagnosticsPackageVersion}"" />
+    <PackageReference Include=""Microsoft.AspNetCore.Mvc"" Version=""${MicrosoftAspNetCoreMvcPackageVersion}"" />
+    <PackageReference Include=""Microsoft.AspNetCore.Server.IISIntegration"" Version=""${MicrosoftAspNetCoreServerIISIntegrationPackageVersion}"" />
+    <PackageReference Include=""Microsoft.AspNetCore.Server.Kestrel"" Version=""${MicrosoftAspNetCoreServerKestrelPackageVersion}"" />
+    <PackageReference Include=""Microsoft.AspNetCore.StaticFiles"" Version=""${MicrosoftAspNetCoreStaticFilesPackageVersion}"" />
+    <PackageReference Include=""Microsoft.Extensions.Configuration.EnvironmentVariables"" Version=""${MicrosoftExtensionsConfigurationEnvironmentVariablesPackageVersion}"" />
+    <PackageReference Include=""Microsoft.Extensions.Configuration.Json"" Version=""${MicrosoftExtensionsConfigurationJsonPackageVersion}"" />
+    <PackageReference Include=""Microsoft.Extensions.Logging"" Version=""${MicrosoftExtensionsLoggingPackageVersion}"" />
+    <PackageReference Include=""Microsoft.Extensions.Logging.Console"" Version=""${MicrosoftExtensionsLoggingConsolePackageVersion}"" />
+    <PackageReference Include=""Microsoft.Extensions.Logging.Debug"" Version=""${MicrosoftExtensionsLoggingDebugPackageVersion}"" />
+    <PackageReference Include=""Microsoft.Extensions.Options.ConfigurationExtensions"" Version=""${MicrosoftExtensionsOptionsConfigurationExtensionsPackageVersion}"" />
+    <PackageReference Include=""Microsoft.VisualStudio.Web.CodeGeneration.Design"" Version=""${MicrosoftVisualStudioWebCodeGenerationDesignPackageVersion}"" />
+    <DotNetCliToolReference Include=""Microsoft.VisualStudio.Web.CodeGeneration.Tools"" Version=""${MicrosoftVisualStudioWebCodeGenerationToolsPackageVersion}"" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include=""..\Library1\Library1.csproj"" />
@@ -287,14 +264,7 @@ namespace WebApplication1
         public const string LibraryProjectTxt = @"
 <Project Sdk=""Microsoft.NET.Sdk"">
   <PropertyGroup>
-    <RestoreSources>$(DotNetRestoreSources)</RestoreSources>
-    <RestoreSources Condition=""'$(DotNetBuildOffline)' != 'true'"">
-      $(RestoreSources);
-      https://dotnet.myget.org/F/aspnet-2-0-2-october2017-patch/api/v3/index.json;
-      https://dotnet.myget.org/F/aspnetcore-master/api/v3/index.json;
-      https://dotnet.myget.org/F/aspnetcore-tools/api/v3/index.json;
-      https://api.nuget.org/v3/index.json;
-    </RestoreSources>
+    <RestoreSources>${RestoreSources}</RestoreSources>
 
     <RootNamespace>Microsoft.Library</RootNamespace>
     <ProjectName>Library1</ProjectName>

--- a/version.props
+++ b/version.props
@@ -4,6 +4,7 @@
     <VersionSuffix>rtm</VersionSuffix>
     <PackageVersion Condition="'$(IsFinalBuild)' == 'true' AND '$(VersionSuffix)' == 'rtm' ">$(VersionPrefix)</PackageVersion>
     <PackageVersion Condition="'$(IsFinalBuild)' == 'true' AND '$(VersionSuffix)' != 'rtm' ">$(VersionPrefix)-$(VersionSuffix)-final</PackageVersion>
+    <BuildNumber Condition=" '$(BuildNumber)' == '' ">t000</BuildNumber>
     <VersionSuffix Condition="'$(VersionSuffix)' != '' And '$(BuildNumber)' != ''">$(VersionSuffix)-$(BuildNumber)</VersionSuffix>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Depends on https://github.com/aspnet/BuildTools/pull/416

Instead of manually updating the hard-coded test packages every time we change patch versions, this will generate the sample test projects using the versions in dependencies.props.