### PR TITLE
Bug fixes for identity scaffolder.

### DIFF
--- a/src/VS.Web.CG.Mvc/Identity/IdentityGeneratorFileComparer.cs
+++ b/src/VS.Web.CG.Mvc/Identity/IdentityGeneratorFileComparer.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Identity
+{
+    internal class IdentityGeneratorFileComparer : IEqualityComparer<IdentityGeneratorFile>
+    {
+        public bool Equals(IdentityGeneratorFile x, IdentityGeneratorFile y)
+        {
+            // If they are the same objects or both are null.
+            if (x == y)
+            {
+                return true;
+            }
+
+            return string.Equals(x?.Name, y?.Name, StringComparison.Ordinal);
+
+        }
+
+        public int GetHashCode(IdentityGeneratorFile obj)
+        {
+            return obj?.Name?.GetHashCode() ?? 0;
+        }
+    }
+}

--- a/src/VS.Web.CG.Mvc/Identity/IdentityGeneratorFilesConfig.cs
+++ b/src/VS.Web.CG.Mvc/Identity/IdentityGeneratorFilesConfig.cs
@@ -117,10 +117,10 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Identity
             {
                 if (names != null && names.Any())
                 {
-                  foreach (var name in names)
-                  {
-                      filesToGenerate.AddRange(_config.NamedFileConfig[name]);
-                  }
+                    foreach (var name in names)
+                    {
+                        filesToGenerate.AddRange(_config.NamedFileConfig[name]);
+                    }
                 }
                 else
                 {
@@ -130,7 +130,8 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Identity
 
             filesToGenerate.Add(IdentityHostingStartup);
             filesToGenerate.Add(ReadMe);
-            return filesToGenerate.ToArray();
+
+            return filesToGenerate.Distinct(new IdentityGeneratorFileComparer()).ToArray();
         }
 
         /// <summary>

--- a/src/VS.Web.CG.Mvc/Identity/IdentityGeneratorTemplateModelBuilder.cs
+++ b/src/VS.Web.CG.Mvc/Identity/IdentityGeneratorTemplateModelBuilder.cs
@@ -282,9 +282,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Identity
 
             if (!RoslynUtilities.IsValidIdentifier(defaultDbContextName))
             {
-                // TODO: This default name causes conflicts in the IdentityHostingStartup.
-                // Need to come up with a different name.
-                defaultDbContextName = "IdentityDbContext";
+                defaultDbContextName = "IdentityDataContext";
             }
 
             return defaultDbContextName;

--- a/src/VS.Web.CG.Mvc/Identity/IdentityGeneratorTemplateModelBuilder.cs
+++ b/src/VS.Web.CG.Mvc/Identity/IdentityGeneratorTemplateModelBuilder.cs
@@ -342,7 +342,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Identity
                 errorStrings.Add(
                     string.Format(MessageStrings.DbContextNeedsToInheritFromIdentityContextMessage,
                         existingUser.Name,
-                        "Microsoft.AspNetCore.Identity.Identityuser"));
+                        "Microsoft.AspNetCore.Identity.IdentityUser"));
             }
 
             if (errorStrings.Any())
@@ -357,7 +357,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Identity
             while (parentType != null && parentType != typeof(object))
             {
                 if (parentType.FullName == "Microsoft.AspNetCore.Identity.IdentityUser"
-                    && parentType.Assembly.GetName().Name == "Microsoft.AspNetCore.Identity.EntityFrameworkCore")
+                    && parentType.Assembly.GetName().Name == "Microsoft.Extensions.Identity.Stores")
                 {
                     return true;
                 }

--- a/src/VS.Web.CG.Mvc/Identity/identitygeneratorfilesconfig.json
+++ b/src/VS.Web.CG.Mvc/Identity/identitygeneratorfilesconfig.json
@@ -162,6 +162,18 @@
         "SourcePath": "Pages/Account/Manage/Account.Manage._Layout.cshtml",
         "OutputPath": "Areas/Identity/Pages/Account/Manage/_Layout.cshtml",
         "IsTemplate": false
