### PR TITLE
Move RazorPageGenerator SelectLists from GET handler to OnPageHandlerExecutionAsync

### DIFF
--- a/src/VS.Web.CG.Mvc/Templates/RazorPageGenerator/Bootstrap3/CreatePageModel.cshtml
+++ b/src/VS.Web.CG.Mvc/Templates/RazorPageGenerator/Bootstrap3/CreatePageModel.cshtml
@@ -40,12 +40,6 @@ namespace @Model.NamespaceName
 
         public IActionResult OnGet()
         {
-@{
-    foreach (var property in relatedProperties.Values)
-    {
-        @:ViewData["@(property.ForeignKeyPropertyNames[0])"] = new SelectList(_context.@property.EntitySetName, "@property.PrimaryKeyNames[0]", "@property.DisplayPropertyName");
-    }
-}
             return Page();
         }
 
@@ -64,5 +58,20 @@ namespace @Model.NamespaceName
 
             return RedirectToPage("./Index");
         }
+@if (relatedProperties.Any())
+{
+
+        public override Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)
+        {
+@{
+    foreach (var property in relatedProperties.Values)
+    {
+            @:ViewData["@(property.ForeignKeyPropertyNames[0])"] = new SelectList(_context.@property.EntitySetName, "@property.PrimaryKeyNames[0]", "@property.DisplayPropertyName");
+    }
+}
+
+            return base.OnPageHandlerExecutionAsync(context, next);
+        }
+}
     }
 }

--- a/src/VS.Web.CG.Mvc/Templates/RazorPageGenerator/Bootstrap3/EditPageModel.cshtml
+++ b/src/VS.Web.CG.Mvc/Templates/RazorPageGenerator/Bootstrap3/EditPageModel.cshtml
@@ -61,12 +61,7 @@ namespace @Model.NamespaceName
             {
                 return NotFound();
             }
-@{
-    foreach (var property in relatedProperties.Values)
-    {
-           @:ViewData["@(property.ForeignKeyPropertyNames[0])"] = new SelectList(_context.@property.EntitySetName, "@property.PrimaryKeyNames[0]", "@property.DisplayPropertyName");
-    }
-}
+
             return Page();
         }
 
@@ -97,6 +92,21 @@ namespace @Model.NamespaceName
 
             return RedirectToPage("./Index");
         }
+@if (relatedProperties.Any())
+{
+
+        public override Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)
+        {
+@{
+    foreach (var property in relatedProperties.Values)
+    {
+            @:ViewData["@(property.ForeignKeyPropertyNames[0])"] = new SelectList(_context.@property.EntitySetName, "@property.PrimaryKeyNames[0]", "@property.DisplayPropertyName");
+    }
+}
+
+            return base.OnPageHandlerExecutionAsync(context, next);
+        }
+}
 
         private bool @(Model.ModelTypeName)Exists(@primaryKeyShortTypeName id)
         {

--- a/src/VS.Web.CG.Mvc/Templates/RazorPageGenerator/Bootstrap4/CreatePageModel.cshtml
+++ b/src/VS.Web.CG.Mvc/Templates/RazorPageGenerator/Bootstrap4/CreatePageModel.cshtml
@@ -40,12 +40,6 @@ namespace @Model.NamespaceName
 
         public IActionResult OnGet()
         {
-@{
-    foreach (var property in relatedProperties.Values)
-    {
-        @:ViewData["@(property.ForeignKeyPropertyNames[0])"] = new SelectList(_context.@property.EntitySetName, "@property.PrimaryKeyNames[0]", "@property.DisplayPropertyName");
-    }
-}
             return Page();
         }
 
@@ -64,5 +58,20 @@ namespace @Model.NamespaceName
 
             return RedirectToPage("./Index");
         }
+@if (relatedProperties.Any())
+{
+
+        public override Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)
+        {
+@{
+    foreach (var property in relatedProperties.Values)
+    {
+            @:ViewData["@(property.ForeignKeyPropertyNames[0])"] = new SelectList(_context.@property.EntitySetName, "@property.PrimaryKeyNames[0]", "@property.DisplayPropertyName");
+    }
+}
+
+            return base.OnPageHandlerExecutionAsync(context, next);
+        }
+}
     }
 }

--- a/src/VS.Web.CG.Mvc/Templates/RazorPageGenerator/Bootstrap4/EditPageModel.cshtml
+++ b/src/VS.Web.CG.Mvc/Templates/RazorPageGenerator/Bootstrap4/EditPageModel.cshtml
@@ -61,12 +61,7 @@ namespace @Model.NamespaceName
             {
                 return NotFound();
             }
