### PR TITLE
Fix for EF controller scaffolding when the model is defined on a parent of the selected db context

### DIFF
--- a/Scaffolding.sln
+++ b/Scaffolding.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27130.2024
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.28124.4003
 MinimumVisualStudioVersion = 15.0.26730.03
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{A4057ACF-27F0-4724-963B-44548B6BC4E9}"
 	ProjectSection(SolutionItems) = preProject

--- a/src/VS.Web.CG.EFCore/DbContextEditorServices.cs
+++ b/src/VS.Web.CG.EFCore/DbContextEditorServices.cs
@@ -278,7 +278,29 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore
             }
         }
 
+        // Check for the model property on the input dbContext, as well as anything it inherits from.
         private bool IsModelPropertyExists(ITypeSymbol dbContext, string modelTypeFullName)
+        {
+            if (IsModelPropertyExistsOnSymbol(dbContext, modelTypeFullName))
+            {
+                return true;
+            }
+
+            ITypeSymbol workingDbContext = dbContext;
+            while (workingDbContext.BaseType != null)
+            {
+                workingDbContext = workingDbContext.BaseType;
+
+                if (IsModelPropertyExistsOnSymbol(workingDbContext, modelTypeFullName))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private bool IsModelPropertyExistsOnSymbol(ITypeSymbol dbContext, string modelTypeFullName)
         {
             var propertySymbols = dbContext.GetMembers().Select(m => m as IPropertySymbol).Where(s => s != null);
             foreach (var pSymbol in propertySymbols)

--- a/src/VS.Web.CG.EFCore/DbContextEditorServices.cs
+++ b/src/VS.Web.CG.EFCore/DbContextEditorServices.cs
@@ -281,21 +281,16 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore
         // Check for the model property on the input dbContext, as well as anything it inherits from.
         private bool IsModelPropertyExists(ITypeSymbol dbContext, string modelTypeFullName)
         {
-            if (IsModelPropertyExistsOnSymbol(dbContext, modelTypeFullName))
-            {
-                return true;
-            }
-
             ITypeSymbol workingDbContext = dbContext;
-            while (workingDbContext.BaseType != null)
+            do
             {
-                workingDbContext = workingDbContext.BaseType;
-
                 if (IsModelPropertyExistsOnSymbol(workingDbContext, modelTypeFullName))
                 {
                     return true;
                 }
-            }
+
+                workingDbContext = workingDbContext.BaseType;
+            } while (workingDbContext != null);
 
             return false;
         }

--- a/test/E2E_Test/Compiler/Resources/BlogsController.txt
+++ b/test/E2E_Test/Compiler/Resources/BlogsController.txt
@@ -1,0 +1,106 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Test.Data;
+using Test.Models;
+
+namespace Test.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class BlogsController : ControllerBase
+    {
+        private readonly DerivedDbContext _context;
+
+        public BlogsController(DerivedDbContext context)
+        {
+            _context = context;
+        }
+
+        // GET: api/Blogs
+        [HttpGet]
+        public async Task<ActionResult<IEnumerable<Blog>>> GetBase_Blogs()
+        {
+            return await _context.Base_Blogs.ToListAsync();
+        }
+
+        // GET: api/Blogs/5
+        [HttpGet("{id}")]
+        public async Task<ActionResult<Blog>> GetBlog(int id)
+        {
+            var blog = await _context.Base_Blogs.FindAsync(id);
+
+            if (blog == null)
+            {
+                return NotFound();
+            }
+
+            return blog;
+        }
+
+        // PUT: api/Blogs/5
+        [HttpPut("{id}")]
+        public async Task<IActionResult> PutBlog(int id, Blog blog)
+        {
+            if (id != blog.Id)
+            {
+                return BadRequest();
+            }
+
+            _context.Entry(blog).State = EntityState.Modified;
+
+            try
+            {
+                await _context.SaveChangesAsync();
+            }
+            catch (DbUpdateConcurrencyException)
+            {
+                if (!BlogExists(id))
+                {
+                    return NotFound();
+                }
+                else
+                {
+                    throw;
+                }
+            }
+
+            return NoContent();
+        }
+
+        // POST: api/Blogs
+        [HttpPost]
+        public async Task<ActionResult<Blog>> PostBlog(Blog blog)
+        {
+            _context.Base_Blogs.Add(blog);
+            await _context.SaveChangesAsync();
+
+            return CreatedAtAction("GetBlog", new { id = blog.Id }, blog);
+        }
+
+        // DELETE: api/Blogs/5
+        [HttpDelete("{id}")]
+        public async Task<ActionResult<Blog>> DeleteBlog(int id)
+        {
+            var blog = await _context.Base_Blogs.FindAsync(id);
+            if (blog == null)
+            {
+                return NotFound();
+            }
+
+            _context.Base_Blogs.Remove(blog);
+            await _context.SaveChangesAsync();
+
+            return blog;
+        }
+
+        private bool BlogExists(int id)
+        {
+            return _context.Base_Blogs.Any(e => e.Id == id);
+        }
+    }
+}

--- a/test/E2E_Test/Compiler/Resources/BlogsDerivedDbContext.txt
+++ b/test/E2E_Test/Compiler/Resources/BlogsDerivedDbContext.txt
@@ -1,0 +1,19 @@
+﻿
+using System.Linq;
+using Microsoft.EntityFrameworkCore;
+
+namespace Test.Data
+{
+    public class DerivedDbContext : BaseDbContext
+    {
+        public DerivedDbContext(DbContextOptions<DerivedDbContext> options)
+            : base(new DbContextOptions<BaseDbContext>(options.Extensions.ToDictionary(x => x.GetType(), x => x)))
+        {
+        }
+
+        public DerivedDbContext(DbContextOptions<BaseDbContext> options)
+            : base(options)
+        {
+        }
+    }
+}

--- a/test/E2E_Test/E2E_Test.csproj
+++ b/test/E2E_Test/E2E_Test.csproj
@@ -13,6 +13,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Remove="Compiler\Resources\BlogsController.txt" />
+    <None Remove="Compiler\Resources\BlogsDerivedDbContext.txt" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="$(MicrosoftExtensionsFileProvidersPhysicalPackageVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
     <PackageReference Include="NuGet.Frameworks" Version="$(NuGetFrameworksPackageVersion)" />

--- a/test/E2E_Test/MvcControllerTest.cs
+++ b/test/E2E_Test/MvcControllerTest.cs
@@ -269,5 +269,47 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.E2E_Test
                 VerifyFileAndContent(Path.Combine(TestProjectPath, "Views", "Shared", "_ValidationScriptsPartial.cshtml"), Path.Combine("SharedViews", "_ValidationScriptsPartial.cshtml"));
             }
         }