+      },
+      {
+        "Name": "Account.Manage._ManageNav",
+        "SourcePath": "Account.Manage._ManageNav.cshtml",
+        "OutputPath": "Areas/Identity/Pages/Account/Manage/_ManageNav.cshtml",
+        "IsTemplate": true
+      },
+      {
+        "Name": "Account.Manage.ManageNavPages",
+        "SourcePath": "Account.Manage.ManageNavPages.cshtml",
+        "OutputPath": "Areas/Identity/Pages/Account/Manage/ManageNavPages.cs",
+        "IsTemplate": true
       }
     ],
     "Account.Manage._ManageNav": [
@@ -212,6 +224,18 @@
         "SourcePath": "Account.Manage.DeletePersonalData.cs.cshtml",
         "OutputPath": "Areas/Identity/Pages/Account/Manage/DeletePersonalData.cshtml.cs",
         "IsTemplate": true
+      },
+      {
+        "Name": "Account.Manage._ManageNav",
+        "SourcePath": "Account.Manage._ManageNav.cshtml",
+        "OutputPath": "Areas/Identity/Pages/Account/Manage/_ManageNav.cshtml",
+        "IsTemplate": true
+      },
+      {
+        "Name": "Account.Manage.ManageNavPages",
+        "SourcePath": "Account.Manage.ManageNavPages.cshtml",
+        "OutputPath": "Areas/Identity/Pages/Account/Manage/ManageNavPages.cs",
+        "IsTemplate": true
       }
     ],
     "Account.Manage.Disable2fa": [
@@ -225,6 +249,18 @@
         "Name": "Account.Manage.Disable2fa.cs",
         "SourcePath": "Account.Manage.Disable2fa.cs.cshtml",
         "OutputPath": "Areas/Identity/Pages/Account/Manage/Disable2fa.cshtml.cs",
+        "IsTemplate": true
+      },
+      {
+        "Name": "Account.Manage._ManageNav",
+        "SourcePath": "Account.Manage._ManageNav.cshtml",
+        "OutputPath": "Areas/Identity/Pages/Account/Manage/_ManageNav.cshtml",
+        "IsTemplate": true
+      },
+      {
+        "Name": "Account.Manage.ManageNavPages",
+        "SourcePath": "Account.Manage.ManageNavPages.cshtml",
+        "OutputPath": "Areas/Identity/Pages/Account/Manage/ManageNavPages.cs",
         "IsTemplate": true
       }
     ],
@@ -240,6 +276,18 @@
         "SourcePath": "Account.Manage.DownloadPersonalData.cs.cshtml",
         "OutputPath": "Areas/Identity/Pages/Account/Manage/DownloadPersonalData.cshtml.cs",
         "IsTemplate": true
+      },
+      {
+        "Name": "Account.Manage._ManageNav",
+        "SourcePath": "Account.Manage._ManageNav.cshtml",
+        "OutputPath": "Areas/Identity/Pages/Account/Manage/_ManageNav.cshtml",
+        "IsTemplate": true
+      },
+      {
+        "Name": "Account.Manage.ManageNavPages",
+        "SourcePath": "Account.Manage.ManageNavPages.cshtml",
+        "OutputPath": "Areas/Identity/Pages/Account/Manage/ManageNavPages.cs",
+        "IsTemplate": true
       }
     ],
     "Account.Manage.EnableAuthenticator": [
@@ -253,6 +301,18 @@
         "Name": "Account.Manage.EnableAuthenticator.cs",
         "SourcePath": "Account.Manage.EnableAuthenticator.cs.cshtml",
         "OutputPath": "Areas/Identity/Pages/Account/Manage/EnableAuthenticator.cshtml.cs",
+        "IsTemplate": true
+      },
+      {
+        "Name": "Account.Manage._ManageNav",
+        "SourcePath": "Account.Manage._ManageNav.cshtml",
+        "OutputPath": "Areas/Identity/Pages/Account/Manage/_ManageNav.cshtml",
+        "IsTemplate": true
+      },
+      {
+        "Name": "Account.Manage.ManageNavPages",
+        "SourcePath": "Account.Manage.ManageNavPages.cshtml",
+        "OutputPath": "Areas/Identity/Pages/Account/Manage/ManageNavPages.cs",
         "IsTemplate": true
       }
     ],
