### PR TITLE
Bug 406400 add textarea

### DIFF
--- a/Scaffolding.sln
+++ b/Scaffolding.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.27120.0
+VisualStudioVersion = 15.0.26730.10
 MinimumVisualStudioVersion = 15.0.26730.03
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{A4057ACF-27F0-4724-963B-44548B6BC4E9}"
 	ProjectSection(SolutionItems) = preProject
@@ -650,6 +650,9 @@ Global
 		{B2FB25DC-DD8D-4A0E-AF9F-CCBC6ED75ED0} = {4B56CCB9-2693-492A-A0C5-B4D15DDF00A4}
 		{867AB4D3-0EE0-4A3E-B0F0-78E2B612495A} = {4B56CCB9-2693-492A-A0C5-B4D15DDF00A4}
 		{8A75336B-A55F-42F6-B8BA-B55EFDA39705} = {4B56CCB9-2693-492A-A0C5-B4D15DDF00A4}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {8DA7AF03-FFF5-4EB3-A7D4-CDBD49A0D4B9}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {26BCDDB3-5505-4903-9D87-C942ED0D03E6}

--- a/Scaffolding.sln
+++ b/Scaffolding.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26730.10
+VisualStudioVersion = 15.0.27120.0
 MinimumVisualStudioVersion = 15.0.26730.03
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{A4057ACF-27F0-4724-963B-44548B6BC4E9}"
 	ProjectSection(SolutionItems) = preProject
@@ -650,9 +650,6 @@ Global
 		{B2FB25DC-DD8D-4A0E-AF9F-CCBC6ED75ED0} = {4B56CCB9-2693-492A-A0C5-B4D15DDF00A4}
 		{867AB4D3-0EE0-4A3E-B0F0-78E2B612495A} = {4B56CCB9-2693-492A-A0C5-B4D15DDF00A4}
 		{8A75336B-A55F-42F6-B8BA-B55EFDA39705} = {4B56CCB9-2693-492A-A0C5-B4D15DDF00A4}
-	EndGlobalSection
-	GlobalSection(ExtensibilityGlobals) = postSolution
-		SolutionGuid = {8DA7AF03-FFF5-4EB3-A7D4-CDBD49A0D4B9}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {26BCDDB3-5505-4903-9D87-C942ED0D03E6}

--- a/src/VS.Web.CG.EFCore/IPropertyExtensions.cs
+++ b/src/VS.Web.CG.EFCore/IPropertyExtensions.cs
@@ -45,6 +45,9 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore
                 {
                     propertyMetadata.Scaffold = scaffoldAttr.Scaffold;
                 }
+
+                var dataTypeAttr = reflectionProperty.GetCustomAttribute(typeof(DataTypeAttribute)) as DataTypeAttribute;
+                propertyMetadata.IsMultilineText = (dataTypeAttr != null) && (dataTypeAttr.DataType == DataType.MultilineText);
             }
 
             propertyMetadata.IsEnumFlags = false;

--- a/src/VS.Web.CG.EFCore/IPropertyMetadata.cs
+++ b/src/VS.Web.CG.EFCore/IPropertyMetadata.cs
@@ -17,6 +17,7 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore
         bool Scaffold { get; set; }
         string ShortTypeName { get; set; }
         string TypeName { get; set; }
+        bool IsMultilineText { get; set; }
 
         PropertyInfo PropertyInfo { get; set; }
     }

--- a/src/VS.Web.CG.EFCore/PropertyMetadata.cs
+++ b/src/VS.Web.CG.EFCore/PropertyMetadata.cs
@@ -38,6 +38,9 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore
                 Scaffold = false;
             }
 
+            var dataTypeAttribute = property.GetCustomAttribute(typeof(DataTypeAttribute)) as DataTypeAttribute;
+            IsMultilineText = (dataTypeAttribute != null) && (dataTypeAttribute.DataType == DataType.MultilineText);
+
             // Since this is not being treated as an EF based model,
             // below values are set as false.
             IsPrimaryKey = false;
@@ -67,6 +70,8 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore
         public string ShortTypeName { get; set; }
 
         public string TypeName { get; set; }
+
+        public bool IsMultilineText { get; set; }
 
         public PropertyInfo PropertyInfo { get; set; }
     }

--- a/src/VS.Web.CG.Mvc/Templates/RazorPageGenerator/Create.cshtml
+++ b/src/VS.Web.CG.Mvc/Templates/RazorPageGenerator/Create.cshtml
@@ -81,8 +81,8 @@
                 {
             @:<div class="form-group">
                 @:<label asp-for="@(Model.ModelTypeName).@property.PropertyName" class="control-label"></label>
-                @:<label asp-for="@(Model.ModelTypeName).@property.PropertyName" class="control-label"></label>
                 @:<textarea asp-for="@(Model.ModelTypeName).@property.PropertyName" class="form-control"></textarea>
+                @:<span asp-validation-for="@(Model.ModelTypeName).@property.PropertyName" class="text-danger"></span>
             @:</div>
                 }
                 else

--- a/src/VS.Web.CG.Mvc/Templates/RazorPageGenerator/Create.cshtml
+++ b/src/VS.Web.CG.Mvc/Templates/RazorPageGenerator/Create.cshtml
@@ -77,6 +77,14 @@
                 @:<span asp-validation-for="@(Model.ModelTypeName).@property.PropertyName" class="text-danger"></span>
             @:</div>
                 }
