### PR TITLE
Bump package versions in sh scripts

### DIFF
--- a/scripts/install-aspnet-codegenerator.sh
+++ b/scripts/install-aspnet-codegenerator.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-VERSION=8.0.0-dev
+VERSION=10.0.0-dev
 DEFAULT_NUPKG_PATH=~/.nuget/packages
 SRC_DIR=$(pwd)
 echo $SRC_DIR

--- a/scripts/install-msidentity.sh
+++ b/scripts/install-msidentity.sh
@@ -1,4 +1,4 @@
-VERSION=1.0.0-dev
+VERSION=2.0.7-dev
 DEFAULT_NUPKG_PATH=~/.nuget/packages
 SRC_DIR=$(pwd)
 NUPKG=artifacts/packages/Debug/Shipping/

--- a/scripts/install-scaffold-all.sh
+++ b/scripts/install-scaffold-all.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-VERSION=9.0.0-dev
+VERSION=10.0.0-dev
 DEFAULT_NUPKG_PATH=~/.nuget/packages
 SRC_DIR=$(pwd)
 echo $SRC_DIR

--- a/scripts/install-scaffold-aspire.sh
+++ b/scripts/install-scaffold-aspire.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-VERSION=9.0.0-dev
+VERSION=10.0.0-dev
 DEFAULT_NUPKG_PATH=~/.nuget/packages
 SRC_DIR=$(pwd)
 echo $SRC_DIR

--- a/scripts/install-scaffold-aspnet.sh
+++ b/scripts/install-scaffold-aspnet.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-VERSION=9.0.0-dev
+VERSION=10.0.0-dev
 DEFAULT_NUPKG_PATH=~/.nuget/packages
 SRC_DIR=$(pwd)
 echo $SRC_DIR

--- a/scripts/install-scaffold.sh
+++ b/scripts/install-scaffold.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-VERSION=9.0.0-dev
+VERSION=10.0.0-dev
 DEFAULT_NUPKG_PATH=~/.nuget/packages
 SRC_DIR=$(pwd)
 echo $SRC_DIR


### PR DESCRIPTION
these versions are out of date, all should be 10.0.0, except the msidentity which is 2.0.7