@@ -282,6 +342,18 @@
         "SourcePath": "Account.Manage.GenerateRecoveryCodes.cs.cshtml",
         "OutputPath": "Areas/Identity/Pages/Account/Manage/GenerateRecoveryCodes.cshtml.cs",
         "IsTemplate": true
+      },
+      {
+        "Name": "Account.Manage._ManageNav",
+        "SourcePath": "Account.Manage._ManageNav.cshtml",
+        "OutputPath": "Areas/Identity/Pages/Account/Manage/_ManageNav.cshtml",
+        "IsTemplate": true
+      },
+      {
+        "Name": "Account.Manage.ManageNavPages",
+        "SourcePath": "Account.Manage.ManageNavPages.cshtml",
+        "OutputPath": "Areas/Identity/Pages/Account/Manage/ManageNavPages.cs",
+        "IsTemplate": true
       }
     ],
     "Account.Manage.Index": [
@@ -310,6 +382,18 @@
         "SourcePath": "Account.Manage.PersonalData.cs.cshtml",
         "OutputPath": "Areas/Identity/Pages/Account/Manage/PersonalData.cshtml.cs",
         "IsTemplate": true
+      },
+      {
+        "Name": "Account.Manage._ManageNav",
+        "SourcePath": "Account.Manage._ManageNav.cshtml",
+        "OutputPath": "Areas/Identity/Pages/Account/Manage/_ManageNav.cshtml",
+        "IsTemplate": true
+      },
+      {
+        "Name": "Account.Manage.ManageNavPages",
+        "SourcePath": "Account.Manage.ManageNavPages.cshtml",
+        "OutputPath": "Areas/Identity/Pages/Account/Manage/ManageNavPages.cs",
+        "IsTemplate": true
       }
     ],
     "Account.Manage.ResetAuthenticator": [
@@ -324,6 +408,18 @@
         "SourcePath": "Account.Manage.ResetAuthenticator.cs.cshtml",
         "OutputPath": "Areas/Identity/Pages/Account/Manage/ResetAuthenticator.cshtml.cs",
         "IsTemplate": true
+      },
+      {
+        "Name": "Account.Manage._ManageNav",
+        "SourcePath": "Account.Manage._ManageNav.cshtml",
+        "OutputPath": "Areas/Identity/Pages/Account/Manage/_ManageNav.cshtml",
+        "IsTemplate": true
+      },
+      {
+        "Name": "Account.Manage.ManageNavPages",
+        "SourcePath": "Account.Manage.ManageNavPages.cshtml",
+        "OutputPath": "Areas/Identity/Pages/Account/Manage/ManageNavPages.cs",
+        "IsTemplate": true
       }
     ],
     "Account.Manage.SetPassword": [
@@ -337,6 +433,18 @@
         "Name": "Account.Manage.SetPassword.cs",
         "SourcePath": "Account.Manage.SetPassword.cs.cshtml",
         "OutputPath": "Areas/Identity/Pages/Account/Manage/SetPassword.cshtml.cs",
+        "IsTemplate": true
+      },
+      {
+        "Name": "Account.Manage._ManageNav",
+        "SourcePath": "Account.Manage._ManageNav.cshtml",
+        "OutputPath": "Areas/Identity/Pages/Account/Manage/_ManageNav.cshtml",
+        "IsTemplate": true
+      },
+      {
+        "Name": "Account.Manage.ManageNavPages",
+        "SourcePath": "Account.Manage.ManageNavPages.cshtml",
+        "OutputPath": "Areas/Identity/Pages/Account/Manage/ManageNavPages.cs",
         "IsTemplate": true
       }
     ],

--- a/test/E2E_Test/IdentityScaffolderTests.cs
+++ b/test/E2E_Test/IdentityScaffolderTests.cs
@@ -48,6 +48,42 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.E2E_Test
         }
 
         [Fact]