+                else if (property.IsMultilineText)
+                {
+            @:<div class="form-group">
+                @:<label asp-for="@(Model.ModelTypeName).@property.PropertyName" class="control-label"></label>
+                @:<label asp-for="@(Model.ModelTypeName).@property.PropertyName" class="control-label"></label>
+                @:<textarea asp-for="@(Model.ModelTypeName).@property.PropertyName" class="form-control"></textarea>
+            @:</div>
+                }
                 else
                 {
             @:<div class="form-group">

--- a/src/VS.Web.CG.Mvc/Templates/RazorPageGenerator/Delete.cshtml
+++ b/src/VS.Web.CG.Mvc/Templates/RazorPageGenerator/Delete.cshtml
@@ -46,9 +46,13 @@
     <hr />
     <dl class="dl-horizontal">
 @{
-    foreach (var property in Model.ModelMetadata.Properties)
+    Dictionary<string, IPropertyMetadata> propertyLookup = ((IModelMetadata)Model.ModelMetadata).Properties.ToDictionary(x => x.PropertyName, x => x);
+    Dictionary<string, INavigationMetadata> navigationLookup = ((IModelMetadata)Model.ModelMetadata).Navigations.ToDictionary(x => x.AssociationPropertyName, x => x);
+
+    foreach (var item in Model.ModelMetadata.ModelType.GetProperties())
     {
-        if (property.Scaffold && !property.IsForeignKey && !property.IsPrimaryKey)
+        if (propertyLookup.TryGetValue(item.Name, out IPropertyMetadata property)
+            && property.Scaffold && !property.IsForeignKey && !property.IsPrimaryKey)
         {
         <dt>
             @@Html.DisplayNameFor(model => model.@(Model.ModelTypeName).@GetValueExpression(property))
@@ -57,15 +61,15 @@
             @@Html.DisplayFor(model => model.@(Model.ModelTypeName).@GetValueExpression(property))
         </dd>
         }
-    }
-    foreach (var navigation in Model.ModelMetadata.Navigations)
-    {
+        else if (navigationLookup.TryGetValue(item.Name, out INavigationMetadata navigation))
+        {
         <dt>
             @@Html.DisplayNameFor(model => model.@(Model.ModelTypeName).@GetValueExpression(navigation))
         </dt>
         <dd>
             @@Html.DisplayFor(model => model.@(Model.ModelTypeName).@GetValueExpression(navigation).@navigation.DisplayPropertyName)
         </dd>
+        }
     }
     @:</dl>
     @:

--- a/src/VS.Web.CG.Mvc/Templates/RazorPageGenerator/Details.cshtml
+++ b/src/VS.Web.CG.Mvc/Templates/RazorPageGenerator/Details.cshtml
@@ -45,9 +45,13 @@
     <hr />
     <dl class="dl-horizontal">
 @{
-    foreach (var property in Model.ModelMetadata.Properties)
+    Dictionary<string, IPropertyMetadata> propertyLookup = ((IModelMetadata)Model.ModelMetadata).Properties.ToDictionary(x => x.PropertyName, x => x);
+    Dictionary<string, INavigationMetadata> navigationLookup = ((IModelMetadata)Model.ModelMetadata).Navigations.ToDictionary(x => x.AssociationPropertyName, x => x);
+
+    foreach (var item in Model.ModelMetadata.ModelType.GetProperties())
     {
-        if (property.Scaffold && !property.IsPrimaryKey && !property.IsForeignKey)
+        if (propertyLookup.TryGetValue(item.Name, out IPropertyMetadata property)
+            && property.Scaffold && !property.IsForeignKey && !property.IsPrimaryKey)
         {
         <dt>
             @@Html.DisplayNameFor(model => model.@(Model.ModelTypeName).@GetValueExpression(property))
@@ -56,15 +60,15 @@
             @@Html.DisplayFor(model => model.@(Model.ModelTypeName).@GetValueExpression(property))
         </dd>
         }
-    }
-    foreach (var navigation in Model.ModelMetadata.Navigations)
-    {
+        else if (navigationLookup.TryGetValue(item.Name, out INavigationMetadata navigation))
+        {
         <dt>
             @@Html.DisplayNameFor(model => model.@(Model.ModelTypeName).@GetValueExpression(navigation))
         </dt>
         <dd>
             @@Html.DisplayFor(model => model.@(Model.ModelTypeName).@GetValueExpression(navigation).@navigation.DisplayPropertyName)
         </dd>
+        }
     }
 }    </dl>
 </div>

--- a/src/VS.Web.CG.Mvc/Templates/RazorPageGenerator/Edit.cshtml
+++ b/src/VS.Web.CG.Mvc/Templates/RazorPageGenerator/Edit.cshtml
@@ -89,6 +89,14 @@
                 @:<span asp-validation-for="@(Model.ModelTypeName).@property.PropertyName" class="text-danger"></span>
             @:</div>
                 }
+                else if (property.IsMultilineText)
+                {
+            @:<div class="form-group">
+                @:<label asp-for="@(Model.ModelTypeName).@property.PropertyName" class="control-label"></label>
+                @:<textarea asp-for="@(Model.ModelTypeName).@property.PropertyName" class="form-control"></textarea>
+                @:<span asp-validation-for="@(Model.ModelTypeName).@property.PropertyName" class="text-danger"></span>
+            @:</div>
+                }
                 else
                 {
             @:<div class="form-group">

--- a/src/VS.Web.CG.Mvc/Templates/RazorPageGenerator/List.cshtml
+++ b/src/VS.Web.CG.Mvc/Templates/RazorPageGenerator/List.cshtml
@@ -50,9 +50,9 @@
         {
             if (property.Scaffold && !property.IsPrimaryKey && !property.IsForeignKey)
             {
-                <th>
-                    @@Html.DisplayNameFor(model => model.@(Model.ModelTypeName)[0].@GetValueExpression(property))
-                </th>
+            <th>
+                @@Html.DisplayNameFor(model => model.@(Model.ModelTypeName)[0].@GetValueExpression(property))
+            </th>
             }
         }
         foreach (var navigation in Model.ModelMetadata.Navigations)

--- a/src/VS.Web.CG.Mvc/Templates/RazorPageGenerator/List.cshtml
+++ b/src/VS.Web.CG.Mvc/Templates/RazorPageGenerator/List.cshtml
@@ -44,22 +44,24 @@
 @:<table class="table">
     @:<thead>
         @:<tr>
+        Dictionary<string, IPropertyMetadata> propertyLookup = ((IModelMetadata)Model.ModelMetadata).Properties.ToDictionary(x => x.PropertyName, x => x);
+        Dictionary<string, INavigationMetadata> navigationLookup = ((IModelMetadata)Model.ModelMetadata).Navigations.ToDictionary(x => x.AssociationPropertyName, x => x);
 
-        var properties = Model.ModelMetadata.Properties;
-        foreach (var property in properties)
+        foreach (var item in Model.ModelMetadata.ModelType.GetProperties())
         {
-            if (property.Scaffold && !property.IsPrimaryKey && !property.IsForeignKey)
+            if (propertyLookup.TryGetValue(item.Name, out IPropertyMetadata property)
+                && property.Scaffold && !property.IsForeignKey && !property.IsPrimaryKey)
             {
             <th>
                 @@Html.DisplayNameFor(model => model.@(Model.ModelTypeName)[0].@GetValueExpression(property))
             </th>
             }
-        }
-        foreach (var navigation in Model.ModelMetadata.Navigations)
-        {
+            else if (navigationLookup.TryGetValue(item.Name, out INavigationMetadata navigation))
+            {
             <th>
                 @@Html.DisplayNameFor(model => model.@(Model.ModelTypeName)[0].@GetValueExpression(navigation))
             </th>
+            }
         }
             @:<th></th>
         @:</tr>
@@ -67,20 +69,21 @@
     @:<tbody>
 @:@@foreach (var item in Model.@(Model.ModelTypeName)) {
         @:<tr>
-        foreach (PropertyMetadata property in properties)
+        foreach (var item in Model.ModelMetadata.ModelType.GetProperties())
         {
-            if (property.Scaffold && !property.IsPrimaryKey && !property.IsForeignKey)
+            if (propertyLookup.TryGetValue(item.Name, out IPropertyMetadata property)
+                && property.Scaffold && !property.IsForeignKey && !property.IsPrimaryKey)
             {
             <td>
                 @@Html.DisplayFor(modelItem => item.@GetValueExpression(property))
             </td>
             }
-        }
-        foreach (var navigation in Model.ModelMetadata.Navigations)
-        {
+            else if (navigationLookup.TryGetValue(item.Name, out INavigationMetadata navigation))
+            {
             <td>
                 @@Html.DisplayFor(modelItem => item.@GetValueExpression(navigation).@navigation.DisplayPropertyName)
             </td>
+            }
         }
         string pkName = GetPrimaryKeyName();
         if (pkName != null)

--- a/src/VS.Web.CG.Mvc/Templates/ViewGenerator/Create.cshtml
+++ b/src/VS.Web.CG.Mvc/Templates/ViewGenerator/Create.cshtml
@@ -80,8 +80,8 @@
                 {
             @:<div class="form-group">
                 @:<label asp-for="@property.PropertyName" class="control-label"></label>
-                @:<label asp-for="@property.PropertyName" class="control-label"></label>
                 @:<textarea asp-for="@property.PropertyName" class="form-control"></textarea>
+                @:<span asp-validation-for="@property.PropertyName" class="text-danger"></span>
             @:</div>
                 }
                 else

--- a/src/VS.Web.CG.Mvc/Templates/ViewGenerator/Create.cshtml
+++ b/src/VS.Web.CG.Mvc/Templates/ViewGenerator/Create.cshtml
@@ -76,6 +76,14 @@
                 @:<span asp-validation-for="@property.PropertyName" class="text-danger"></span>
             @:</div>
                 }
+                else if (property.IsMultilineText)
+                {
+            @:<div class="form-group">
+                @:<label asp-for="@property.PropertyName" class="control-label"></label>
+                @:<label asp-for="@property.PropertyName" class="control-label"></label>
+                @:<textarea asp-for="@property.PropertyName" class="form-control"></textarea>
+            @:</div>
+                }
                 else
                 {
             @:<div class="form-group">

--- a/src/VS.Web.CG.Mvc/Templates/ViewGenerator/Delete.cshtml
+++ b/src/VS.Web.CG.Mvc/Templates/ViewGenerator/Delete.cshtml
@@ -45,9 +45,13 @@
     <hr />
     <dl class="dl-horizontal">
 @{
-    foreach (var property in Model.ModelMetadata.Properties)
+    Dictionary<string, IPropertyMetadata> propertyLookup = ((IModelMetadata)Model.ModelMetadata).Properties.ToDictionary(x => x.PropertyName, x => x);
+    Dictionary<string, INavigationMetadata> navigationLookup = ((IModelMetadata)Model.ModelMetadata).Navigations.ToDictionary(x => x.AssociationPropertyName, x => x);
+
+    foreach (var item in Model.ModelMetadata.ModelType.GetProperties())
     {
-        if (property.Scaffold && !property.IsForeignKey && !property.IsPrimaryKey)
+        if (propertyLookup.TryGetValue(item.Name, out IPropertyMetadata property)
+            && property.Scaffold && !property.IsForeignKey && !property.IsPrimaryKey)
         {
         <dt>
             @@Html.DisplayNameFor(model => model.@GetValueExpression(property))
@@ -56,15 +60,15 @@
             @@Html.DisplayFor(model => model.@GetValueExpression(property))
         </dd>
         }
-    }
-    foreach (var navigation in Model.ModelMetadata.Navigations)
-    {
+        else if (navigationLookup.TryGetValue(item.Name, out INavigationMetadata navigation))
+        {
         <dt>
             @@Html.DisplayNameFor(model => model.@GetValueExpression(navigation))
         </dt>
         <dd>
             @@Html.DisplayFor(model => model.@GetValueExpression(navigation).@navigation.DisplayPropertyName)
         </dd>
+        }
     }
     @:</dl>
     @:

--- a/src/VS.Web.CG.Mvc/Templates/ViewGenerator/Details.cshtml
+++ b/src/VS.Web.CG.Mvc/Templates/ViewGenerator/Details.cshtml
@@ -44,9 +44,13 @@
     <hr />
     <dl class="dl-horizontal">
 @{
-    foreach (var property in Model.ModelMetadata.Properties)
+    Dictionary<string, IPropertyMetadata> propertyLookup = ((IModelMetadata)Model.ModelMetadata).Properties.ToDictionary(x => x.PropertyName, x => x);
+    Dictionary<string, INavigationMetadata> navigationLookup = ((IModelMetadata)Model.ModelMetadata).Navigations.ToDictionary(x => x.AssociationPropertyName, x => x);
+
+    foreach (var item in Model.ModelMetadata.ModelType.GetProperties())
     {
-        if (property.Scaffold && !property.IsPrimaryKey && !property.IsForeignKey)
+        if (propertyLookup.TryGetValue(item.Name, out IPropertyMetadata property)
+            && property.Scaffold && !property.IsForeignKey && !property.IsPrimaryKey)
         {
         <dt>
             @@Html.DisplayNameFor(model => model.@GetValueExpression(property))
@@ -55,15 +59,15 @@
             @@Html.DisplayFor(model => model.@GetValueExpression(property))
         </dd>
         }
-    }
-    foreach (var navigation in Model.ModelMetadata.Navigations)
-    {
+        else if (navigationLookup.TryGetValue(item.Name, out INavigationMetadata navigation))
+        {
         <dt>
             @@Html.DisplayNameFor(model => model.@GetValueExpression(navigation))
         </dt>
         <dd>
             @@Html.DisplayFor(model => model.@GetValueExpression(navigation).@navigation.DisplayPropertyName)
         </dd>
+        }
     }
 }    </dl>
 </div>

--- a/src/VS.Web.CG.Mvc/Templates/ViewGenerator/Edit.cshtml
+++ b/src/VS.Web.CG.Mvc/Templates/ViewGenerator/Edit.cshtml
@@ -88,6 +88,14 @@
                 @:<span asp-validation-for="@property.PropertyName" class="text-danger"></span>
             @:</div>
                 }
+                else if (property.IsMultilineText)
+                {
+            @:<div class="form-group">
+                @:<label asp-for="@property.PropertyName" class="control-label"></label>
+                @:<textarea asp-for="@property.PropertyName" class="form-control"></textarea>
+                @:<span asp-validation-for="@property.PropertyName" class="text-danger"></span>
+            @:</div>
+                }
                 else
                 {
             @:<div class="form-group">

--- a/src/VS.Web.CG.Mvc/Templates/ViewGenerator/List.cshtml
+++ b/src/VS.Web.CG.Mvc/Templates/ViewGenerator/List.cshtml
@@ -49,7 +49,7 @@
         {
             if (property.Scaffold && !property.IsPrimaryKey && !property.IsForeignKey)
             {
-                <th>
+               <th>
                     @@Html.DisplayNameFor(model => model.@GetValueExpression(property))
                 </th>
             }

--- a/src/VS.Web.CG.Mvc/Templates/ViewGenerator/List.cshtml
+++ b/src/VS.Web.CG.Mvc/Templates/ViewGenerator/List.cshtml
@@ -49,9 +49,9 @@
         {
             if (property.Scaffold && !property.IsPrimaryKey && !property.IsForeignKey)
             {
-               <th>
-                    @@Html.DisplayNameFor(model => model.@GetValueExpression(property))
-                </th>
+            <th>
+                @@Html.DisplayNameFor(model => model.@GetValueExpression(property))
+            </th>
             }
         }
         foreach (var navigation in Model.ModelMetadata.Navigations)

--- a/src/VS.Web.CG.Mvc/Templates/ViewGenerator/List.cshtml
+++ b/src/VS.Web.CG.Mvc/Templates/ViewGenerator/List.cshtml
@@ -43,22 +43,24 @@
 @:<table class="table">
     @:<thead>
         @:<tr>
+        Dictionary<string, IPropertyMetadata> propertyLookup = ((IModelMetadata)Model.ModelMetadata).Properties.ToDictionary(x => x.PropertyName, x => x);
+        Dictionary<string, INavigationMetadata> navigationLookup = ((IModelMetadata)Model.ModelMetadata).Navigations.ToDictionary(x => x.AssociationPropertyName, x => x);
 
-        var properties = Model.ModelMetadata.Properties;
-        foreach (var property in properties)
+        foreach (var item in Model.ModelMetadata.ModelType.GetProperties())
         {
-            if (property.Scaffold && !property.IsPrimaryKey && !property.IsForeignKey)
+            if (propertyLookup.TryGetValue(item.Name, out IPropertyMetadata property)
+                && property.Scaffold && !property.IsForeignKey && !property.IsPrimaryKey)
             {
             <th>
                 @@Html.DisplayNameFor(model => model.@GetValueExpression(property))
             </th>
             }
-        }
-        foreach (var navigation in Model.ModelMetadata.Navigations)
-        {
+            else if (navigationLookup.TryGetValue(item.Name, out INavigationMetadata navigation))
+            {
             <th>
                 @@Html.DisplayNameFor(model => model.@GetValueExpression(navigation))
             </th>
+            }
         }
             @:<th></th>
         @:</tr>
@@ -66,20 +68,21 @@
     @:<tbody>
 @:@@foreach (var item in Model) {
         @:<tr>
-        foreach (PropertyMetadata property in properties)
+        foreach (var item in Model.ModelMetadata.ModelType.GetProperties())
         {
-            if (property.Scaffold && !property.IsPrimaryKey && !property.IsForeignKey)
+            if (propertyLookup.TryGetValue(item.Name, out IPropertyMetadata property)
+                && property.Scaffold && !property.IsForeignKey && !property.IsPrimaryKey)
             {
             <td>
                 @@Html.DisplayFor(modelItem => item.@GetValueExpression(property))
             </td>
             }
-        }
-        foreach (var navigation in Model.ModelMetadata.Navigations)
-        {
+            else if (navigationLookup.TryGetValue(item.Name, out INavigationMetadata navigation))
+            {
             <td>
                 @@Html.DisplayFor(modelItem => item.@GetValueExpression(navigation).@navigation.DisplayPropertyName)
             </td>
+            }
         }
         string pkName = GetPrimaryKeyName();
         if (pkName != null)

--- a/test/E2E_Test/Compiler/Resources/CarViews/Create.cshtml
+++ b/test/E2E_Test/Compiler/Resources/CarViews/Create.cshtml
@@ -29,6 +29,11 @@
                 <select asp-for="ManufacturerID" class ="form-control" asp-items="ViewBag.ManufacturerID"></select>
             </div>
             <div class="form-group">
+                <label asp-for="Notes" class="control-label"></label>
+                <label asp-for="Notes" class="control-label"></label>
+                <textarea asp-for="Notes" class="form-control"></textarea>
+            </div>
+            <div class="form-group">
                 <input type="submit" value="Create" class="btn btn-default" />
             </div>
         </form>

--- a/test/E2E_Test/Compiler/Resources/CarViews/Create.cshtml
+++ b/test/E2E_Test/Compiler/Resources/CarViews/Create.cshtml
@@ -30,8 +30,8 @@
             </div>
             <div class="form-group">
                 <label asp-for="Notes" class="control-label"></label>
-                <label asp-for="Notes" class="control-label"></label>
                 <textarea asp-for="Notes" class="form-control"></textarea>
+                <span asp-validation-for="Notes" class="text-danger"></span>
             </div>
             <div class="form-group">
                 <input type="submit" value="Create" class="btn btn-default" />

--- a/test/E2E_Test/Compiler/Resources/CarViews/Delete.cshtml
+++ b/test/E2E_Test/Compiler/Resources/CarViews/Delete.cshtml
@@ -25,16 +25,16 @@
             @Html.DisplayFor(model => model.Name)
         </dd>
         <dt>
-            @Html.DisplayNameFor(model => model.Notes)
-        </dt>
-        <dd>
-            @Html.DisplayFor(model => model.Notes)
-        </dd>
-        <dt>
             @Html.DisplayNameFor(model => model.Manufacturer)
         </dt>
         <dd>
             @Html.DisplayFor(model => model.Manufacturer.ID)
+        </dd>
+        <dt>
+            @Html.DisplayNameFor(model => model.Notes)
+        </dt>
+        <dd>
+            @Html.DisplayFor(model => model.Notes)
         </dd>
     </dl>
     

--- a/test/E2E_Test/Compiler/Resources/CarViews/Delete.cshtml
+++ b/test/E2E_Test/Compiler/Resources/CarViews/Delete.cshtml
@@ -25,6 +25,12 @@
             @Html.DisplayFor(model => model.Name)
         </dd>
         <dt>
+            @Html.DisplayNameFor(model => model.Notes)
+        </dt>
+        <dd>
+            @Html.DisplayFor(model => model.Notes)
+        </dd>
+        <dt>
             @Html.DisplayNameFor(model => model.Manufacturer)
         </dt>
         <dd>

--- a/test/E2E_Test/Compiler/Resources/CarViews/Details.cshtml
+++ b/test/E2E_Test/Compiler/Resources/CarViews/Details.cshtml
@@ -24,16 +24,16 @@
             @Html.DisplayFor(model => model.Name)
         </dd>
         <dt>
-            @Html.DisplayNameFor(model => model.Notes)
-        </dt>
-        <dd>
-            @Html.DisplayFor(model => model.Notes)
-        </dd>
-        <dt>
             @Html.DisplayNameFor(model => model.Manufacturer)
         </dt>
         <dd>
             @Html.DisplayFor(model => model.Manufacturer.ID)
+        </dd>
+        <dt>
+            @Html.DisplayNameFor(model => model.Notes)
+        </dt>
+        <dd>
+            @Html.DisplayFor(model => model.Notes)
         </dd>
     </dl>
 </div>

--- a/test/E2E_Test/Compiler/Resources/CarViews/Details.cshtml
+++ b/test/E2E_Test/Compiler/Resources/CarViews/Details.cshtml
@@ -24,6 +24,12 @@
             @Html.DisplayFor(model => model.Name)
         </dd>
         <dt>
+            @Html.DisplayNameFor(model => model.Notes)
+        </dt>
+        <dd>
+            @Html.DisplayFor(model => model.Notes)
+        </dd>
+        <dt>
             @Html.DisplayNameFor(model => model.Manufacturer)
         </dt>
         <dd>

--- a/test/E2E_Test/Compiler/Resources/CarViews/Edit.cshtml
+++ b/test/E2E_Test/Compiler/Resources/CarViews/Edit.cshtml
@@ -32,7 +32,7 @@
             </div>
             <div class="form-group">
                 <label asp-for="Notes" class="control-label"></label>
-                <input asp-for="Notes" class="form-control" />
+                <textarea asp-for="Notes" class="form-control"></textarea>
                 <span asp-validation-for="Notes" class="text-danger"></span>
             </div>
             <div class="form-group">

--- a/test/E2E_Test/Compiler/Resources/CarViews/Edit.cshtml
+++ b/test/E2E_Test/Compiler/Resources/CarViews/Edit.cshtml
@@ -31,6 +31,11 @@
                 <span asp-validation-for="ManufacturerID" class="text-danger"></span>
             </div>
             <div class="form-group">
+                <label asp-for="Notes" class="control-label"></label>
+                <input asp-for="Notes" class="form-control" />
+                <span asp-validation-for="Notes" class="text-danger"></span>
+            </div>
+            <div class="form-group">
                 <input type="submit" value="Save" class="btn btn-default" />
             </div>
         </form>

--- a/test/E2E_Test/Compiler/Resources/CarViews/Index.cshtml
+++ b/test/E2E_Test/Compiler/Resources/CarViews/Index.cshtml
@@ -22,10 +22,10 @@
                 @Html.DisplayNameFor(model => model.Name)
             </th>
             <th>
-                @Html.DisplayNameFor(model => model.Notes)
+                @Html.DisplayNameFor(model => model.Manufacturer)
             </th>
             <th>
-                @Html.DisplayNameFor(model => model.Manufacturer)
+                @Html.DisplayNameFor(model => model.Notes)
             </th>
             <th></th>
         </tr>
@@ -37,10 +37,10 @@
                 @Html.DisplayFor(modelItem => item.Name)
             </td>
             <td>
-                @Html.DisplayFor(modelItem => item.Notes)
+                @Html.DisplayFor(modelItem => item.Manufacturer.ID)
             </td>
             <td>
-                @Html.DisplayFor(modelItem => item.Manufacturer.ID)
+                @Html.DisplayFor(modelItem => item.Notes)
             </td>
             <td>
                 <a asp-action="Edit" asp-route-id="@item.ID">Edit</a> |

--- a/test/E2E_Test/Compiler/Resources/CarViews/Index.cshtml
+++ b/test/E2E_Test/Compiler/Resources/CarViews/Index.cshtml
@@ -21,6 +21,9 @@
                 <th>
                     @Html.DisplayNameFor(model => model.Name)
                 </th>
+                <th>
+                    @Html.DisplayNameFor(model => model.Notes)
+                </th>
             <th>
                 @Html.DisplayNameFor(model => model.Manufacturer)
             </th>
@@ -32,6 +35,9 @@
         <tr>
             <td>
                 @Html.DisplayFor(modelItem => item.Name)
+            </td>
+            <td>
+                @Html.DisplayFor(modelItem => item.Notes)
             </td>
             <td>
                 @Html.DisplayFor(modelItem => item.Manufacturer.ID)

--- a/test/E2E_Test/Compiler/Resources/CarViews/Index.cshtml
+++ b/test/E2E_Test/Compiler/Resources/CarViews/Index.cshtml
@@ -18,12 +18,12 @@
 <table class="table">
     <thead>
         <tr>
-                <th>
-                    @Html.DisplayNameFor(model => model.Name)
-                </th>
-                <th>
-                    @Html.DisplayNameFor(model => model.Notes)
-                </th>
+            <th>
+                @Html.DisplayNameFor(model => model.Name)
+            </th>
+            <th>
+                @Html.DisplayNameFor(model => model.Notes)
+            </th>
             <th>
                 @Html.DisplayNameFor(model => model.Manufacturer)
             </th>

--- a/test/E2E_Test/Compiler/Resources/CarsController.txt
+++ b/test/E2E_Test/Compiler/Resources/CarsController.txt
@@ -57,7 +57,7 @@ namespace TestProject
         // more details see http://go.microsoft.com/fwlink/?LinkId=317598.
         [HttpPost]
         [ValidateAntiForgeryToken]
-        public async Task<IActionResult> Create([Bind("ID,Name,ManufacturerID")] Car car)
+        public async Task<IActionResult> Create([Bind("ID,Name,ManufacturerID,Notes")] Car car)
         {
             if (ModelState.IsValid)
             {
@@ -91,7 +91,7 @@ namespace TestProject
         // more details see http://go.microsoft.com/fwlink/?LinkId=317598.
         [HttpPost]
         [ValidateAntiForgeryToken]
-        public async Task<IActionResult> Edit(string id, [Bind("ID,Name,ManufacturerID")] Car car)
+        public async Task<IActionResult> Edit(string id, [Bind("ID,Name,ManufacturerID,Notes")] Car car)
         {
             if (id != car.ID)
             {

--- a/test/E2E_Test/Compiler/Resources/CarsControllerWithDAL.txt
+++ b/test/E2E_Test/Compiler/Resources/CarsControllerWithDAL.txt
@@ -58,7 +58,7 @@ namespace TestProject.Areas.Test.Controllers
         // more details see http://go.microsoft.com/fwlink/?LinkId=317598.
         [HttpPost]
         [ValidateAntiForgeryToken]
-        public async Task<IActionResult> Create([Bind("ID,Name,ManufacturerID")] Car car)
+        public async Task<IActionResult> Create([Bind("ID,Name,ManufacturerID,Notes")] Car car)
         {
             if (ModelState.IsValid)
             {
@@ -92,7 +92,7 @@ namespace TestProject.Areas.Test.Controllers
         // more details see http://go.microsoft.com/fwlink/?LinkId=317598.
         [HttpPost]
         [ValidateAntiForgeryToken]
-        public async Task<IActionResult> Edit(string id, [Bind("ID,Name,ManufacturerID")] Car car)
+        public async Task<IActionResult> Edit(string id, [Bind("ID,Name,ManufacturerID,Notes")] Car car)
         {
             if (id != car.ID)
             {

--- a/test/E2E_Test/Compiler/Resources/CarsWithViewController.txt
+++ b/test/E2E_Test/Compiler/Resources/CarsWithViewController.txt
@@ -58,7 +58,7 @@ namespace TestProject.Areas.Test.Controllers
         // more details see http://go.microsoft.com/fwlink/?LinkId=317598.
         [HttpPost]
         [ValidateAntiForgeryToken]
-        public async Task<IActionResult> Create([Bind("ID,Name,ManufacturerID")] Car car)
+        public async Task<IActionResult> Create([Bind("ID,Name,ManufacturerID,Notes")] Car car)
         {
             if (ModelState.IsValid)
             {
@@ -92,7 +92,7 @@ namespace TestProject.Areas.Test.Controllers
         // more details see http://go.microsoft.com/fwlink/?LinkId=317598.
         [HttpPost]
         [ValidateAntiForgeryToken]
-        public async Task<IActionResult> Edit(string id, [Bind("ID,Name,ManufacturerID")] Car car)
+        public async Task<IActionResult> Edit(string id, [Bind("ID,Name,ManufacturerID,Notes")] Car car)
         {
             if (id != car.ID)
             {

--- a/test/E2E_Test/Compiler/Resources/ProductViews/Index.cshtml
+++ b/test/E2E_Test/Compiler/Resources/ProductViews/Index.cshtml
@@ -18,12 +18,12 @@
 <table class="table">
     <thead>
         <tr>
-                <th>
-                    @Html.DisplayNameFor(model => model.Name)
-                </th>
-                <th>
-                    @Html.DisplayNameFor(model => model.Price)
-                </th>
+            <th>
+                @Html.DisplayNameFor(model => model.Name)
+            </th>
+            <th>
+                @Html.DisplayNameFor(model => model.Price)
+            </th>
             <th>
                 @Html.DisplayNameFor(model => model.Manufacturer)
             </th>

--- a/test/E2E_Test/Compiler/Resources/RazorPages/CarCreate.txt
+++ b/test/E2E_Test/Compiler/Resources/RazorPages/CarCreate.txt
@@ -31,8 +31,8 @@
             </div>
             <div class="form-group">
                 <label asp-for="Car.Notes" class="control-label"></label>
-                <label asp-for="Car.Notes" class="control-label"></label>
                 <textarea asp-for="Car.Notes" class="form-control"></textarea>
+                <span asp-validation-for="Car.Notes" class="text-danger"></span>
             </div>
             <div class="form-group">
                 <input type="submit" value="Create" class="btn btn-default" />

--- a/test/E2E_Test/Compiler/Resources/RazorPages/CarCreate.txt
+++ b/test/E2E_Test/Compiler/Resources/RazorPages/CarCreate.txt
@@ -30,6 +30,11 @@
                 <select asp-for="Car.ManufacturerID" class ="form-control" asp-items="ViewBag.ManufacturerID"></select>
             </div>
             <div class="form-group">
+                <label asp-for="Car.Notes" class="control-label"></label>
+                <label asp-for="Car.Notes" class="control-label"></label>
+                <textarea asp-for="Car.Notes" class="form-control"></textarea>
+            </div>
+            <div class="form-group">
                 <input type="submit" value="Create" class="btn btn-default" />
             </div>
         </form>

--- a/test/E2E_Test/Compiler/Resources/RazorPages/Crud/Create.txt
+++ b/test/E2E_Test/Compiler/Resources/RazorPages/Crud/Create.txt
@@ -18,8 +18,8 @@
             </div>
             <div class="form-group">
                 <label asp-for="Car.Notes" class="control-label"></label>
-                <label asp-for="Car.Notes" class="control-label"></label>
                 <textarea asp-for="Car.Notes" class="form-control"></textarea>
+                <span asp-validation-for="Car.Notes" class="text-danger"></span>
             </div>
             <div class="form-group">
                 <input type="submit" value="Create" class="btn btn-default" />

--- a/test/E2E_Test/Compiler/Resources/RazorPages/Crud/Create.txt
+++ b/test/E2E_Test/Compiler/Resources/RazorPages/Crud/Create.txt
@@ -17,6 +17,11 @@
                 <select asp-for="Car.ManufacturerID" class ="form-control" asp-items="ViewBag.ManufacturerID"></select>
             </div>
             <div class="form-group">
+                <label asp-for="Car.Notes" class="control-label"></label>
+                <label asp-for="Car.Notes" class="control-label"></label>
+                <textarea asp-for="Car.Notes" class="form-control"></textarea>
+            </div>
+            <div class="form-group">
                 <input type="submit" value="Create" class="btn btn-default" />
             </div>
         </form>

--- a/test/E2E_Test/Compiler/Resources/RazorPages/Crud/Delete.txt
+++ b/test/E2E_Test/Compiler/Resources/RazorPages/Crud/Delete.txt
@@ -13,6 +13,12 @@
             @Html.DisplayFor(model => model.Car.Name)
         </dd>
         <dt>
+            @Html.DisplayNameFor(model => model.Car.Notes)
+        </dt>
+        <dd>
+            @Html.DisplayFor(model => model.Car.Notes)
+        </dd>
+        <dt>
             @Html.DisplayNameFor(model => model.Car.Manufacturer)
         </dt>
         <dd>

--- a/test/E2E_Test/Compiler/Resources/RazorPages/Crud/Delete.txt
+++ b/test/E2E_Test/Compiler/Resources/RazorPages/Crud/Delete.txt
@@ -13,16 +13,16 @@
             @Html.DisplayFor(model => model.Car.Name)
         </dd>
         <dt>
-            @Html.DisplayNameFor(model => model.Car.Notes)
-        </dt>
-        <dd>
-            @Html.DisplayFor(model => model.Car.Notes)
-        </dd>
-        <dt>
             @Html.DisplayNameFor(model => model.Car.Manufacturer)
         </dt>
         <dd>
             @Html.DisplayFor(model => model.Car.Manufacturer.ID)
+        </dd>
+        <dt>
+            @Html.DisplayNameFor(model => model.Car.Notes)
+        </dt>
+        <dd>
+            @Html.DisplayFor(model => model.Car.Notes)
         </dd>
     </dl>
     

--- a/test/E2E_Test/Compiler/Resources/RazorPages/Crud/Details.txt
+++ b/test/E2E_Test/Compiler/Resources/RazorPages/Crud/Details.txt
@@ -12,16 +12,16 @@
             @Html.DisplayFor(model => model.Car.Name)
         </dd>
         <dt>
-            @Html.DisplayNameFor(model => model.Car.Notes)
-        </dt>
-        <dd>
-            @Html.DisplayFor(model => model.Car.Notes)
-        </dd>
-        <dt>
             @Html.DisplayNameFor(model => model.Car.Manufacturer)
         </dt>
         <dd>
             @Html.DisplayFor(model => model.Car.Manufacturer.ID)
+        </dd>
+        <dt>
+            @Html.DisplayNameFor(model => model.Car.Notes)
+        </dt>
+        <dd>
+            @Html.DisplayFor(model => model.Car.Notes)
         </dd>
     </dl>
 </div>

--- a/test/E2E_Test/Compiler/Resources/RazorPages/Crud/Details.txt
+++ b/test/E2E_Test/Compiler/Resources/RazorPages/Crud/Details.txt
@@ -12,6 +12,12 @@
             @Html.DisplayFor(model => model.Car.Name)
         </dd>
         <dt>
+            @Html.DisplayNameFor(model => model.Car.Notes)
+        </dt>
+        <dd>
+            @Html.DisplayFor(model => model.Car.Notes)
+        </dd>
+        <dt>
             @Html.DisplayNameFor(model => model.Car.Manufacturer)
         </dt>
         <dd>

--- a/test/E2E_Test/Compiler/Resources/RazorPages/Crud/Edit.txt
+++ b/test/E2E_Test/Compiler/Resources/RazorPages/Crud/Edit.txt
@@ -19,6 +19,11 @@
                 <span asp-validation-for="Car.ManufacturerID" class="text-danger"></span>
             </div>
             <div class="form-group">
+                <label asp-for="Car.Notes" class="control-label"></label>
+                <input asp-for="Car.Notes" class="form-control" />
+                <span asp-validation-for="Car.Notes" class="text-danger"></span>
+            </div>
+            <div class="form-group">
                 <input type="submit" value="Save" class="btn btn-default" />
             </div>
         </form>

--- a/test/E2E_Test/Compiler/Resources/RazorPages/Crud/Edit.txt
+++ b/test/E2E_Test/Compiler/Resources/RazorPages/Crud/Edit.txt
@@ -20,7 +20,7 @@
             </div>
             <div class="form-group">
                 <label asp-for="Car.Notes" class="control-label"></label>
-                <input asp-for="Car.Notes" class="form-control" />
+                <textarea asp-for="Car.Notes" class="form-control"></textarea>
                 <span asp-validation-for="Car.Notes" class="text-danger"></span>
             </div>
             <div class="form-group">

--- a/test/E2E_Test/Compiler/Resources/RazorPages/Crud/Index.txt
+++ b/test/E2E_Test/Compiler/Resources/RazorPages/Crud/Index.txt
@@ -7,12 +7,12 @@
 <table class="table">
     <thead>
         <tr>
-                <th>
-                    @Html.DisplayNameFor(model => model.Car[0].Name)
-                </th>
-                <th>
-                    @Html.DisplayNameFor(model => model.Car[0].Notes)
-                </th>
+            <th>
+                @Html.DisplayNameFor(model => model.Car[0].Name)
+            </th>
+            <th>
+                @Html.DisplayNameFor(model => model.Car[0].Notes)
+            </th>
             <th>
                 @Html.DisplayNameFor(model => model.Car[0].Manufacturer)
             </th>

--- a/test/E2E_Test/Compiler/Resources/RazorPages/Crud/Index.txt
+++ b/test/E2E_Test/Compiler/Resources/RazorPages/Crud/Index.txt
@@ -11,10 +11,10 @@
                 @Html.DisplayNameFor(model => model.Car[0].Name)
             </th>
             <th>
-                @Html.DisplayNameFor(model => model.Car[0].Notes)
+                @Html.DisplayNameFor(model => model.Car[0].Manufacturer)
             </th>
             <th>
-                @Html.DisplayNameFor(model => model.Car[0].Manufacturer)
+                @Html.DisplayNameFor(model => model.Car[0].Notes)
             </th>
             <th></th>
         </tr>
@@ -26,10 +26,10 @@
                 @Html.DisplayFor(modelItem => item.Name)
             </td>
             <td>
-                @Html.DisplayFor(modelItem => item.Notes)
+                @Html.DisplayFor(modelItem => item.Manufacturer.ID)
             </td>
             <td>
-                @Html.DisplayFor(modelItem => item.Manufacturer.ID)
+                @Html.DisplayFor(modelItem => item.Notes)
             </td>
             <td>
                 <a asp-page="./Edit" asp-route-id="@item.ID">Edit</a> |

--- a/test/E2E_Test/Compiler/Resources/RazorPages/Crud/Index.txt
+++ b/test/E2E_Test/Compiler/Resources/RazorPages/Crud/Index.txt
@@ -10,6 +10,9 @@
                 <th>
                     @Html.DisplayNameFor(model => model.Car[0].Name)
                 </th>
+                <th>
+                    @Html.DisplayNameFor(model => model.Car[0].Notes)
+                </th>
             <th>
                 @Html.DisplayNameFor(model => model.Car[0].Manufacturer)
             </th>
@@ -21,6 +24,9 @@
         <tr>
             <td>
                 @Html.DisplayFor(modelItem => item.Name)
+            </td>
+            <td>
+                @Html.DisplayFor(modelItem => item.Notes)
             </td>
             <td>
                 @Html.DisplayFor(modelItem => item.Manufacturer.ID)

--- a/test/E2E_Test/Compiler/Resources/Views/CarCreate.txt
+++ b/test/E2E_Test/Compiler/Resources/Views/CarCreate.txt
@@ -29,6 +29,11 @@
                 <select asp-for="ManufacturerID" class ="form-control" asp-items="ViewBag.ManufacturerID"></select>
             </div>
             <div class="form-group">
+                <label asp-for="Notes" class="control-label"></label>
+                <label asp-for="Notes" class="control-label"></label>
+                <textarea asp-for="Notes" class="form-control"></textarea>
+            </div>
+            <div class="form-group">
                 <input type="submit" value="Create" class="btn btn-default" />
             </div>
         </form>

--- a/test/E2E_Test/Compiler/Resources/Views/CarCreate.txt
+++ b/test/E2E_Test/Compiler/Resources/Views/CarCreate.txt
@@ -30,8 +30,8 @@
             </div>
             <div class="form-group">
                 <label asp-for="Notes" class="control-label"></label>
-                <label asp-for="Notes" class="control-label"></label>
                 <textarea asp-for="Notes" class="form-control"></textarea>
+                <span asp-validation-for="Notes" class="text-danger"></span>
             </div>
             <div class="form-group">
                 <input type="submit" value="Create" class="btn btn-default" />

--- a/test/E2E_Test/Compiler/Resources/Views/CarDetails.txt
+++ b/test/E2E_Test/Compiler/Resources/Views/CarDetails.txt
@@ -22,6 +22,12 @@
         <dd>
             @Html.DisplayFor(model => model.ManufacturerID)
         </dd>
+        <dt>
+            @Html.DisplayNameFor(model => model.Notes)
+        </dt>
+        <dd>
+            @Html.DisplayFor(model => model.Notes)
+        </dd>
     </dl>
 </div>
 <div>

--- a/test/Shared/MsBuildProjectStrings.cs.in
+++ b/test/Shared/MsBuildProjectStrings.cs.in
@@ -273,6 +273,10 @@ namespace WebApplication1
     <Compile Include=""**\*.cs"" Exclude=""Excluded.cs;$(DefaultItemExcludes)"" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include=""System.ComponentModel.Annotations"" Version=""4.4.1"" />
+  </ItemGroup>
+
 </Project>
 ";
 
@@ -304,6 +308,7 @@ namespace WebApplication1.Models
 ";
         public const string CarTxt = @"
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 
 namespace Library1.Models
 {
@@ -313,6 +318,8 @@ namespace Library1.Models
         public string Name { get; set; }
         public int ManufacturerID { get; set; }
         public Manufacturer Manufacturer { get; set; }
+        [DataType(DataType.MultilineText)]
+        public string Notes { get; set; }
     }
 
     public class Manufacturer

--- a/test/VS.Web.CG.EFCore.Test/CodeModelMetadataTests.cs
+++ b/test/VS.Web.CG.EFCore.Test/CodeModelMetadataTests.cs
@@ -19,7 +19,7 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore.Test
             var metadata = new CodeModelMetadata(typeof(Product));
 
             //Act && Assert
-            Assert.Equal(8, metadata.Properties.Length);
+            Assert.Equal(9, metadata.Properties.Length);
             Assert.Empty(metadata.PrimaryKeys);
             Assert.Empty(metadata.Navigations);
 

--- a/test/VS.Web.CG.EFCore.Test/CodeModelServiceTests.cs
+++ b/test/VS.Web.CG.EFCore.Test/CodeModelServiceTests.cs
@@ -70,7 +70,7 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore.Test
                Assert.Equal(ContextProcessingStatus.ContextAvailable, metadata.ContextProcessingStatus);
                Assert.False(metadata.ModelMetadata.Navigations.Any());
                Assert.False(metadata.ModelMetadata.PrimaryKeys.Any());
-               Assert.Equal(3, metadata.ModelMetadata.Properties.Length);
+               Assert.Equal(4, metadata.ModelMetadata.Properties.Length);
            }
         }
 

--- a/test/VS.Web.CG.EFCore.Test/ModelMetadataTests.cs
+++ b/test/VS.Web.CG.EFCore.Test/ModelMetadataTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore.Test
             var productMetadata = new ModelMetadata(productEntity, typeof(TestDbContext));
 
             //Act && Assert
-            Assert.Equal(8, productMetadata.Properties.Length);
+            Assert.Equal(9, productMetadata.Properties.Length);
             Assert.Single(productMetadata.Navigations);
 
             //Arrange

--- a/test/VS.Web.CG.EFCore.Test/PropertyMetadataTests.cs
+++ b/test/VS.Web.CG.EFCore.Test/PropertyMetadataTests.cs
@@ -174,6 +174,22 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore.Test
         }
 
         [Fact]
+        public void DataType_Attribute_Is_Reflected_In_Metadata()
+        {
+            //Arrange
+            var productEntity = TestModel.CategoryProductModel.FindEntityType(typeof(Product));
+            var modelMetadata = new ModelMetadata(productEntity, typeof(TestDbContext));
+
+            //Act
+            var dataTypeAttributePropertyMetadata = modelMetadata.Properties.FirstOrDefault(p => p.PropertyName == nameof(Product.DataTypeAttributeProperty));
+            var productNameAttributeMetadata = modelMetadata.Properties.FirstOrDefault(p => p.PropertyName == nameof(Product.ProductName));
+
+            //Assert
+            Assert.True(dataTypeAttributePropertyMetadata.IsMultilineText);
+            Assert.False(productNameAttributeMetadata.IsMultilineText);
+        }
+
+        [Fact]
         public void PropertyMetadata_From_PropertyInfo()
         {
             //Arrange

--- a/test/VS.Web.CG.EFCore.Test/TestModels/Models.cs
+++ b/test/VS.Web.CG.EFCore.Test/TestModels/Models.cs
@@ -37,6 +37,9 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore.Test.Tes
 
         //[ReadOnly(true)]
         public string ReadOnlyProperty { get; set; }
+
+        [DataType(DataType.MultilineText)]
+        public string DataTypeAttributeProperty { get; set; }
     }
 
     public class CategoryBase


### PR DESCRIPTION
Generates textarea inputs for [DataType(DataType.MultilineText)] attributed properties in the create & edit views. 
Fixes an issue where display properties would always get generated before navigation properties in most views. 
Fixes some minor spacing issues in generated views.