+
+        [Fact]
+        public void TestApiControllerWithModelPropertyInParentDbContextClass()
+        {
+            using (TemporaryFileProvider fileProvider = new TemporaryFileProvider())
+            {
+                new MsBuildProjectSetupHelper().SetupProjectWithModelPropertyInParentDbContextClass(fileProvider, Output);
+                TestProjectPath = fileProvider.Root;
+
+                string[] args = new string[]
+                {
+                    "-p",
+                    Path.Combine(TestProjectPath, "Test.csproj"),
+                    "-c",
+                    Configuration,
+                    "controller",
+                    "--controllerName",
+                    "BlogsController",
+                    "--model",
+                    "Test.Models.Blog",
+                    "--dataContext",
+                    "Test.Data.DerivedDbContext",
+                    "--referenceScriptLibraries",
+                    "--relativeFolderPath",
+                    "Controllers",
+                    "--restWithNoViews",
+                    "--bootstrapVersion",
+                    "3"
+                };
+
+                Scaffold(args, TestProjectPath);
+                string generatedFilePath = Path.Combine(TestProjectPath, "Controllers", "BlogsController.cs");
+
+                VerifyFileAndContent(generatedFilePath, "BlogsController.txt");
+
+                // verify that the db context wasn't modified, since the model is refernced in the base class.
+                string derivedDataContextPath = Path.Combine(TestProjectPath, "Data", MsBuildProjectStrings.DerivedDbContextFileName);
+                VerifyFileAndContent(derivedDataContextPath, "BlogsDerivedDbContext.txt");
+            }
+
+            Assert.True(false, "dummy assert to force failure");
+        }
     }
 }