+        public void TestIdentityGenerator_WithExistingUser()
+        {
+            using (var fileProvider = new TemporaryFileProvider())
+            {
+                new MsBuildProjectSetupHelper().SetupProjectsForIdentityScaffolder(fileProvider, Output);
+                TestProjectPath = Path.Combine(fileProvider.Root, "Root");
+                var args = new string[]
+                {
+                    "-p",
+                    Path.Combine(TestProjectPath, "Test.csproj"),
+                    "-c",
+                    Configuration,
+                    "identity",
+                    "-u",
+                    "Test.Data.MyIdentityUser",
+                    "--generateLayout",
+                    "-f"
+                };
+
+                Scaffold(args, TestProjectPath);
+
+                foreach(var file in IdentityGeneratorFilesConfig.Templates)
+                {
+                    Assert.True(File.Exists(Path.Combine(TestProjectPath, file)), $"Template file does not exist: '{Path.Combine(TestProjectPath, file)}'");
+                }
+
+                foreach(var file in IdentityGeneratorFilesConfig.StaticFiles)
+                {
+                    Assert.True(File.Exists(Path.Combine(TestProjectPath, file)), $"Static file does not exist: '{Path.Combine(TestProjectPath, file)}'");
+                }
+
+                Assert.False(File.Exists(Path.Combine(TestProjectPath, "Areas", "Identity", "Data", "MyIdentityUser.cs")));
+            }
+        }
+
+        [Fact]
         public void TestIdentityGenerator_IndividualFiles()
         {
             using (var fileProvider = new TemporaryFileProvider())

--- a/test/E2E_Test/IdentityScaffolderTests.cs
+++ b/test/E2E_Test/IdentityScaffolderTests.cs
@@ -1,8 +1,11 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Runtime.InteropServices;
+using Microsoft.Extensions.Internal;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -154,6 +157,83 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.E2E_Test
                 var contents = File.ReadAllText(manageViewImportsPath);
                 Assert.False(File.Exists(Path.Combine(TestProjectPath, "Areas", "Identity", "Pages", "_ViewImports.cshtml")));
                 Assert.Equal("__", contents);
+            }
+        }
+
+        [Theory, MemberData(nameof(TestData))]
+        public void TestIdentityGenerator_IndividualFiles_AllFilesBuild(string fileName)
+        {
+            using (var fileProvider = new TemporaryFileProvider())
+            {
+                new MsBuildProjectSetupHelper().SetupProjectsForIdentityScaffolder(fileProvider, Output);
+                TestProjectPath = Path.Combine(fileProvider.Root, "Root");
+
+                var args = new string[]
+                {
+                    "-p",
+                    Path.Combine(TestProjectPath, "Test.csproj"),
+                    "-c",
+                    Configuration,
+                    "identity",
+                    "--dbContext",
+                    "Test.Data.MyApplicationDbContext",
+                    "--files",
+                    fileName
+                };
+
+                Scaffold(args, TestProjectPath);
+
+                var result = Command.CreateDotNet("build", new string[] { "-c", Configuration })
+                .WithEnvironmentVariable("DOTNET_SKIP_FIRST_TIME_EXPERIENCE", "true")
+                .InWorkingDirectory(TestProjectPath)
+                .OnErrorLine(l => Output.WriteLine(l))
+                .OnOutputLine(l => Output.WriteLine(l))
+                .Execute();
+
+                if (result.ExitCode != 0)
+                {
+                    throw new InvalidOperationException($"Build failed with exit code: {result.ExitCode}");
+                }
+            }
+        }
+
+        public static IEnumerable<object[]> TestData
+        {
+            get
+            {
+                return new[]
+                {
+                    new object[] {"_LoginPartial"},
+                    new object[] {"_ValidationScriptsPartial"},
+                    new object[] {"Account.AccessDenied"},
+                    new object[] {"Account.ConfirmEmail"},
+                    new object[] {"Account.ExternalLogin"},
+                    new object[] {"Account.ForgotPassword"},
+                    new object[] {"Account.ForgotPasswordConfirmation"},
+                    new object[] {"Account.Lockout"},
+                    new object[] {"Account.Login"},
+                    new object[] {"Account.LoginWith2fa"},
+                    new object[] {"Account.LoginWithRecoveryCode"},
+                    new object[] {"Account.Logout"},
+                    new object[] {"Account.Manage._Layout"},
+                    new object[] {"Account.Manage._ManageNav"},
+                    new object[] {"Account.Manage._StatusMessage"},
+                    new object[] {"Account.Manage.ChangePassword"},
+                    new object[] {"Account.Manage.DeletePersonalData"},
+                    new object[] {"Account.Manage.Disable2fa"},
+                    new object[] {"Account.Manage.DownloadPersonalData"},
+                    new object[] {"Account.Manage.EnableAuthenticator"},
+                    new object[] {"Account.Manage.ExternalLogins"},
+                    new object[] {"Account.Manage.GenerateRecoveryCodes"},
+                    new object[] {"Account.Manage.Index"},
+                    new object[] {"Account.Manage.PersonalData"},
+                    new object[] {"Account.Manage.ResetAuthenticator"},
+                    new object[] {"Account.Manage.SetPassword"},
+                    new object[] {"Account.Manage.TwoFactorAuthentication"},
+                    new object[] {"Account.Register"},
+                    new object[] {"Account.ResetPassword"},
+                    new object[] {"Account.ResetPasswordConfirmation"}
+                };
             }
         }
     }

