### PR TITLE
fix error on filename

### DIFF
--- a/src/VS.Web.CG.Mvc/Identity/bootstrap4_identitygeneratorfilesconfig.json
+++ b/src/VS.Web.CG.Mvc/Identity/bootstrap4_identitygeneratorfilesconfig.json
@@ -796,8 +796,8 @@
       },
       {
         "Name": "Jquery.validate.min.js",
-        "SourcePath": "wwwroot/lib/jquery-validation/dist/Jquery.validate.min.js",
-        "OutputPath": "wwwroot/lib/jquery-validation/dist/Jquery.validate.min.js",
+        "SourcePath": "wwwroot/lib/jquery-validation/dist/jquery.validate.min.js",
+        "OutputPath": "wwwroot/lib/jquery-validation/dist/jquery.validate.min.js",
         "IsTemplate": false,
         "ShowInListFiles": false
       },


### PR DESCRIPTION
Fix error filename case, which cause a problem on case-sensitive filesystem (like most filesystems on Linux).

I got following error while following aspnet core tutorial:

```
$ dotnet aspnet-codegenerator identity --useDefaultUI
Building project ...
Finding the generator 'identity'...
Running the generator 'identity'...
The provided file '/usr/share/dotnet/sdk/NuGetFallbackFolder/microsoft.visualstudio.web.codegenerators.mvc/2.1.4/Templates/Identity/wwwroot/lib/jquery-validation/dist/Jquery.validate.min.js' does not exist. This method expects a fully qualified path of an existing file.
   at Microsoft.VisualStudio.Web.CodeGeneration.ActionInvoker.<BuildCommandLine>b__6_0()
   at Microsoft.Extensions.CommandLineUtils.CommandLineApplication.Execute(String[] args)
   at Microsoft.VisualStudio.Web.CodeGeneration.ActionInvoker.Execute(String[] args)
   at Microsoft.VisualStudio.Web.CodeGeneration.CodeGenCommand.Execute(String[] args)
RunTime 00:00:06.56
```

And it seems to be caused by typo on filename, because file exists with lowercase name.
```
$ file /usr/share/dotnet/sdk/NuGetFallbackFolder/microsoft.visualstudio.web.codegenerators.mvc/2.1.4/Templates/Identity/wwwroot/li
b/jquery-validation/dist/jquery.validate.min.js
/usr/share/dotnet/sdk/NuGetFallbackFolder/microsoft.visualstudio.web.codegenerators.mvc/2.1.4/Templates/Identity/wwwroot/lib/jquery-validation/dist/jquery.validate.min.js: UTF-8 Unicode text, with very long lines, with CRLF line terminators
```