--- a/test/E2E_Test/MvcControllerTest.cs
+++ b/test/E2E_Test/MvcControllerTest.cs
@@ -291,7 +291,6 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.E2E_Test
                     "Test.Models.Blog",
                     "--dataContext",
                     "Test.Data.DerivedDbContext",
-                    "--referenceScriptLibraries",
                     "--relativeFolderPath",
                     "Controllers",
                     "--restWithNoViews",
@@ -308,8 +307,6 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration.E2E_Test
                 string derivedDataContextPath = Path.Combine(TestProjectPath, "Data", MsBuildProjectStrings.DerivedDbContextFileName);
                 VerifyFileAndContent(derivedDataContextPath, "BlogsDerivedDbContext.txt");
             }
-
-            Assert.True(false, "dummy assert to force failure");
         }
     }
 }

--- a/test/Shared/MsBuildProjectSetupHelper.cs
+++ b/test/Shared/MsBuildProjectSetupHelper.cs
@@ -192,7 +192,7 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration
             Directory.CreateDirectory(Path.Combine(fileProvider.Root, "Controllers"));
             Directory.CreateDirectory(Path.Combine(fileProvider.Root, "toolAssets", "netcoreapp2.0"));
 
-            fileProvider.Add($"TestCodeGeneration.targets", MsBuildProjectStrings.TestCodeGenerationTargetFileText);
+            fileProvider.Add($"TestCodeGeneration.targets", MsBuildProjectStrings.DbContextInheritanceTestCodeGenerationTargetFileText);
 
             var msbuildTaskDllPath = Path.Combine(Path.GetDirectoryName(typeof(MsBuildProjectSetupHelper).Assembly.Location), "Microsoft.VisualStudio.Web.CodeGeneration.Msbuild.dll");
             fileProvider.Copy(msbuildTaskDllPath, "toolAssets/netcoreapp2.0/Microsoft.VisualStudio.Web.CodeGeneration.Msbuild.dll");
@@ -203,7 +203,7 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration
             fileProvider.Add(MsBuildProjectStrings.DbContextInheritanceProgramName, MsBuildProjectStrings.DbContextInheritanceProjectProgramText);
             fileProvider.Add(MsBuildProjectStrings.AppSettingsFileName, MsBuildProjectStrings.AppSettingsFileTxt);
 
-            fileProvider.Add("Models/BlogModel.cs", MsBuildProjectStrings.BlogModelText);
+            fileProvider.Add("Models/Blog.cs", MsBuildProjectStrings.BlogModelText);
             fileProvider.Add("Data/BaseDbContext.cs", MsBuildProjectStrings.BaseDbContextText);
             fileProvider.Add($"Data/{MsBuildProjectStrings.DerivedDbContextFileName}", MsBuildProjectStrings.DerivedDbContextText);
 

--- a/test/Shared/MsBuildProjectSetupHelper.cs
+++ b/test/Shared/MsBuildProjectSetupHelper.cs
@@ -183,5 +183,31 @@ namespace Microsoft.VisualStudio.Web.CodeGeneration
 
             RestoreAndBuild(Path.Combine(fileProvider.Root, "Root"), output);
         }