--- a/test/Shared/MsBuildProjectSetupHelper.cs
+++ b/test/Shared/MsBuildProjectSetupHelper.cs
@@ -94,6 +94,7 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration
             fileProvider.Add($"Root/Startup.cs", MsBuildProjectStrings.StartupForIdentityTxt);
             fileProvider.Add($"Root/{MsBuildProjectStrings.ProgramFileName}", MsBuildProjectStrings.ProgramFileText);
             fileProvider.Add($"Root/{MsBuildProjectStrings.IdentityContextName}", MsBuildProjectStrings.IdentityContextText);
+            fileProvider.Add($"Root/{MsBuildProjectStrings.IdentityUserName}", MsBuildProjectStrings.IdentityUserText);
             fileProvider.Add($"Library1/{MsBuildProjectStrings.LibraryProjectName}", MsBuildProjectStrings.LibraryProjectTxt);
             RestoreAndBuild(Path.Combine(fileProvider.Root, "Root"), output);
         }

--- a/test/Shared/MsBuildProjectStrings.cs.in
+++ b/test/Shared/MsBuildProjectStrings.cs.in
@@ -672,5 +672,21 @@ namespace WebApplication1
     }
 }
 ";
+        public const string IdentityUserName = "MyIdentityUser.cs";
+        public const string IdentityUserText = @"
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Identity;
+
+namespace Test.Data
+{
+    public class MyIdentityUser : IdentityUser
+    {
+
+    }
+}
+";
     }
 }

--- a/test/VS.Web.CG.Mvc.Test/IdentityGeneratorTemplateModelBuilderTests.cs
+++ b/test/VS.Web.CG.Mvc.Test/IdentityGeneratorTemplateModelBuilderTests.cs
@@ -68,18 +68,6 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc
 
                 Assert.Equal("IdentityUser", templateModel.UserClass);
                 Assert.False(templateModel.IsGenerateCustomUser);
-
-                commandLineModel.UserClass = "MyIdentityUser";
-
-                templateModel = await builder.ValidateAndBuild();
-
-                Assert.Equal("Test.Namespace.Areas.Identity.Data", templateModel.DbContextNamespace);
-                Assert.False(templateModel.IsUsingExistingDbContext);
-
-                Assert.Equal("MyIdentityUser", templateModel.UserClass);
-                Assert.True(templateModel.IsGenerateCustomUser);
-                Assert.False(templateModel.IsGeneratingIndividualFiles);
-
             }
         }
 


### PR DESCRIPTION
- Changed the default name for the generated DbContext to be `IdentityDataContext` 
  - Earlier it was `IdentityDbContext` and it would clash with the one from Identity assemblies.
- Enabled passing in an existing user class in case a new DbContext is being generated.
- Some pages under `Pages/Account/Mangage` have a dependency on `/Pages/Account/Manage/_ManageNav.cshtml`. 
  - Added support to scaffold dependency pages when they are not selected. 
  - Also added E2E tests that test scaffolding each individual page and ensure that the project still builds. 