-@{
-    foreach (var property in relatedProperties.Values)
-    {
-           @:ViewData["@(property.ForeignKeyPropertyNames[0])"] = new SelectList(_context.@property.EntitySetName, "@property.PrimaryKeyNames[0]", "@property.DisplayPropertyName");
-    }
-}
+
             return Page();
         }
 
@@ -97,6 +92,21 @@ namespace @Model.NamespaceName
 
             return RedirectToPage("./Index");
         }
+@if (relatedProperties.Any())
+{
+
+        public override Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)
+        {
+@{
+    foreach (var property in relatedProperties.Values)
+    {
+            @:ViewData["@(property.ForeignKeyPropertyNames[0])"] = new SelectList(_context.@property.EntitySetName, "@property.PrimaryKeyNames[0]", "@property.DisplayPropertyName");
+    }
+}
+
+            return base.OnPageHandlerExecutionAsync(context, next);
+        }
+}
 
         private bool @(Model.ModelTypeName)Exists(@primaryKeyShortTypeName id)
         {

--- a/test/E2E_Test/Compiler/Resources/RazorPages/CarCreateCs.txt
+++ b/test/E2E_Test/Compiler/Resources/RazorPages/CarCreateCs.txt
@@ -21,7 +21,6 @@ namespace TestProject
 
         public IActionResult OnGet()
         {
-        ViewData["ManufacturerID"] = new SelectList(_context.Set<Manufacturer>(), "ID", "ID");
             return Page();
         }
 
@@ -39,6 +38,13 @@ namespace TestProject
             await _context.SaveChangesAsync();
 
             return RedirectToPage("./Index");
+        }
+
+        public override Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)
+        {
+            ViewData["ManufacturerID"] = new SelectList(_context.Set<Manufacturer>(), "ID", "ID");
+
+            return base.OnPageHandlerExecutionAsync(context, next);
         }
     }
 }

--- a/test/E2E_Test/Compiler/Resources/RazorPages/CarCreateCsWithDAL.txt
+++ b/test/E2E_Test/Compiler/Resources/RazorPages/CarCreateCsWithDAL.txt
@@ -21,7 +21,6 @@ namespace TestProject
 
         public IActionResult OnGet()
         {
-        ViewData["ManufacturerID"] = new SelectList(_context.Set<Manufacturer>(), "ID", "ID");
             return Page();
         }
 
@@ -39,6 +38,13 @@ namespace TestProject
             await _context.SaveChangesAsync();
 
             return RedirectToPage("./Index");
+        }
+
+        public override Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)
+        {
+            ViewData["ManufacturerID"] = new SelectList(_context.Set<Manufacturer>(), "ID", "ID");
+
+            return base.OnPageHandlerExecutionAsync(context, next);
         }
     }
 }

--- a/test/E2E_Test/Compiler/Resources/RazorPages/Crud/CreateCs.txt
+++ b/test/E2E_Test/Compiler/Resources/RazorPages/Crud/CreateCs.txt
@@ -21,7 +21,6 @@ namespace TestProject
 
         public IActionResult OnGet()
         {
-        ViewData["ManufacturerID"] = new SelectList(_context.Set<Manufacturer>(), "ID", "ID");
             return Page();
         }
 
@@ -39,6 +38,13 @@ namespace TestProject
             await _context.SaveChangesAsync();
 
             return RedirectToPage("./Index");
+        }
+
+        public override Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)
+        {
+            ViewData["ManufacturerID"] = new SelectList(_context.Set<Manufacturer>(), "ID", "ID");
+
+            return base.OnPageHandlerExecutionAsync(context, next);
         }
     }
 }

--- a/test/E2E_Test/Compiler/Resources/RazorPages/Crud/EditCs.txt
+++ b/test/E2E_Test/Compiler/Resources/RazorPages/Crud/EditCs.txt
@@ -37,7 +37,7 @@ namespace TestProject
             {
                 return NotFound();
             }
-           ViewData["ManufacturerID"] = new SelectList(_context.Set<Manufacturer>(), "ID", "ID");
+
             return Page();
         }
 
@@ -67,6 +67,13 @@ namespace TestProject
             }
 
             return RedirectToPage("./Index");
+        }
+
+        public override Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)
+        {
+            ViewData["ManufacturerID"] = new SelectList(_context.Set<Manufacturer>(), "ID", "ID");
+
+            return base.OnPageHandlerExecutionAsync(context, next);
         }
 
         private bool CarExists(string id)


### PR DESCRIPTION
`SelectList` initializers are only being code-generated into the GET handlers, but not the POST handlers.  Since `.ViewData` entries do not persist across responses, the page will not render correctly when the POST handler does not redirect (i.e. because validation failed).

This change moves the initialization into a shared `OnPageHandlerExecutionAsync`, which is invoked after model binding but before the handler itself.  No need to dual-generate the initializers into both handlers!