### PR TITLE
Fix identity generator test. Fixes case diff between config and actual filenames

### DIFF
--- a/src/VS.Web.CG.Mvc/Identity/bootstrap3_identitygeneratorfilesconfig.json
+++ b/src/VS.Web.CG.Mvc/Identity/bootstrap3_identitygeneratorfilesconfig.json
@@ -798,8 +798,8 @@
       },
       {
         "Name": "Jquery.validate.min.js",
-        "SourcePath": "wwwroot/lib/jquery-validation/dist/Jquery.validate.min.js",
-        "OutputPath": "wwwroot/lib/jquery-validation/dist/Jquery.validate.min.js",
+        "SourcePath": "wwwroot/lib/jquery-validation/dist/jquery.validate.min.js",
+        "OutputPath": "wwwroot/lib/jquery-validation/dist/jquery.validate.min.js",
         "IsTemplate": false,
         "ShowInListFiles": false
       },

--- a/src/VS.Web.CG.Mvc/Identity/bootstrap4_identitygeneratorfilesconfig.json
+++ b/src/VS.Web.CG.Mvc/Identity/bootstrap4_identitygeneratorfilesconfig.json
@@ -770,8 +770,8 @@
       },
       {
         "Name": "Jquery.validate.min.js",
-        "SourcePath": "wwwroot/lib/jquery-validation/dist/Jquery.validate.min.js",
-        "OutputPath": "wwwroot/lib/jquery-validation/dist/Jquery.validate.min.js",
+        "SourcePath": "wwwroot/lib/jquery-validation/dist/jquery.validate.min.js",
+        "OutputPath": "wwwroot/lib/jquery-validation/dist/jquery.validate.min.js",
         "IsTemplate": false,
         "ShowInListFiles": false
       },


### PR DESCRIPTION
This is meant to fix this issue: #750 

Most of the errors referenced in those tests indicate a casing issue between a filename on disk and how the file is referenced in the config files being changed here (which should only be an issue on *nix). But it seems like this error would have been occurring since identity scaffolding was added.

This may be a red-herring in terms of the test failures, but the config should match case anyway.