### PR TITLE
Remove reference to Microsoft.AspNetCore.Mvc.Razor.Extensions

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -12,7 +12,7 @@
     <MicrosoftAspNetCoreIdentityEntityFrameworkCorePackageVersion>2.1.0-preview2-30478</MicrosoftAspNetCoreIdentityEntityFrameworkCorePackageVersion>
     <MicrosoftAspNetCoreIdentityUIPackageVersion>2.1.0-preview2-30478</MicrosoftAspNetCoreIdentityUIPackageVersion>
     <MicrosoftAspNetCoreMvcPackageVersion>2.1.0-preview2-30478</MicrosoftAspNetCoreMvcPackageVersion>
-    <MicrosoftAspNetCoreMvcRazorExtensionsPackageVersion>2.1.0-preview2-30478</MicrosoftAspNetCoreMvcRazorExtensionsPackageVersion>
+    <MicrosoftAspNetCoreRazorLanguagePackageVersion>2.1.0-preview2-30478</MicrosoftAspNetCoreRazorLanguagePackageVersion>
     <MicrosoftAspNetCorePackageVersion>2.1.0-preview2-30478</MicrosoftAspNetCorePackageVersion>
     <MicrosoftAspNetCoreServerIISIntegrationPackageVersion>2.1.0-preview2-30478</MicrosoftAspNetCoreServerIISIntegrationPackageVersion>
     <MicrosoftAspNetCoreServerKestrelPackageVersion>2.1.0-preview2-30478</MicrosoftAspNetCoreServerKestrelPackageVersion>

--- a/src/VS.Web.CG.Templating/RazorTemplating.cs
+++ b/src/VS.Web.CG.Templating/RazorTemplating.cs
@@ -4,10 +4,10 @@
 using System;
 using System.IO;
 using System.Linq;
-using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
-using Microsoft.AspNetCore.Mvc.Razor.Extensions;
+using Microsoft.AspNetCore.Razor.Language.Extensions;
 using Microsoft.VisualStudio.Web.CodeGeneration.Templating.Compilation;
 
 namespace Microsoft.VisualStudio.Web.CodeGeneration.Templating
@@ -35,7 +35,14 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.Templating
             var fileSystem = RazorProjectFileSystem.Create(Directory.GetCurrentDirectory());
             var projectEngine = RazorProjectEngine.Create(RazorConfiguration.Default, fileSystem, (builder) =>
             {
-                 RazorExtensions.Register(builder);
+                FunctionsDirective.Register(builder);
+                InheritsDirective.Register(builder);
+                SectionDirective.Register(builder);
+
+                builder.AddTargetExtension(new TemplateTargetExtension()
+                {
+                    TemplateTypeName = "global::Microsoft.AspNetCore.Mvc.Razor.HelperResult",
+                });
 
                 builder.AddDefaultImports(@"
 @using System
@@ -67,10 +74,9 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.Templating
             }
 
             var compiledObject = Activator.CreateInstance(templateResult.CompiledType);
-            var razorTemplate = compiledObject as RazorTemplateBase;
 
-            string result = String.Empty;
-            if (razorTemplate != null)
+            var result = string.Empty;
+            if (compiledObject is RazorTemplateBase razorTemplate)
             {
                 razorTemplate.Model = templateModel;
                 //ToDo: If there are errors executing the code, they are missed here.

--- a/src/VS.Web.CG.Templating/VS.Web.CG.Templating.csproj
+++ b/src/VS.Web.CG.Templating/VS.Web.CG.Templating.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.Extensions" Version="$(MicrosoftAspNetCoreMvcRazorExtensionsPackageVersion)" />
+    <PackageReference Include="Microsoft.AspNetCore.Razor.Language" Version="$(MicrosoftAspNetCoreRazorLanguagePackageVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(MicrosoftCodeAnalysisCSharpPackageVersion)" />
   </ItemGroup>
 


### PR DESCRIPTION
Between preview1 and preview2, the bitness of .NET Framework targeting projects changed from x86 to AnyCPU [1]. Consequently the app is compiled with AnyCPU, but the Scaffolding binary is x86. In both preview1 and preview2, Mvc attempts to load Scaffolding binaries because it appears to be a candidate containing controllers[2]. However, the change in bitness of the app results in an exception when attempting to Assembly.Load scaffolding's binary. Possible suggested fixes:

* Make Scaffolding not appear to be a candidate for Mvc
* Put the correct bitness exe in the output directory.

[1] - Between Preview1 and Preview2, Asp.Net Core no longer depends on Libuv, a native dependency. This causes the PlatformTarget to change. Here's the culprit: https://github.com/dotnet/sdk/blob/34454e6b651d4e1f0f1149c13d8c1ec115e111a1/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.RuntimeIdentifierInference.targets#L158-L167

[2] - This is because Scaffolding references Microsoft.AspNetCore.Mvc.Razor.Extensions, an Mvc specific library.