### PR TITLE
Use Process.MainModule, not FX_DEPS_FILE to find dotnet.exe

### DIFF
--- a/src/Shared/Cli.Utils/DotNetMuxer.cs
+++ b/src/Shared/Cli.Utils/DotNetMuxer.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
 
@@ -29,28 +30,14 @@ namespace Microsoft.Extensions.Internal
                 fileName += ".exe";
             }
 
-            var fxDepsFile = AppContext.GetData("FX_DEPS_FILE") as string;
-
-            if (string.IsNullOrEmpty(fxDepsFile))
+            var mainModule = Process.GetCurrentProcess().MainModule;
+            if (!string.IsNullOrEmpty(mainModule?.FileName)
+                && Path.GetFileName(mainModule.FileName).Equals(fileName, StringComparison.OrdinalIgnoreCase))
             {
-                return null;
+                return mainModule.FileName;
             }
 
-            var muxerDir = new FileInfo(fxDepsFile) // Microsoft.NETCore.App.deps.json
-                .Directory? // (version)
-                .Parent? // Microsoft.NETCore.App
-                .Parent? // shared
-                .Parent; // DOTNET_HOME
-
-            if (muxerDir == null)
-            {
-                return null;
-            }
-
-            var muxer = Path.Combine(muxerDir.FullName, fileName);
-            return File.Exists(muxer)
-                ? muxer
-                : null;
+            return null;
         }
     }
 }


### PR DESCRIPTION
This is why tests might fail on AppVeyor but not other machines. See also https://github.com/aspnet/Common/pull/299