### PR TITLE
Fix for razor scaffolding when user project provides no bootstrap version

### DIFF
--- a/src/VS.Web.CG.Mvc/Controller/CommandLineGeneratorModel.cs
+++ b/src/VS.Web.CG.Mvc/Controller/CommandLineGeneratorModel.cs
@@ -37,6 +37,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Controller
             ControllerName = copyFrom.ControllerName;
             IsRestController = copyFrom.IsRestController;
             GenerateReadWriteActions = copyFrom.GenerateReadWriteActions;
+            BootstrapVersion = copyFrom.BootstrapVersion;
         }
 
         public override CommonCommandLineModel Clone()

--- a/src/VS.Web.CG.Mvc/RazorPage/RazorPageScaffolderBase.cs
+++ b/src/VS.Web.CG.Mvc/RazorPage/RazorPageScaffolderBase.cs
@@ -222,6 +222,11 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Razor
                 ? GetDefaultPageModelNamespaceName(razorGeneratorModel.RelativeFolderPath)
                 : razorGeneratorModel.NamespaceName;
 
+            if (string.IsNullOrEmpty(razorGeneratorModel.BootstrapVersion))
+            {
+                razorGeneratorModel.BootstrapVersion = RazorPageScaffolderBase.DefaultBootstrapVersion;
+            }
+
             RazorPageGeneratorTemplateModel2 templateModel = new RazorPageGeneratorTemplateModel2()
             {
                 NamespaceName = namespaceName,
@@ -248,6 +253,11 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Razor
             var namespaceName = string.IsNullOrEmpty(razorGeneratorModel.NamespaceName)
                 ? GetDefaultPageModelNamespaceName(razorGeneratorModel.RelativeFolderPath)
                 : razorGeneratorModel.NamespaceName;
+
+            if (string.IsNullOrEmpty(razorGeneratorModel.BootstrapVersion))
+            {
+                razorGeneratorModel.BootstrapVersion = RazorPageScaffolderBase.DefaultBootstrapVersion;
+            }
 
             RazorPageWithContextTemplateModel2 templateModel = new RazorPageWithContextTemplateModel2(modelTypeAndContextModel.ModelType, modelTypeAndContextModel.DbContextFullName)
             {


### PR DESCRIPTION
Causes razor page scaffolding to use the default bootstrap version when a bootstrap version is not provided by the command line args.