### PR TITLE
Dont overwrite wwwroot dir if it exists and is non-empty

### DIFF
--- a/src/VS.Web.CG.Mvc/Identity/IdentityGeneratorFilesConfig.cs
+++ b/src/VS.Web.CG.Mvc/Identity/IdentityGeneratorFilesConfig.cs
@@ -147,7 +147,9 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Identity
                 }
                 else
                 {
-                    filesToGenerate.AddRange(_config.NamedFileConfig.SelectMany(f => f.Value));
+                    filesToGenerate.AddRange(_config.NamedFileConfig
+                                                    .Where(x => !string.Equals(x.Key, "wwwroot", StringComparison.OrdinalIgnoreCase))
+                                                    .SelectMany(f => f.Value));
                 }
             }
 

--- a/test/VS.Web.CG.Mvc.Test/IdentityGeneratorFilesConfigTests.cs
+++ b/test/VS.Web.CG.Mvc.Test/IdentityGeneratorFilesConfigTests.cs
@@ -16,6 +16,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc
             {
                 UseDefaultUI = false,
                 HasExistingNonEmptyWwwRoot = true,
+                SupportFileLocation = "\\tmp\\"
             };
 
             IdentityGeneratorFile[] templateFiles = IdentityGeneratorFilesConfig.GetFilesToGenerate(null, model);

--- a/test/VS.Web.CG.Mvc.Test/IdentityGeneratorFilesConfigTests.cs
+++ b/test/VS.Web.CG.Mvc.Test/IdentityGeneratorFilesConfigTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Identity;
 using Xunit;
@@ -8,6 +9,20 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc
 {
     public class IdentityGeneratorFilesConfigTests
     {
+        [Fact]
+        public void TestExistingWwwRootDataIsNotOverwrittenWhenScaffoldAllFilesSelected()
+        {
+            IdentityGeneratorTemplateModel model = new IdentityGeneratorTemplateModel()
+            {
+                UseDefaultUI = false,
+                HasExistingNonEmptyWwwRoot = true,
+            };
+
+            IdentityGeneratorFile[] templateFiles = IdentityGeneratorFilesConfig.GetFilesToGenerate(null, model);
+
+            Assert.DoesNotContain(templateFiles, x => x.SourcePath.IndexOf("wwwroot", StringComparison.OrdinalIgnoreCase) > -1);
+        }
+
         [Theory, MemberData(nameof(TestData))]
         public void TestGetTemplates(string dbContextClass,
             string userClass,


### PR DESCRIPTION
Fixes #844 

This fix is targeted for the release/2.2 branch. We can back-port it for servicing as appropriate.