+
+        public void SetupProjectWithModelPropertyInParentDbContextClass(TemporaryFileProvider fileProvider, ITestOutputHelper output)
+        {
+            fileProvider.Add("global.json", GlobalJsonText);
+            Directory.CreateDirectory(Path.Combine(fileProvider.Root, "Models"));
+            Directory.CreateDirectory(Path.Combine(fileProvider.Root, "Data"));
+            Directory.CreateDirectory(Path.Combine(fileProvider.Root, "Controllers"));
+            Directory.CreateDirectory(Path.Combine(fileProvider.Root, "toolAssets", "netcoreapp2.0"));
+
+            fileProvider.Add($"TestCodeGeneration.targets", MsBuildProjectStrings.TestCodeGenerationTargetFileText);
+
+            var msbuildTaskDllPath = Path.Combine(Path.GetDirectoryName(typeof(MsBuildProjectSetupHelper).Assembly.Location), "Microsoft.VisualStudio.Web.CodeGeneration.Msbuild.dll");
+            fileProvider.Copy(msbuildTaskDllPath, "toolAssets/netcoreapp2.0/Microsoft.VisualStudio.Web.CodeGeneration.Msbuild.dll");
+
+            var rootProjectTxt = MsBuildProjectStrings.DbContextInheritanceProjectTxt;
+            fileProvider.Add(MsBuildProjectStrings.RootProjectName, rootProjectTxt);
+            fileProvider.Add("Startup.cs", MsBuildProjectStrings.DerivedContextTestStartupText);
+            fileProvider.Add(MsBuildProjectStrings.DbContextInheritanceProgramName, MsBuildProjectStrings.DbContextInheritanceProjectProgramText);
+            fileProvider.Add(MsBuildProjectStrings.AppSettingsFileName, MsBuildProjectStrings.AppSettingsFileTxt);
+
+            fileProvider.Add("Models/BlogModel.cs", MsBuildProjectStrings.BlogModelText);
+            fileProvider.Add("Data/BaseDbContext.cs", MsBuildProjectStrings.BaseDbContextText);
+            fileProvider.Add($"Data/{MsBuildProjectStrings.DerivedDbContextFileName}", MsBuildProjectStrings.DerivedDbContextText);
+
+            RestoreAndBuild(fileProvider.Root, output);
+        }
     }
 }

--- a/test/Shared/MsBuildProjectStrings.cs.in
+++ b/test/Shared/MsBuildProjectStrings.cs.in
@@ -704,5 +704,161 @@ namespace Test.Data
     }
 }
 ";
