### PR TITLE
Fixed missing .AddDefaultUI() in Identity template

### DIFF
--- a/src/VS.Web.CG.Mvc/Templates/Identity/Bootstrap3/IdentityHostingStartup.cshtml
+++ b/src/VS.Web.CG.Mvc/Templates/Identity/Bootstrap3/IdentityHostingStartup.cshtml
@@ -60,6 +60,10 @@ namespace @(thisNamespace)
 @:
 
 @:                services.AddDefaultIdentity<@(Model.UserClass)>()
+        if (Model.UseDefaultUI)
+        {
+@:                    .AddDefaultUI(UIFramework.Bootstrap3);
+        }
 @:                    .AddEntityFrameworkStores<@Model.DbContextClass>();
 
     } // End Model.IsUsingExstingDbContext

--- a/src/VS.Web.CG.Mvc/Templates/Identity/Bootstrap3/IdentityHostingStartup.cshtml
+++ b/src/VS.Web.CG.Mvc/Templates/Identity/Bootstrap3/IdentityHostingStartup.cshtml
@@ -62,7 +62,7 @@ namespace @(thisNamespace)
 @:                services.AddDefaultIdentity<@(Model.UserClass)>()
         if (Model.UseDefaultUI)
         {
-@:                    .AddDefaultUI(UIFramework.Bootstrap3);
+@:                    .AddDefaultUI(UIFramework.Bootstrap3)
         }
 @:                    .AddEntityFrameworkStores<@Model.DbContextClass>();
 

--- a/src/VS.Web.CG.Mvc/Templates/Identity/Bootstrap4/IdentityHostingStartup.cshtml
+++ b/src/VS.Web.CG.Mvc/Templates/Identity/Bootstrap4/IdentityHostingStartup.cshtml
@@ -62,7 +62,7 @@ namespace @(thisNamespace)
 @:                services.AddDefaultIdentity<@(Model.UserClass)>()
         if (Model.UseDefaultUI)
         {
-@:                    .AddDefaultUI(UIFramework.Bootstrap4);
+@:                    .AddDefaultUI(UIFramework.Bootstrap4)
         }
 @:                    .AddEntityFrameworkStores<@Model.DbContextClass>();
 

--- a/src/VS.Web.CG.Mvc/Templates/Identity/Bootstrap4/IdentityHostingStartup.cshtml
+++ b/src/VS.Web.CG.Mvc/Templates/Identity/Bootstrap4/IdentityHostingStartup.cshtml
@@ -1,4 +1,4 @@
-﻿@inherits Microsoft.VisualStudio.Web.CodeGeneration.Templating.RazorTemplateBase
+@inherits Microsoft.VisualStudio.Web.CodeGeneration.Templating.RazorTemplateBase
 @using System.Collections.Generic
 @using System.Linq
 using System;
@@ -60,6 +60,10 @@ namespace @(thisNamespace)
 @:
 
 @:                services.AddDefaultIdentity<@(Model.UserClass)>()
+        if (Model.UseDefaultUI)
+        {
+@:                    .AddDefaultUI(UIFramework.Bootstrap4);
+        }
 @:                    .AddEntityFrameworkStores<@Model.DbContextClass>();
 
     } // End Model.IsUsingExstingDbContext


### PR DESCRIPTION
When scaffolding ASP.NET Identity, there's an issue where the  --useDefaultUI flag doesn't actually include the `.AddDefaultUI()` method call in *IdentityHostingStartup.cs*.

This change checks the `AddDefaultUI` flag on the model and, if true, adds the required `.AddDefaultUI()` method call.

Related to https://github.com/aspnet/Scaffolding/issues/885, but doesn't resolve the original issue.

cc: @scottaddie 