### PR TITLE
Use Internal.AspNetCore.Sdk as an MSBuild SDK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,5 +36,5 @@ project.fragment.lock.json
 .vscode/**
 backup/**/*.*
 .dotnet/**
-global.json
 *.g.targets
+*.binlog

--- a/NuGet.config
+++ b/NuGet.config
@@ -2,6 +2,10 @@
 <configuration>
   <packageSources>
     <clear />
-    <!-- Restore sources should be defined in build/sources.props. -->
+    <!--
+      Restore sources should be defined in build/sources.props.
+      The only allowed feed here is myget.org/aspnet-tools which is required to workaround https://github.com/Microsoft/msbuild/issues/2914
+    -->
+    <add key="myget.org aspnetcore-tools" value="https://dotnet.myget.org/F/aspnetcore-tools/api/v3/index.json" />
   </packageSources>
 </configuration>

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -3,7 +3,6 @@
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
   </PropertyGroup>
   <PropertyGroup Label="Package Versions">
-    <InternalAspNetCoreSdkPackageVersion>2.2.0-preview1-20180928.5</InternalAspNetCoreSdkPackageVersion>
     <MicrosoftApplicationInsightsAspNetCorePackageVersion>2.1.1</MicrosoftApplicationInsightsAspNetCorePackageVersion>
     <MicrosoftAspNetCoreAuthenticationCookiesPackageVersion>2.2.0-preview3-35359</MicrosoftAspNetCoreAuthenticationCookiesPackageVersion>
     <MicrosoftAspNetCoreDiagnosticsEntityFrameworkCorePackageVersion>2.2.0-preview3-35359</MicrosoftAspNetCoreDiagnosticsEntityFrameworkCorePackageVersion>

--- a/global.json
+++ b/global.json
@@ -1,0 +1,8 @@
+{
+    "sdk": {
+        "version": "2.2.100-preview2-009404"
+    },
+    "msbuild-sdks": {
+        "Internal.AspNetCore.Sdk": "2.2.0-preview2-20181001.5"
+    }
+}

--- a/korebuild-lock.txt
+++ b/korebuild-lock.txt
@@ -1,2 +1,2 @@
-version:2.2.0-preview1-20180928.5
-commithash:43faa29f679f47b88689d645b39e6be5e0055d70
+version:2.2.0-preview2-20181001.5
+commithash:89ae11d9237d412447f9ee4d5db6d7edf176f8df

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,0 @@
-﻿<Project>
-  <Import Project="..\Directory.Build.props" />
-
-  <ItemGroup>
-    <PackageReference Include="Internal.AspNetCore.Sdk" PrivateAssets="All" Version="$(InternalAspNetCoreSdkPackageVersion)" />
-  </ItemGroup>
-</Project>

--- a/src/VS.Web.CG.Contracts/VS.Web.CG.Contracts.csproj
+++ b/src/VS.Web.CG.Contracts/VS.Web.CG.Contracts.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Internal.AspNetCore.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>

--- a/src/VS.Web.CG.Core/VS.Web.CG.Core.csproj
+++ b/src/VS.Web.CG.Core/VS.Web.CG.Core.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Internal.AspNetCore.Sdk">
 
   <PropertyGroup>
     <Description>Contains the core infrastructure used by ASP.NET Core Code Generators.</Description>

--- a/src/VS.Web.CG.Design/VS.Web.CG.Design.csproj
+++ b/src/VS.Web.CG.Design/VS.Web.CG.Design.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Internal.AspNetCore.Sdk">
   <!--
    NOTE: Do not add package/ project references to this file.
    Edit the Shared.proj file to add additional package/ project references.

--- a/src/VS.Web.CG.EFCore/VS.Web.CG.EFCore.csproj
+++ b/src/VS.Web.CG.EFCore/VS.Web.CG.EFCore.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Internal.AspNetCore.Sdk">
   <PropertyGroup>
     <Description>Contains Entity Framework Core Services used by ASP.NET Core Code Generators.</Description>
     <TargetFramework>netstandard2.0</TargetFramework>

--- a/src/VS.Web.CG.Msbuild/VS.Web.CG.Msbuild.csproj
+++ b/src/VS.Web.CG.Msbuild/VS.Web.CG.Msbuild.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Internal.AspNetCore.Sdk">
 
   <PropertyGroup>
     <Description>MSBuild task (EvaluateProjectInfoForCodeGeneration) used by Microsoft.VisualStudio.Web.CodeGeneration.Tools</Description>

--- a/src/VS.Web.CG.Mvc/VS.Web.CG.Mvc.csproj
+++ b/src/VS.Web.CG.Mvc/VS.Web.CG.Mvc.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Internal.AspNetCore.Sdk">
 
   <PropertyGroup>
     <Description>Code Generators for ASP.NET Core MVC. Contains code generators for MVC Controllers and Views.</Description>

--- a/src/VS.Web.CG.Templating/VS.Web.CG.Templating.csproj
+++ b/src/VS.Web.CG.Templating/VS.Web.CG.Templating.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Internal.AspNetCore.Sdk">
 
   <PropertyGroup>
     <Description>Contains Razor based templating host used by ASP.NET Core Code Generators.</Description>

--- a/src/VS.Web.CG.Utils/VS.Web.CG.Utils.csproj
+++ b/src/VS.Web.CG.Utils/VS.Web.CG.Utils.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Internal.AspNetCore.Sdk">
 
   <PropertyGroup>
     <Description>Contains utilities used by ASP.NET Core Code Generation packages.</Description>

--- a/src/VS.Web.CG/VS.Web.CG.csproj
+++ b/src/VS.Web.CG/VS.Web.CG.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Internal.AspNetCore.Sdk">
 
   <PropertyGroup>
     <Description>Contains the CodeGenCommand that finds the appropriate code generator and invokes it from project dependencies.</Description>

--- a/src/dotnet-aspnet-codegenerator/dotnet-aspnet-codegenerator.csproj
+++ b/src/dotnet-aspnet-codegenerator/dotnet-aspnet-codegenerator.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Internal.AspNetCore.Sdk">
 
   <PropertyGroup>
     <Description>Code Generation tool for ASP.NET Core. Contains the dotnet-aspnet-codegenerator command used for generating controllers and views. </Description>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -4,11 +4,9 @@
   <PropertyGroup>
     <DeveloperBuildTestTfms>netcoreapp2.2</DeveloperBuildTestTfms>
     <StandardTestTfms>$(DeveloperBuildTestTfms)</StandardTestTfms>
-
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Internal.AspNetCore.Sdk" PrivateAssets="All" Version="$(InternalAspNetCoreSdkPackageVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Testing" Version="$(MicrosoftAspNetCoreTestingPackageVersion)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPackageVersion)" />
     <PackageReference Include="Moq" Version="$(MoqPackageVersion)" />

--- a/test/E2E_Test/E2E_Test.csproj
+++ b/test/E2E_Test/E2E_Test.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Internal.AspNetCore.Sdk">
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
     <NoWarn>$(NoWarn);CS1591</NoWarn>

--- a/test/Ext.ProjectModel.Tests/Ext.ProjectModel.Tests.csproj
+++ b/test/Ext.ProjectModel.Tests/Ext.ProjectModel.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Internal.AspNetCore.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(StandardTestTfms)</TargetFrameworks>
     <AssemblyName>Microsoft.Extensions.ProjectModel.Tests</AssemblyName>

--- a/test/VS.Web.CG.Core.FunctionalTest/VS.Web.CG.Core.FunctionalTest.csproj
+++ b/test/VS.Web.CG.Core.FunctionalTest/VS.Web.CG.Core.FunctionalTest.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Internal.AspNetCore.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(StandardTestTfms)</TargetFrameworks>
     <AssemblyName>Microsoft.VisualStudio.Web.CodeGeneration.Core.FunctionalTest</AssemblyName>

--- a/test/VS.Web.CG.Core.Test/VS.Web.CG.Core.Test.csproj
+++ b/test/VS.Web.CG.Core.Test/VS.Web.CG.Core.Test.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Internal.AspNetCore.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(StandardTestTfms)</TargetFrameworks>
     <AssemblyName>Microsoft.VisualStudio.Web.CodeGeneration.Core.Test</AssemblyName>

--- a/test/VS.Web.CG.EFCore.Test/VS.Web.CG.EFCore.Test.csproj
+++ b/test/VS.Web.CG.EFCore.Test/VS.Web.CG.EFCore.Test.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Internal.AspNetCore.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(StandardTestTfms)</TargetFrameworks>
     <AssemblyName>Microsoft.VisualStudio.Web.CodeGeneration.EntityFrameworkCore.Test</AssemblyName>

--- a/test/VS.Web.CG.MSBuild.Test/VS.Web.CG.MSBuild.Test.csproj
+++ b/test/VS.Web.CG.MSBuild.Test/VS.Web.CG.MSBuild.Test.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Internal.AspNetCore.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(StandardTestTfms)</TargetFrameworks>
     <AssemblyName>Microsoft.VisualStudio.Web.CodeGeneration.MSBuild.Test</AssemblyName>

--- a/test/VS.Web.CG.Mvc.Test/VS.Web.CG.Mvc.Test.csproj
+++ b/test/VS.Web.CG.Mvc.Test/VS.Web.CG.Mvc.Test.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Internal.AspNetCore.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(StandardTestTfms)</TargetFrameworks>
     <AssemblyName>Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Test</AssemblyName>

--- a/test/VS.Web.CG.Sources.Test/VS.Web.CG.Sources.Test.csproj
+++ b/test/VS.Web.CG.Sources.Test/VS.Web.CG.Sources.Test.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Internal.AspNetCore.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(StandardTestTfms)</TargetFrameworks>
     <AssemblyName>Microsoft.VisualStudio.Web.CodeGeneration.Sources.Test</AssemblyName>

--- a/test/VS.Web.CG.Templating.Test/VS.Web.CG.Templating.Test.csproj
+++ b/test/VS.Web.CG.Templating.Test/VS.Web.CG.Templating.Test.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Internal.AspNetCore.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(StandardTestTfms)</TargetFrameworks>
     <AssemblyName>Microsoft.VisualStudio.Web.CodeGeneration.Templating.Test</AssemblyName>

--- a/test/VS.Web.CG.Tools.Test/VS.Web.CG.Tools.Test.csproj
+++ b/test/VS.Web.CG.Tools.Test/VS.Web.CG.Tools.Test.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Internal.AspNetCore.Sdk">
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
     <AssemblyName>Microsoft.VisualStudio.Web.CodeGeneration.Tools.Test</AssemblyName>

--- a/tools/Directory.Build.props
+++ b/tools/Directory.Build.props
@@ -4,8 +4,4 @@
   <PropertyGroup>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Internal.AspNetCore.Sdk" PrivateAssets="All" Version="$(InternalAspNetCoreSdkPackageVersion)" />
-  </ItemGroup>
 </Project>

--- a/tools/Shared.props
+++ b/tools/Shared.props
@@ -1,7 +1,6 @@
 <Project>
   <Import Project="$(MSBuildThisFileDirectory)..\src\VS.Web.CG.Design\Shared.props" />
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
     <CodeGenDesignSrcPath>$(MSBuildThisFileDirectory)..\src\VS.Web.CG.Design\</CodeGenDesignSrcPath>
   </PropertyGroup>
   <ItemGroup>

--- a/tools/VS.Web.CG.Design-anycpu/VS.Web.CG.Design-anycpu.csproj
+++ b/tools/VS.Web.CG.Design-anycpu/VS.Web.CG.Design-anycpu.csproj
@@ -1,6 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Internal.AspNetCore.Sdk">
   <Import Project="..\Shared.props" />
   <PropertyGroup>
+    <TargetFramework>net461</TargetFramework>
     <PlatformTarget>AnyCpu</PlatformTarget>
   </PropertyGroup>
 </Project>

--- a/tools/VS.Web.CG.Design-arm/VS.Web.CG.Design-arm.csproj
+++ b/tools/VS.Web.CG.Design-arm/VS.Web.CG.Design-arm.csproj
@@ -1,6 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Internal.AspNetCore.Sdk">
   <Import Project="..\Shared.props" />
   <PropertyGroup>
+    <TargetFramework>net461</TargetFramework>
     <RuntimeIdentifier>win-arm</RuntimeIdentifier>
   </PropertyGroup>
 </Project>

--- a/tools/VS.Web.CG.Design-arm64/VS.Web.CG.Design-arm64.csproj
+++ b/tools/VS.Web.CG.Design-arm64/VS.Web.CG.Design-arm64.csproj
@@ -1,6 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Internal.AspNetCore.Sdk">
   <Import Project="..\Shared.props" />
   <PropertyGroup>
+    <TargetFramework>net461</TargetFramework>
     <RuntimeIdentifier>win-arm64</RuntimeIdentifier>
   </PropertyGroup>
 </Project>

--- a/tools/VS.Web.CG.Design-x86/VS.Web.CG.Design-x86.csproj
+++ b/tools/VS.Web.CG.Design-x86/VS.Web.CG.Design-x86.csproj
@@ -1,6 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Internal.AspNetCore.Sdk">
   <Import Project="..\Shared.props" />
   <PropertyGroup>
+    <TargetFramework>net461</TargetFramework>
     <RuntimeIdentifier>win7-x86</RuntimeIdentifier>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Convert from using Internal.AspNetCore.Sdk as a package reference to using it as an MSBuild SDK. This gives Internal.AspNetCore.Sdk more control over the projects and how they operation. MSBuild SDKs evaluate before restore, and can alter MSBuild settings which packages cannot.

