### PR TITLE
Fix build warnings about missing template variables

### DIFF
--- a/Scaffolding.sln
+++ b/Scaffolding.sln
@@ -11,6 +11,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{81B64EBF-613D-43AE-82DA-B375FB751921}"
 	ProjectSection(SolutionItems) = preProject
 		test\Directory.Build.props = test\Directory.Build.props
+		test\Directory.Build.targets = test\Directory.Build.targets
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "TestApps", "TestApps", "{95C6F0B4-1687-4C36-90BF-1362CAB06524}"

--- a/test/Shared/MsBuildProjectStrings.cs.in
+++ b/test/Shared/MsBuildProjectStrings.cs.in
@@ -341,7 +341,8 @@ namespace Library1.Models
     <RootNamespace>Microsoft.TestProject</RootNamespace>
     <ProjectName>TestProject</ProjectName>
     <NoWarn>NU1605</NoWarn>
-    <RuntimeFrameworkVersion>${RuntimeFrameworkVersion}</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion Condition=""'$(TargetFramework)'=='netcoreapp2.0'"">${MicrosoftNETCoreApp20PackageVersion}</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion Condition=""'$(TargetFramework)'=='netcoreapp2.1'"">${MicrosoftNETCoreApp21PackageVersion}</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -508,7 +509,8 @@ namespace DAL
     <RootNamespace>Microsoft.TestProject</RootNamespace>
     <ProjectName>TestProject</ProjectName>
     <NoWarn>NU1605</NoWarn>
-    <RuntimeFrameworkVersion>${RuntimeFrameworkVersion}</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion Condition=""'$(TargetFramework)'=='netcoreapp2.0'"">${MicrosoftNETCoreApp20PackageVersion}</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion Condition=""'$(TargetFramework)'=='netcoreapp2.1'"">${MicrosoftNETCoreApp21PackageVersion}</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -559,7 +561,6 @@ namespace Test.Data
 }
 ";
 
-      public const string MSBuildTaskDllPath = @"${OutputPath}\Microsoft.VisualStudio.Web.CodeGeneration.Msbuild.dll";
       public const string TestCodeGenerationTargetFileText = @"<Project xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
 <!--
 **********************************************************************************


### PR DESCRIPTION
The .cs.in file had undefined variables and was causing a build warning.