### PR TITLE
Set projects under tools/ as IsPackable=false

### DIFF
--- a/tools/Directory.Build.props
+++ b/tools/Directory.Build.props
@@ -1,6 +1,10 @@
 ﻿<Project>
   <Import Project="..\Directory.Build.props" />
 
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Internal.AspNetCore.Sdk" PrivateAssets="All" Version="$(InternalAspNetCoreSdkPackageVersion)" />
   </ItemGroup>


### PR DESCRIPTION
It throws off Universe's groove because these projects under tools/ appear to produce the same package ID.