### PR TITLE
Better messaging of DbContext errors

### DIFF
--- a/src/VS.Web.CG.EFCore/EntityFrameworkModelProcessor.cs
+++ b/src/VS.Web.CG.EFCore/EntityFrameworkModelProcessor.cs
@@ -339,6 +339,11 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore
                     ? string.Empty
                     : string.Join(Environment.NewLine, compilationErrors)));
 
+            if (compilationErrors != null && compilationErrors.Any())
+            {
+                throw new InvalidOperationException(string.Format(MessageStrings.DbContextCompilationError, _dbContextFullTypeName, dbContextTemplateModel.DbContextTypeName));
+            }
+
             _dbContextSyntaxTree = _dbContextSyntaxTree.WithFilePath(GetPathForNewContext(dbContextTemplateModel.DbContextTypeName, _areaName));
         }
 

--- a/src/VS.Web.CG.EFCore/EntityFrameworkModelProcessor.cs
+++ b/src/VS.Web.CG.EFCore/EntityFrameworkModelProcessor.cs
@@ -80,7 +80,6 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore
             var dbContextSymbols = _modelTypesLocator.GetType(_dbContextFullTypeName).ToList();
             var startupType = _modelTypesLocator.GetType("Startup").FirstOrDefault();
             var programType = _modelTypesLocator.GetType("Program").FirstOrDefault();
-            string dbContextError = string.Empty;
 
             ModelType dbContextSymbolInWebProject = null;
             if (!dbContextSymbols.Any())
@@ -102,7 +101,7 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore
 
             if (dbContextType == null)
             {
-                throw new InvalidOperationException(dbContextError);
+                throw new InvalidOperationException(_dbContextError);
             }
 
             var modelReflectionType = _reflectedTypesProvider.GetReflectedType(
@@ -338,11 +337,6 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore
                 (compilationErrors == null
                     ? string.Empty
                     : string.Join(Environment.NewLine, compilationErrors)));
-
-            if (compilationErrors != null && compilationErrors.Any())
-            {
-                throw new InvalidOperationException(string.Format(MessageStrings.DbContextCompilationError, _dbContextFullTypeName, dbContextTemplateModel.DbContextTypeName));
-            }
 
             _dbContextSyntaxTree = _dbContextSyntaxTree.WithFilePath(GetPathForNewContext(dbContextTemplateModel.DbContextTypeName, _areaName));
         }

--- a/src/VS.Web.CG.EFCore/MessageStrings.Designer.cs
+++ b/src/VS.Web.CG.EFCore/MessageStrings.Designer.cs
@@ -105,7 +105,16 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore {
                 return ResourceManager.GetString("CompilingWithModifiedDbContext", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to The specified DbContext '{0}' could not be created. This is likely caused by a type name clash with '{1}'. Try renaming the DbContext and run scaffolding again.
+        /// </summary>
+        internal static string DbContextCompilationError {
+            get {
+                return ResourceManager.GetString("DbContextCompilationError", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to There was an error creating a DbContext :{0}.
         /// </summary>

--- a/src/VS.Web.CG.EFCore/MessageStrings.Designer.cs
+++ b/src/VS.Web.CG.EFCore/MessageStrings.Designer.cs
@@ -107,15 +107,6 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore {
         }
 
         /// <summary>
-        ///   Looks up a localized string similar to The specified DbContext '{0}' could not be created. This is likely caused by a type name clash with '{1}'. Try renaming the DbContext and run scaffolding again.
-        /// </summary>
-        internal static string DbContextCompilationError {
-            get {
-                return ResourceManager.GetString("DbContextCompilationError", resourceCulture);
-            }
-        }
-
-        /// <summary>
         ///   Looks up a localized string similar to There was an error creating a DbContext :{0}.
         /// </summary>
         internal static string DbContextCreationError {

--- a/src/VS.Web.CG.EFCore/MessageStrings.resx
+++ b/src/VS.Web.CG.EFCore/MessageStrings.resx
@@ -132,6 +132,9 @@
   <data name="CompilingWithModifiedDbContext" xml:space="preserve">
     <value>Attempting to compile the application in memory with the modified DbContext.</value>
   </data>
+  <data name="DbContextCompilationError" xml:space="preserve">
+    <value>The specified DbContext '{0}' could not be created. This is likely caused by a type name clash with '{1}'. Try renaming the DbContext and run scaffolding again.</value>
+  </data>
   <data name="DbContextCreationError" xml:space="preserve">
     <value>There was an error creating a DbContext :{0}</value>
   </data>

--- a/src/VS.Web.CG.EFCore/MessageStrings.resx
+++ b/src/VS.Web.CG.EFCore/MessageStrings.resx
@@ -132,9 +132,6 @@
   <data name="CompilingWithModifiedDbContext" xml:space="preserve">
     <value>Attempting to compile the application in memory with the modified DbContext.</value>
   </data>
-  <data name="DbContextCompilationError" xml:space="preserve">
-    <value>The specified DbContext '{0}' could not be created. This is likely caused by a type name clash with '{1}'. Try renaming the DbContext and run scaffolding again.</value>
-  </data>
   <data name="DbContextCreationError" xml:space="preserve">
     <value>There was an error creating a DbContext :{0}</value>
   </data>


### PR DESCRIPTION
The current behavior is that scaffolding exits with no message, and the logged info doesn't indicate the problem. This causes a meaningful message to be reported to the user when a newly generated DbContext has compilation errors - which is usually caused by type name clashes. For example, give a DbContext name of "AppContext", "MyApp.Data.AppContext", etc.

**Update**
This PR has been updated to deal with more general errors with DB Contexts. The error message was already created, this just causes the error message to properly propagate back to the user.