### PR TITLE
Removing bower file from identity config

### DIFF
--- a/src/VS.Web.CG.Mvc/Identity/identitygeneratorfilesconfig.json
+++ b/src/VS.Web.CG.Mvc/Identity/identitygeneratorfilesconfig.json
@@ -667,13 +667,6 @@
         "ShowInListFiles": false
       },
       {
-        "Name": "Lib.Bootstrap.bower.json",
-        "SourcePath": "wwwroot/lib/bootstrap/.bower.json",
-        "OutputPath": "wwwroot/lib/bootstrap/.bower.json",
-        "IsTemplate": false,
-        "ShowInListFiles": false
-      },
-      {
         "Name": "Lib.Bootstrap.License",
         "SourcePath": "wwwroot/lib/bootstrap/LICENSE",
         "OutputPath": "wwwroot/lib/bootstrap/LICENSE",


### PR DESCRIPTION
The file was removed from the directory tree in #949 - which broke Identity scaffolding of a project without a wwwroot directory. This resynchronizes the files on disk, and the configuration.
