### PR TITLE
fix hang: don't wait forever for a CLI command

### DIFF
--- a/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Internal/CliHelpers/AzCliRunner.cs
+++ b/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Internal/CliHelpers/AzCliRunner.cs
@@ -50,7 +50,21 @@ internal class AzCliRunner
         var taskOut = outStream.BeginRead(process.StandardOutput);
         var taskErr = errStream.BeginRead(process.StandardError);
 
-        process.WaitForExit();
+        // Wait for process to exit with a timeout (e.g., 30 seconds)
+        const int timeoutMilliseconds = 30000;
+        bool exited = process.WaitForExit(timeoutMilliseconds);
+
+        if (!exited)
+        {
+            try
+            {
+                process.Kill(entireProcessTree: true);
+            }
+            catch
+            {
+                // Ignore exceptions from killing the process
+            }
+        }
 
         taskOut.Wait();
         taskErr.Wait();


### PR DESCRIPTION
fixed #3217 
fixed #3220

`dotnet-scaffold-aspnet get-commands` was hanging.

This hang was caused by the `az cli` coming to completion, but we were always waiting for it and it caused a hang. Now, we don't wait forever. 

