### PR TITLE
adding IdentityHostingStartup file back

### DIFF
--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/Identity/Bootstrap5/IdentityHostingStartup.cshtml
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/Identity/Bootstrap5/IdentityHostingStartup.cshtml
@@ -1,0 +1,71 @@
+@inherits Microsoft.VisualStudio.Web.CodeGeneration.Templating.RazorTemplateBase
+@using System.Collections.Generic
+@using System.Linq
+using System;
+@{
+    var namespaceSet = new HashSet<string>(
+        new string[]
+        {
+            "Microsoft.AspNetCore.Identity",
+            "Microsoft.AspNetCore.Identity.UI",
+            "Microsoft.AspNetCore.Hosting",
+            "Microsoft.EntityFrameworkCore",
+            "Microsoft.Extensions.Configuration",
+            "Microsoft.Extensions.DependencyInjection",
+        });
+    var thisNamespace = @Model.Namespace + ".Areas.Identity";
+
+    if (!string.IsNullOrEmpty(Model.UserClassNamespace) && thisNamespace != Model.UserClassNamespace)
+    {
+        namespaceSet.Add(Model.UserClassNamespace);
+    }
+    else
+    {
+        namespaceSet.Add("Microsoft.AspNetCore.Identity.EntityFrameworkCore");
+    }
+    if (thisNamespace != Model.DbContextNamespace)
+    {
+        namespaceSet.Add(Model.DbContextNamespace);
+    }
+    foreach(var name in namespaceSet.OrderBy(n => n))
+    {
+@:using @name;
+    }
+}
+
+[assembly: HostingStartup(typeof(@(thisNamespace).IdentityHostingStartup))]
+namespace @(thisNamespace)
+{
+    public class IdentityHostingStartup : IHostingStartup
+    {
+        public void Configure(IWebHostBuilder builder)
+        {
+@{
+@:            builder.ConfigureServices((context, services) => {
+
+    if (!Model.IsUsingExistingDbContext)
+    {
+        if (Model.UseSQLite)
+        {
+@:                services.AddDbContext<@Model.DbContextClass>(options =>
+@:                    options.UseSqlite(
+@:                        context.Configuration.GetConnectionString("@(Model.DbContextClass)Connection")));
+        } // End if Model.UseSQLite
+        else
+        {
+@:                services.AddDbContext<@Model.DbContextClass>(options =>
+@:                    options.UseSqlServer(
+@:                        context.Configuration.GetConnectionString("@(Model.DbContextClass)Connection")));
+        } // End else
+@:
+
+@:                services.AddDefaultIdentity<@(Model.UserClass)>(options => options.SignIn.RequireConfirmedAccount = true)
+@:                    .AddEntityFrameworkStores<@Model.DbContextClass>();
+
+    } // End Model.IsUsingExstingDbContext
+
+@:            });
+        }
+        }
+    }
+}


### PR DESCRIPTION
adding IdentityHostingStartup.cshtml file back to fix Issues #1831, #1714. Logic already exists to ignore this file in minimal app scenarios [here](https://github.com/dotnet/Scaffolding/blob/7ffe40b8c1abc973cf8155336afb78cb3723bfff/src/Scaffolding/VS.Web.CG.Mvc/Identity/IdentityGenerator.cs#L255)