+
+// Strings for model property defined in db context base class
+        public const string DbContextInheritanceProgramName = "Program.cs";
+        public const string DbContextInheritanceProjectProgramText = @"using System;
+using Microsoft.AspNetCore;
+using Microsoft.AspNetCore.Hosting;
+
+namespace Test
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            BuildWebHost(args).Run();
+        }
+
+        public static IWebHost BuildWebHost(string[] args) =>
+            WebHost
+                .CreateDefaultBuilder(args)
+                .UseStartup<Startup>()
+                .Build();
+    }
+}
+";
+
+    public const string DbContextInheritanceProjectTxt = @"
+<Project Sdk=""Microsoft.NET.Sdk.Web"">
+  <Import Project=""$(MSBuildThisFileDirectory)\TestCodeGeneration.targets"" Condition=""Exists('$(MSBuildThisFileDirectory)\TestCodeGeneration.targets')"" />
+
+  <PropertyGroup>
+    <RestoreSources>${RestoreSources}</RestoreSources>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <RootNamespace>Microsoft.TestProject</RootNamespace>
+    <ProjectName>TestProject</ProjectName>
+    <NoWarn>NU1605</NoWarn>
+    <RuntimeFrameworkVersion Condition=""'$(TargetFramework)'=='netcoreapp2.0'"">${MicrosoftNETCoreApp20PackageVersion}</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion Condition=""'$(TargetFramework)'=='netcoreapp2.1'"">${MicrosoftNETCoreApp21PackageVersion}</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion Condition=""'$(TargetFramework)'=='netcoreapp2.2'"">${MicrosoftNETCoreApp22PackageVersion}</RuntimeFrameworkVersion>
+    <!-- aspnet/BuildTools#662 Don't police what version of NetCoreApp we use -->
+    <NETCoreAppMaximumVersion>99.9</NETCoreAppMaximumVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include=""Microsoft.ApplicationInsights.AspNetCore"" Version=""${MicrosoftApplicationInsightsAspNetCorePackageVersion}"" />
+    <PackageReference Include=""Microsoft.AspNetCore"" Version=""${MicrosoftAspNetCorePackageVersion}"" />
+    <PackageReference Include=""Microsoft.AspNetCore.Mvc"" Version=""${MicrosoftAspNetCoreMvcPackageVersion}"" />
+    <PackageReference Include=""Microsoft.AspNetCore.StaticFiles"" Version=""${MicrosoftAspNetCoreStaticFilesPackageVersion}"" />
+    <PackageReference Include=""Microsoft.Extensions.Logging.Debug"" Version=""${MicrosoftExtensionsLoggingDebugPackageVersion}"" />
+    <PackageReference Include=""Microsoft.VisualStudio.Web.BrowserLink"" Version=""${MicrosoftVisualStudioWebBrowserLinkPackageVersion}"" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include=""Microsoft.AspNetCore.Authentication.Cookies"" Version=""${MicrosoftAspNetCoreAuthenticationCookiesPackageVersion}"" />
+    <PackageReference Include=""Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore"" Version=""${MicrosoftAspNetCoreDiagnosticsEntityFrameworkCorePackageVersion}"" />
+    <PackageReference Include=""Microsoft.AspNetCore.Identity.EntityFrameworkCore"" Version=""${MicrosoftAspNetCoreIdentityEntityFrameworkCorePackageVersion}"" />
+    <PackageReference Include=""Microsoft.EntityFrameworkCore.Design"" Version=""${MicrosoftEntityFrameworkCoreDesignPackageVersion}"" />
+    <PackageReference Include=""Microsoft.EntityFrameworkCore.SqlServer"" Version=""${MicrosoftEntityFrameworkCoreSqlServerPackageVersion}"" />
+    <PackageReference Include=""Microsoft.Extensions.Configuration.UserSecrets"" Version=""${MicrosoftExtensionsConfigurationUserSecretsPackageVersion}"" />
+    <PackageReference Include=""Microsoft.VisualStudio.Web.CodeGeneration.Design"" Version=""${MicrosoftVisualStudioWebCodeGenerationDesignPackageVersion}"" />
+  </ItemGroup>
+  <ItemFroup>
+    <Folder Include=""Controllers\"" />
+  </ItemGroup>
+</Project>
+";
+
+        public const string BaseDbContextText = @"
+using Microsoft.EntityFrameworkCore;
+using Test.Models;
+
+namespace Test.Data
+{
+    public class BaseDbContext : DbContext
+    {
+        public BaseDbContext(DbContextOptions<BaseDbContext> options)
+            : base(options)
+        {
+        }
+
+        public DbSet<Blog> Base_Blogs { get; set; }
+    }
+}
+";
+        public const string DerivedDbContextFileName = "DerivedDbContext.cs";
+        public const string DerivedDbContextText = @"
+using System.Linq;
+using Microsoft.EntityFrameworkCore;
+
+namespace Test.Data
+{
+    public class DerivedDbContext : BaseDbContext
+    {
+        public DerivedDbContext(DbContextOptions<DerivedDbContext> options)
+            : base(new DbContextOptions<BaseDbContext>(options.Extensions.ToDictionary(x => x.GetType(), x => x)))
+        {
+        }
+
+        public DerivedDbContext(DbContextOptions<BaseDbContext> options)
+            : base(options)
+        {
+        }
+    }
+}
+";
+
+        public const string DerivedContextTestStartupText = @"
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.EntityFrameworkCore;
+using Test.Models;
+using Test.Data;
+
+namespace Test
+{
+    public class Startup
+    {
+        public Startup(IConfiguration configuration)
+        {
+            Configuration = configuration;
+        }
+
+        public IConfiguration Configuration { get; }
+
+        // This method gets called by the runtime. Use this method to add services to the container.
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddMvc();
+
+            services.AddDbContext<DerivedDbContext>(options =>
+                    options.UseSqlServer(Configuration.GetConnectionString(""DefaultConnection"")));
+        }
+
+        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        {
+            app.UseStaticFiles();
+            app.UseMvc();
+        }
+    }
+}
+";
+
+        public const string BlogModelText = @"
+namespace Test.Models
+{
+    public class Blog
+    {
+        public int Id { get; set; }
+        public string User { get; set; }
+        public string Message { get; set; }
+    }
+}
+";
     }
 }

