### PR TITLE
Use constant for readme text file name

### DIFF
--- a/src/VS.Web.CG.Mvc/Identity/IdentityGeneratorFilesConfig.cs
+++ b/src/VS.Web.CG.Mvc/Identity/IdentityGeneratorFilesConfig.cs
@@ -39,7 +39,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Identity
         {
             Name = "ScaffoldingReadme",
             SourcePath = "ScaffoldingReadme.cshtml",
-            OutputPath = "./ScaffoldingReadme.txt",
+            OutputPath = $"./{Constants.ReadMeOutputFileName}",
             IsTemplate = true,
             ShouldOverWrite = OverWriteCondition.Always,
             ShowInListFiles = false


### PR DESCRIPTION
I noticed that the casing of the two file names differed. This PR makes use of the existing constant to enforce consistency.