### PR TITLE
Use MSBuild to set NuGet feeds instead of NuGet.config

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,6 +5,7 @@
 
   <Import Project="version.props" />
   <Import Project="build\dependencies.props" />
+  <Import Project="build\sources.props" />
 
   <PropertyGroup>
     <RepositoryUrl>https://github.com/aspnet/scaffolding</RepositoryUrl>

--- a/NuGet.config
+++ b/NuGet.config
@@ -2,8 +2,6 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="AspNetCore" value="https://dotnet.myget.org/F/aspnetcore-ci-dev/api/v3/index.json" />
-    <add key="AspNetCoreTools" value="https://dotnet.myget.org/F/aspnetcore-tools/api/v3/index.json" />
-    <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
+    <!-- Restore sources should be defined in build/sources.props. -->
   </packageSources>
 </configuration>

--- a/build/sources.props
+++ b/build/sources.props
@@ -1,0 +1,16 @@
+﻿<Project>
+  <Import Project="$(DotNetRestoreSourcePropsPath)" Condition="'$(DotNetRestoreSourcePropsPath)' != ''"/>
+
+  <PropertyGroup Label="RestoreSources">
+    <RestoreSources>$(DotNetRestoreSources)</RestoreSources>
+    <RestoreSources Condition="'$(DotNetBuildOffline)' != 'true' AND '$(AspNetUniverseBuildOffline)' != 'true' ">
+      $(RestoreSources);
+      https://dotnet.myget.org/F/aspnetcore-ci-dev/api/v3/index.json;
+      https://dotnet.myget.org/F/aspnetcore-tools/api/v3/index.json;
+    </RestoreSources>
+    <RestoreSources Condition="'$(DotNetBuildOffline)' != 'true'">
+      $(RestoreSources);
+      https://api.nuget.org/v3/index.json;
+    </RestoreSources>
+  </PropertyGroup>
+</Project>

--- a/test/Ext.ProjectModel.Tests/NuGet.config
+++ b/test/Ext.ProjectModel.Tests/NuGet.config
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <add key="msbuild" value="https://dotnet.myget.org/F/msbuild/api/v3/index.json" />
- </packageSources>
-</configuration>

--- a/test/Shared/MsBuildProjectSetupHelper.cs
+++ b/test/Shared/MsBuildProjectSetupHelper.cs
@@ -21,39 +21,6 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration
 #endif
 
         private static object _syncObj = new object();
-        private static string _nugetConfigText;
-        private static string NuGetConfigText
-        {
-            get
-            {
-                if (string.IsNullOrEmpty(_nugetConfigText))
-                {
-                    lock (_syncObj)
-                    {
-                        if (string.IsNullOrEmpty(_nugetConfigText))
-                        {
-                            string artifactsDir = null;
-                            string nugetConfigPath = null;
-                            var current = new DirectoryInfo(AppContext.BaseDirectory);
-                            while (current != null)
-                            {
-                                if (File.Exists(Path.Combine(current.FullName, "Scaffolding.sln")))
-                                {
-                                    artifactsDir = Path.Combine(current.FullName, "artifacts", "build");
-                                    nugetConfigPath = Path.Combine(current.FullName, "NuGet.config");
-                                    break;
-                                }
-                                current = current.Parent;
-                            }
-
-                            _nugetConfigText = GetNugetConfigTxt(artifactsDir, nugetConfigPath);
-                        }
-                    }
-                }
-
-                return _nugetConfigText;
-            }
-        }
 
         private static string _globalJsonText;
         private static string GlobalJsonText
@@ -87,31 +54,11 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration
             }
         }
 
-        private static string GetNugetConfigTxt(string artifactsDir, string nugetConfigPath)
-        {
-            var xmlDoc = new XmlDocument();
-            xmlDoc.Load(nugetConfigPath);
-
-            var root = xmlDoc.DocumentElement;
-            var packageSources = root.SelectSingleNode("packageSources");
-            var newSource = xmlDoc.CreateElement("add");
-            newSource.SetAttribute("key", "local");
-            newSource.SetAttribute("value", artifactsDir);
-            packageSources.AppendChild(newSource);
-
-            using (var sw = new StringWriter())
-            {
-                xmlDoc.WriteContentTo(new XmlTextWriter(sw));
-                return sw.ToString();
-            }
-        }
-
         public void SetupProjects(TemporaryFileProvider fileProvider, ITestOutputHelper output, bool fullFramework = false)
         {
             Directory.CreateDirectory(Path.Combine(fileProvider.Root, "Root"));
             Directory.CreateDirectory(Path.Combine(fileProvider.Root, "Library1"));
             fileProvider.Add("global.json", GlobalJsonText);
-            fileProvider.Add("NuGet.config", NuGetConfigText);
 
             var rootProjectTxt = fullFramework ? MsBuildProjectStrings.RootNet45ProjectTxt : MsBuildProjectStrings.RootProjectTxt;
             fileProvider.Add($"Root/{MsBuildProjectStrings.RootProjectName}", rootProjectTxt);
@@ -158,7 +105,6 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration
             Directory.CreateDirectory(Path.Combine(fileProvider.Root, "Root"));
             Directory.CreateDirectory(Path.Combine(fileProvider.Root, "Library1"));
             fileProvider.Add("global.json", GlobalJsonText);
-            fileProvider.Add("NuGet.config", NuGetConfigText);
 
             var rootProjectTxt = MsBuildProjectStrings.RootProjectTxtWithoutEF;
             fileProvider.Add($"Root/{MsBuildProjectStrings.RootProjectName}", rootProjectTxt);

--- a/test/Shared/MsBuildProjectStrings.cs.in
+++ b/test/Shared/MsBuildProjectStrings.cs.in
@@ -13,6 +13,7 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration
 <Project Sdk=""Microsoft.NET.Sdk.Web"">
 
   <PropertyGroup>
+    <RestoreSources>${RestoreSources}</RestoreSources>
     <TargetFramework>${TargetFramework}</TargetFramework>
     <RootNamespace>Microsoft.TestProject</RootNamespace>
     <ProjectName>TestProject</ProjectName>
@@ -54,6 +55,7 @@ public const string RootProjectTxtWithoutEF = @"
 <Project ToolsVersion=""15.0"" Sdk=""Microsoft.NET.Sdk.Web"">
 
   <PropertyGroup>
+    <RestoreSources>${RestoreSources}</RestoreSources>
     <TargetFramework>${TargetFramework}</TargetFramework>
     <RootNamespace>Microsoft.TestProject</RootNamespace>
     <ProjectName>TestProject</ProjectName>
@@ -90,7 +92,7 @@ public const string RootProjectTxtWithoutEF = @"
         public const string RootNet45ProjectTxt = @"
 <Project Sdk=""Microsoft.NET.Sdk"">
   <PropertyGroup>
-
+    <RestoreSources>${RestoreSources}</RestoreSources>
     <RootNamespace>Microsoft.TestProject</RootNamespace>
     <ProjectName>TestProject</ProjectName>
     <OutputType>EXE</OutputType>
@@ -259,7 +261,7 @@ namespace WebApplication1
         public const string LibraryProjectTxt = @"
 <Project Sdk=""Microsoft.NET.Sdk"">
   <PropertyGroup>
-
+    <RestoreSources>${RestoreSources}</RestoreSources>
     <RootNamespace>Microsoft.Library</RootNamespace>
     <ProjectName>Library1</ProjectName>
     <OutputType>Library</OutputType>


### PR DESCRIPTION
Part of https://github.com/aspnet/Coherence-Signed/issues/682

This backports some fixes already in release/2.0.0 to better support orchestrated build.