--- a/test/Shared/MsBuildProjectStrings.cs.in
+++ b/test/Shared/MsBuildProjectStrings.cs.in
@@ -736,8 +736,8 @@ namespace Test
   <PropertyGroup>
     <RestoreSources>${RestoreSources}</RestoreSources>
     <TargetFramework>netcoreapp2.2</TargetFramework>
-    <RootNamespace>Microsoft.TestProject</RootNamespace>
-    <ProjectName>TestProject</ProjectName>
+    <RootNamespace>Microsoft.Test</RootNamespace>
+    <ProjectName>Test</ProjectName>
     <NoWarn>NU1605</NoWarn>
     <RuntimeFrameworkVersion Condition=""'$(TargetFramework)'=='netcoreapp2.0'"">${MicrosoftNETCoreApp20PackageVersion}</RuntimeFrameworkVersion>
     <RuntimeFrameworkVersion Condition=""'$(TargetFramework)'=='netcoreapp2.1'"">${MicrosoftNETCoreApp21PackageVersion}</RuntimeFrameworkVersion>
@@ -747,19 +747,18 @@ namespace Test
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include=""Microsoft.ApplicationInsights.AspNetCore"" Version=""${MicrosoftApplicationInsightsAspNetCorePackageVersion}"" />
     <PackageReference Include=""Microsoft.AspNetCore"" Version=""${MicrosoftAspNetCorePackageVersion}"" />
     <PackageReference Include=""Microsoft.AspNetCore.Mvc"" Version=""${MicrosoftAspNetCoreMvcPackageVersion}"" />
     <PackageReference Include=""Microsoft.AspNetCore.StaticFiles"" Version=""${MicrosoftAspNetCoreStaticFilesPackageVersion}"" />
-    <PackageReference Include=""Microsoft.Extensions.Logging.Debug"" Version=""${MicrosoftExtensionsLoggingDebugPackageVersion}"" />
-    <PackageReference Include=""Microsoft.VisualStudio.Web.BrowserLink"" Version=""${MicrosoftVisualStudioWebBrowserLinkPackageVersion}"" />
+    <PackageReference Include=""Microsoft.EntityFrameworkCore.Design"" Version=""${MicrosoftEntityFrameworkCoreDesignPackageVersion}"" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include=""Microsoft.AspNetCore.Authentication.Cookies"" Version=""${MicrosoftAspNetCoreAuthenticationCookiesPackageVersion}"" />
-    <PackageReference Include=""Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore"" Version=""${MicrosoftAspNetCoreDiagnosticsEntityFrameworkCorePackageVersion}"" />
-    <PackageReference Include=""Microsoft.AspNetCore.Identity.EntityFrameworkCore"" Version=""${MicrosoftAspNetCoreIdentityEntityFrameworkCorePackageVersion}"" />
-    <PackageReference Include=""Microsoft.EntityFrameworkCore.Design"" Version=""${MicrosoftEntityFrameworkCoreDesignPackageVersion}"" />
     <PackageReference Include=""Microsoft.EntityFrameworkCore.SqlServer"" Version=""${MicrosoftEntityFrameworkCoreSqlServerPackageVersion}"" />
+    <PackageReference Include=""Microsoft.EntityFrameworkCore.Tools"" Version=""${MicrosoftEntityFrameworkCoreDesignPackageVersion}"">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+
     <PackageReference Include=""Microsoft.Extensions.Configuration.UserSecrets"" Version=""${MicrosoftExtensionsConfigurationUserSecretsPackageVersion}"" />
     <PackageReference Include=""Microsoft.VisualStudio.Web.CodeGeneration.Design"" Version=""${MicrosoftVisualStudioWebCodeGenerationDesignPackageVersion}"" />
   </ItemGroup>
@@ -859,6 +858,63 @@ namespace Test.Models
         public string Message { get; set; }
     }
 }
+";
+      public const string DbContextInheritanceTestCodeGenerationTargetFileText = @"<Project xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+<!--
+**********************************************************************************
+Target: EvaluateProjectInfoForCodeGeneration
+
+Outputs the Project Information needed for CodeGeneration to a file.
+
+**********************************************************************************
+-->
+
+  <PropertyGroup>
+    <EvaluateProjectInfoForCodeGenerationDependsOn>
+      $(EvaluateProjectInfoForCodeGenerationDependsOn);
+      ResolveReferences;
+      ResolvePackageDependenciesDesignTime;
+    </EvaluateProjectInfoForCodeGenerationDependsOn>
+  </PropertyGroup>
+  <Choose>
+    <!-- For Portable Msbuild, MSBuildRuntimeType = 'Core'. For Desktop MsBuild, MSBuildRuntimeType = 'Full'-->
+    <When Condition=""'$(MSBuildRuntimeType)' == 'Core'"">
+      <PropertyGroup>
+        <EvaluateProjectInfoForCodeGenerationAssemblyPath>$(MSBuildThisFileDirectory)\toolAssets\netcoreapp2.0\Microsoft.VisualStudio.Web.CodeGeneration.Msbuild.dll</EvaluateProjectInfoForCodeGenerationAssemblyPath>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup >
+        <EvaluateProjectInfoForCodeGenerationAssemblyPath>$(MSBuildThisFileDirectory)\toolAssets\net461\Microsoft.VisualStudio.Web.CodeGeneration.Msbuild.dll</EvaluateProjectInfoForCodeGenerationAssemblyPath>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+
+  <UsingTask TaskName=""ProjectContextWriter""
+             AssemblyFile=""$(EvaluateProjectInfoForCodeGenerationAssemblyPath)"" />
+
+  <Target Name=""EvaluateProjectInfoForCodeGeneration"" DependsOnTargets=""$(EvaluateProjectInfoForCodeGenerationDependsOn)"">
+
+    <ProjectContextWriter TargetFramework =""$(TargetFramework)""
+                          OutputFile =""$(OutputFile)""
+                          Name =""$(ProjectName)""
+                          ResolvedReferences =""@(ReferencePath)""
+                          PackageDependencies =""@(_DependenciesDesignTime)""
+                          ProjectReferences =""@(ProjectReference)""
+                          AssemblyFullPath =""$(TargetPath)""
+                          OutputType=""$(OutputType)""
+                          Platform=""$(Platform)""
+                          RootNameSpace =""$(RootNamespace)""
+                          CompilationItems =""@(Compile)""
+                          TargetDirectory=""$(TargetDir)""
+                          EmbeddedItems=""@(EmbeddedResource)""
+                          Configuration=""$(Configuration)""
+                          ProjectFullPath=""$(MSBuildProjectFullPath)""
+                          ProjectDepsFileName=""$(ProjectDepsFileName)""
+                          ProjectRuntimeConfigFileName=""$(ProjectRuntimeConfigFileName)""/>
+
+  </Target>
+</Project>
 ";
     }
 }

--- a/test/Shared/MsBuildProjectStrings.cs.in
+++ b/test/Shared/MsBuildProjectStrings.cs.in
@@ -763,7 +763,7 @@ namespace Test
     <PackageReference Include=""Microsoft.Extensions.Configuration.UserSecrets"" Version=""${MicrosoftExtensionsConfigurationUserSecretsPackageVersion}"" />
     <PackageReference Include=""Microsoft.VisualStudio.Web.CodeGeneration.Design"" Version=""${MicrosoftVisualStudioWebCodeGenerationDesignPackageVersion}"" />
   </ItemGroup>
-  <ItemFroup>
+  <ItemGroup>
     <Folder Include=""Controllers\"" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Before this fix, if the model property is defined on a class that the selected db context is derived from, the model property would be added on the selected db context. This would hide the base classes model property.