### PR TITLE
move interactive experience to interactive dir in dotnet-scaffold

### DIFF
--- a/src/dotnet-scaffolding/dotnet-scaffold/Interactive/AppBuilder/ScaffoldCommandApp.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Interactive/AppBuilder/ScaffoldCommandApp.cs
@@ -1,6 +1,7 @@
-using Microsoft.DotNet.Tools.Scaffold.Command;
+using Microsoft.DotNet.Tools.Scaffold.Interactive.Command;
+using Spectre.Console.Cli;
 
-namespace Microsoft.DotNet.Tools.Scaffold;
+namespace Microsoft.DotNet.Tools.Scaffold.Interactive.AppBuilder;
 
 /// <summary>
 /// Represents the application entry point for running the scaffold command.
@@ -12,14 +13,14 @@ internal class ScaffoldCommandApp
     private readonly string[] _args;
 
     // The Spectre.Console command application instance for the scaffold command.
-    private readonly Spectre.Console.Cli.CommandApp<ScaffoldCommand> _commandApp;
+    private readonly CommandApp<ScaffoldCommand> _commandApp;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ScaffoldCommandApp"/> class.
     /// </summary>
     /// <param name="commandApp">The command application to execute.</param>
     /// <param name="args">The command-line arguments.</param>
-    public ScaffoldCommandApp(Spectre.Console.Cli.CommandApp<ScaffoldCommand> commandApp, string[] args)
+    public ScaffoldCommandApp(CommandApp<ScaffoldCommand> commandApp, string[] args)
     {
         _commandApp = commandApp;
         _args = args;

--- a/src/dotnet-scaffolding/dotnet-scaffold/Interactive/AppBuilder/ScaffoldCommandAppBuilder.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Interactive/AppBuilder/ScaffoldCommandAppBuilder.cs
@@ -1,13 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 using Microsoft.DotNet.Scaffolding.Internal.Services;
-using Microsoft.DotNet.Tools.Scaffold.AppBuilder;
-using Microsoft.DotNet.Tools.Scaffold.Command;
 using Microsoft.DotNet.Tools.Scaffold.Helpers;
+using Microsoft.DotNet.Tools.Scaffold.Interactive.Command;
+using Microsoft.DotNet.Tools.Scaffold.Interactive.Services;
 using Microsoft.DotNet.Tools.Scaffold.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Spectre.Console.Cli;
 
-namespace Microsoft.DotNet.Tools.Scaffold;
+namespace Microsoft.DotNet.Tools.Scaffold.Interactive.AppBuilder;
 
 /// <summary>
 /// Builds and configures the <see cref="ScaffoldCommandApp"/>, including service registration and command setup.

--- a/src/dotnet-scaffolding/dotnet-scaffold/Interactive/AppBuilder/TypeRegistrar.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Interactive/AppBuilder/TypeRegistrar.cs
@@ -1,12 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 
 using Microsoft.DotNet.Scaffolding.Core.Logging;
-using Microsoft.DotNet.Tools.Scaffold.AspNet.AppBuilder;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Spectre.Console.Cli;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AppBuilder;
+namespace Microsoft.DotNet.Tools.Scaffold.Interactive.AppBuilder;
 
 /// <summary>
 /// Provides a custom type registrar for dependency injection, used by Spectre.Console.Cli to resolve services.

--- a/src/dotnet-scaffolding/dotnet-scaffold/Interactive/AppBuilder/TypeResolver.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Interactive/AppBuilder/TypeResolver.cs
@@ -2,7 +2,7 @@
 
 using Spectre.Console.Cli;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.AppBuilder;
+namespace Microsoft.DotNet.Tools.Scaffold.Interactive.AppBuilder;
 
 /// <summary>
 /// Resolves service types using the provided <see cref="IServiceProvider"/>.

--- a/src/dotnet-scaffolding/dotnet-scaffold/Interactive/Command/BaseCommand.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Interactive/Command/BaseCommand.cs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 using Microsoft.DotNet.Scaffolding.Internal.Services;
-using Microsoft.DotNet.Tools.Scaffold.Flow;
-using Microsoft.DotNet.Tools.Scaffold.Services;
+using Microsoft.DotNet.Tools.Scaffold.Interactive.Flow;
+using Microsoft.DotNet.Tools.Scaffold.Interactive.Services;
 using Spectre.Console.Cli;
 using Spectre.Console.Flow;
 
-namespace Microsoft.DotNet.Tools.Scaffold.Command;
+namespace Microsoft.DotNet.Tools.Scaffold.Interactive.Command;
 
 /// <summary>
 /// Provides a base class for scaffold commands, handling flow execution and telemetry.

--- a/src/dotnet-scaffolding/dotnet-scaffold/Interactive/Command/ScaffoldCommand.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Interactive/Command/ScaffoldCommand.cs
@@ -1,12 +1,13 @@
 using System.ComponentModel;
 using Microsoft.DotNet.Scaffolding.Internal.Services;
-using Microsoft.DotNet.Tools.Scaffold.Flow.Steps;
+using Microsoft.DotNet.Tools.Scaffold.Interactive.Flow.Steps;
+using Microsoft.DotNet.Tools.Scaffold.Interactive.Services;
 using Microsoft.DotNet.Tools.Scaffold.Services;
 using Microsoft.Extensions.Logging;
 using Spectre.Console.Cli;
 using Spectre.Console.Flow;
 
-namespace Microsoft.DotNet.Tools.Scaffold.Command;
+namespace Microsoft.DotNet.Tools.Scaffold.Interactive.Command;
 
 /// <summary>
 /// Implements the main scaffold command, orchestrating the flow of user interaction and code generation.

--- a/src/dotnet-scaffolding/dotnet-scaffold/Interactive/Command/ToolInstallCommand.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Interactive/Command/ToolInstallCommand.cs
@@ -5,7 +5,7 @@ using System.Diagnostics.CodeAnalysis;
 using Microsoft.DotNet.Tools.Scaffold.Services;
 using Spectre.Console.Cli;
 
-namespace Microsoft.DotNet.Tools.Scaffold.Command;
+namespace Microsoft.DotNet.Tools.Scaffold.Interactive.Command;
 
 /// <summary>
 /// Command to handle the installation of tools via the scaffold CLI.

--- a/src/dotnet-scaffolding/dotnet-scaffold/Interactive/Command/ToolInstallSettings.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Interactive/Command/ToolInstallSettings.cs
@@ -4,7 +4,7 @@
 using System.ComponentModel;
 using Spectre.Console.Cli;
 
-namespace Microsoft.DotNet.Tools.Scaffold.Command;
+namespace Microsoft.DotNet.Tools.Scaffold.Interactive.Command;
 
 /// <summary>
 /// Represents the settings used for installing a tool via the scaffold CLI.

--- a/src/dotnet-scaffolding/dotnet-scaffold/Interactive/Command/ToolListCommand.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Interactive/Command/ToolListCommand.cs
@@ -5,7 +5,7 @@ using System.Diagnostics.CodeAnalysis;
 using Microsoft.DotNet.Tools.Scaffold.Services;
 using Spectre.Console.Cli;
 
-namespace Microsoft.DotNet.Tools.Scaffold.Command;
+namespace Microsoft.DotNet.Tools.Scaffold.Interactive.Command;
 
 /// <summary>
 /// Command to handle listing installed tools via the scaffold CLI.

--- a/src/dotnet-scaffolding/dotnet-scaffold/Interactive/Command/ToolListSettings.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Interactive/Command/ToolListSettings.cs
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-namespace Microsoft.DotNet.Tools.Scaffold.Command;
+namespace Microsoft.DotNet.Tools.Scaffold.Interactive.Command;
 
 /// <summary>
 /// Represents the settings used for listing installed tools via the scaffold CLI.

--- a/src/dotnet-scaffolding/dotnet-scaffold/Interactive/Command/ToolSettings.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Interactive/Command/ToolSettings.cs
@@ -3,7 +3,7 @@
 
 using Spectre.Console.Cli;
 
-namespace Microsoft.DotNet.Tools.Scaffold.Command
+namespace Microsoft.DotNet.Tools.Scaffold.Interactive.Command
 {
     /// <summary>
     /// Base settings class for tool-related scaffold commands.

--- a/src/dotnet-scaffolding/dotnet-scaffold/Interactive/Command/ToolUninstallCommand.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Interactive/Command/ToolUninstallCommand.cs
@@ -5,7 +5,7 @@ using System.Diagnostics.CodeAnalysis;
 using Microsoft.DotNet.Tools.Scaffold.Services;
 using Spectre.Console.Cli;
 
-namespace Microsoft.DotNet.Tools.Scaffold.Command;
+namespace Microsoft.DotNet.Tools.Scaffold.Interactive.Command;
 
 /// <summary>
 /// Command to handle the uninstallation of tools via the scaffold CLI.

--- a/src/dotnet-scaffolding/dotnet-scaffold/Interactive/Command/ToolUninstallSettings.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Interactive/Command/ToolUninstallSettings.cs
@@ -3,7 +3,7 @@
 
 using Spectre.Console.Cli;
 
-namespace Microsoft.DotNet.Tools.Scaffold.Command;
+namespace Microsoft.DotNet.Tools.Scaffold.Interactive.Command;
 
 /// <summary>
 /// Represents the settings used for uninstalling a tool via the scaffold CLI.

--- a/src/dotnet-scaffolding/dotnet-scaffold/Interactive/Flow/FlowContextProperties.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Interactive/Flow/FlowContextProperties.cs
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-namespace Microsoft.DotNet.Tools.Scaffold.Flow;
+namespace Microsoft.DotNet.Tools.Scaffold.Interactive.Flow;
 
 /// <summary>
 /// Provides constant property names used for storing and retrieving values in the flow context during scaffolding operations.

--- a/src/dotnet-scaffolding/dotnet-scaffold/Interactive/Flow/FlowExtensions.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Interactive/Flow/FlowExtensions.cs
@@ -2,12 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.Core.ComponentModel;
 using Microsoft.DotNet.Scaffolding.Roslyn.Services;
-using Microsoft.DotNet.Tools.Scaffold.Command;
+using Microsoft.DotNet.Tools.Scaffold.Interactive.Command;
 using Spectre.Console;
 using Spectre.Console.Cli;
 using Spectre.Console.Flow;
 
-namespace Microsoft.DotNet.Tools.Scaffold.Flow
+namespace Microsoft.DotNet.Tools.Scaffold.Interactive.Flow
 {
     /// <summary>
     /// Extension methods for <see cref="IFlowContext"/> to simplify retrieval of common scaffolding context values.

--- a/src/dotnet-scaffolding/dotnet-scaffold/Interactive/Flow/Steps/CategoryDiscovery.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Interactive/Flow/Steps/CategoryDiscovery.cs
@@ -5,7 +5,7 @@ using Microsoft.DotNet.Tools.Scaffold.Services;
 using Spectre.Console;
 using Spectre.Console.Flow;
 
-namespace Microsoft.DotNet.Tools.Scaffold.Flow.Steps;
+namespace Microsoft.DotNet.Tools.Scaffold.Interactive.Flow.Steps;
 
 /// <summary>
 /// Handles the discovery and selection of scaffolding categories for a given component or all components.

--- a/src/dotnet-scaffolding/dotnet-scaffold/Interactive/Flow/Steps/CategoryPickerFlowStep.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Interactive/Flow/Steps/CategoryPickerFlowStep.cs
@@ -1,51 +1,44 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.Core.ComponentModel;
-using Microsoft.DotNet.Scaffolding.Internal.Services;
 using Microsoft.DotNet.Tools.Scaffold.Services;
 using Microsoft.Extensions.Logging;
 using Spectre.Console.Flow;
 
-namespace Microsoft.DotNet.Tools.Scaffold.Flow.Steps
+namespace Microsoft.DotNet.Tools.Scaffold.Interactive.Flow.Steps
 {
     /// <summary>
     /// IFlowStep that deals with the selection of the component (DotNetToolInfo) and the associated command (CommandInfo).
     /// If provided by the user, verifies if the component is installed and the command is supported.
     /// </summary>
-    internal class CommandPickerFlowStep : IFlowStep
+    internal class CategoryPickerFlowStep : IFlowStep
     {
         private readonly ILogger _logger;
         private readonly IDotNetToolService _dotnetToolService;
-        private readonly IEnvironmentService _environmentService;
-        private readonly IFileSystem _fileSystem;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="CommandPickerFlowStep"/> class.
+        /// Initializes a new instance of the <see cref="CategoryPickerFlowStep"/> class.
         /// </summary>
-        public CommandPickerFlowStep(
-            ILogger logger,
-            IDotNetToolService dotnetToolService,
-            IEnvironmentService environmentService,
-            IFileSystem fileSystem)
+        public CategoryPickerFlowStep(ILogger logger, IDotNetToolService dotnetToolService)
         {
             _logger = logger;
             _dotnetToolService = dotnetToolService;
-            _environmentService = environmentService;
-            _fileSystem = fileSystem;
         }
 
         /// <inheritdoc/>
-        public string Id => nameof(CommandPickerFlowStep);
+        public string Id => nameof(CategoryPickerFlowStep);
         /// <inheritdoc/>
-        public string DisplayName => "Command Name";
+        public string DisplayName => "Scaffolding Category";
 
         /// <inheritdoc/>
         public ValueTask ResetAsync(IFlowContext context, CancellationToken cancellationToken)
         {
+            context.Unset(FlowContextProperties.ScaffoldingCategories);
+            context.Unset(FlowContextProperties.ChosenCategory);
             context.Unset(FlowContextProperties.ComponentName);
             context.Unset(FlowContextProperties.ComponentObj);
             context.Unset(FlowContextProperties.CommandName);
-            context.Unset(FlowContextProperties.CommandObj);
+            context.Unset(FlowContextProperties.CommandObj); 
             return new ValueTask();
         }
 
@@ -55,42 +48,27 @@ namespace Microsoft.DotNet.Tools.Scaffold.Flow.Steps
             var settings = context.GetCommandSettings();
             var componentName = settings?.ComponentName;
             var commandName = settings?.CommandName;
-            // KeyValuePair with key being name of the DotNetToolInfo (component) and value being the CommandInfo supported by that component.
-            KeyValuePair<string, CommandInfo>? commandInfoKvp = null;
-            CommandInfo? commandInfo = null;
+            string? displayCategory = null;
             var dotnetTools = _dotnetToolService.GetDotNetTools();
             var dotnetToolComponent = dotnetTools.FirstOrDefault(x => x.Command.Equals(componentName, StringComparison.OrdinalIgnoreCase));
-            CommandDiscovery commandDiscovery = new(_dotnetToolService, dotnetToolComponent);
-            commandInfoKvp = commandDiscovery.Discover(context);
-            if (commandDiscovery.State.IsNavigation())
+
+            CategoryDiscovery categoryDiscovery = new(_dotnetToolService, dotnetToolComponent);
+            displayCategory = categoryDiscovery.Discover(context);
+            if (categoryDiscovery.State.IsNavigation())
             {
-                return new ValueTask<FlowStepResult>(new FlowStepResult { State = commandDiscovery.State });
+                return new ValueTask<FlowStepResult>(new FlowStepResult { State = categoryDiscovery.State });
             }
 
-            if (commandInfoKvp is null || !commandInfoKvp.HasValue || commandInfoKvp.Value.Value is null || string.IsNullOrEmpty(commandInfoKvp.Value.Key))
+            if (string.IsNullOrEmpty(displayCategory))
             {
-                return new ValueTask<FlowStepResult>(FlowStepResult.Failure("Unable to find any commands."));
+                return new ValueTask<FlowStepResult>(FlowStepResult.Failure("Unable to find any component categories."));
             }
             else
             {
-                commandInfo = commandInfoKvp.Value.Value;
-                componentName = commandInfoKvp.Value.Key;
-                dotnetToolComponent ??= _dotnetToolService.GetDotNetTool(componentName);
-                if (dotnetToolComponent != null)
-                {
-                    SelectComponent(context, dotnetToolComponent);
-                }
-
-                SelectCommand(context, commandInfo);
+                SelectChosenCategory(context, displayCategory);
             }
 
-            var commandFirstStep = GetFirstParameterBasedStep(commandInfo);
-            if (commandFirstStep is null)
-            {
-                return new ValueTask<FlowStepResult>(FlowStepResult.Failure($"Failed to get/parse parameters for command '{commandInfo.Name}'"));
-            }
-
-            return new ValueTask<FlowStepResult>(new FlowStepResult { State = FlowStepState.Success, Steps = new List<ParameterBasedFlowStep> { commandFirstStep } });
+            return new ValueTask<FlowStepResult>(FlowStepResult.Success);
         }
 
         /// <inheritdoc/>
@@ -121,66 +99,34 @@ namespace Microsoft.DotNet.Tools.Scaffold.Flow.Steps
                 return new ValueTask<FlowStepResult>(FlowStepResult.Failure($"Invalid or empty command provided for component '{componentName}'"));
             }
 
-            var commandFirstStep = GetFirstParameterBasedStep(commandInfo);
-            if (commandFirstStep is null)
-            {
-                return new ValueTask<FlowStepResult>(FlowStepResult.Failure($"Failed to get/parse parameters for command '{commandInfo.Name}'"));
-            }
-
             SelectComponent(context, dotnetToolComponent);
             SelectCommand(context, commandInfo);
-            return new ValueTask<FlowStepResult>(new FlowStepResult { State = FlowStepState.Success, Steps = new List<ParameterBasedFlowStep> { commandFirstStep } });
+            SelectCategories(context, commandInfo.DisplayCategories);
+            return new ValueTask<FlowStepResult>(FlowStepResult.Success);
         }
 
         /// <summary>
-        /// Wrapper to get the first ParameterBasedFlowStep. Uses 'BuildParameterFlowSteps'.
+        /// Sets the available categories in the flow context.
         /// </summary>
-        internal ParameterBasedFlowStep? GetFirstParameterBasedStep(CommandInfo commandInfo)
+        private void SelectCategories(IFlowContext context, List<string> categories)
         {
-            ParameterBasedFlowStep? firstParameterStep = null;
-            if (commandInfo.Parameters != null && commandInfo.Parameters.Length != 0)
-            {
-                firstParameterStep = BuildParameterFlowSteps([.. commandInfo.Parameters]);
-            }
-
-            return firstParameterStep;
+            context.Set(new FlowProperty(
+                FlowContextProperties.ScaffoldingCategories,
+                categories,
+                "Scaffolding Categories",
+                isVisible: false));
         }
 
         /// <summary>
-        /// Takes all the 'Parameter's, creates ParameterBasedFlowSteps, and connects them using 'NextStep'.
+        /// Sets the chosen category in the flow context.
         /// </summary>
-        /// <returns>The first step from the connected ParameterBasedFlowSteps.</returns>
-        internal ParameterBasedFlowStep? BuildParameterFlowSteps(List<Parameter> parameters)
+        private void SelectChosenCategory(IFlowContext context, string category)
         {
-            ParameterBasedFlowStep? firstStep = null;
-            ParameterBasedFlowStep? previousStep = null;
-
-            foreach (var parameter in parameters)
-            {
-                var step = new ParameterBasedFlowStep(
-                    parameter,
-                    null,
-                    _environmentService,
-                    _fileSystem,
-                    _logger);
-                if (firstStep == null)
-                {
-                    // This is the first step
-                    firstStep = step;
-                }
-                else
-                {
-                    if (previousStep != null)
-                    {
-                        // Connect the previous step to this step
-                        previousStep.NextStep = step;
-                    }
-                }
-
-                previousStep = step;
-            }
-
-            return firstStep;
+            context.Set(new FlowProperty(
+                FlowContextProperties.ChosenCategory,
+                category,
+                "Scaffolding Category",
+                isVisible: true));
         }
 
         /// <summary>

--- a/src/dotnet-scaffolding/dotnet-scaffold/Interactive/Flow/Steps/CommandDiscovery.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Interactive/Flow/Steps/CommandDiscovery.cs
@@ -5,7 +5,7 @@ using Microsoft.DotNet.Tools.Scaffold.Services;
 using Spectre.Console;
 using Spectre.Console.Flow;
 
-namespace Microsoft.DotNet.Tools.Scaffold.Flow.Steps;
+namespace Microsoft.DotNet.Tools.Scaffold.Interactive.Flow.Steps;
 
 /// <summary>
 /// Handles the discovery and selection of a scaffolding command for a given component or category.

--- a/src/dotnet-scaffolding/dotnet-scaffold/Interactive/Flow/Steps/CommandExecuteFlowStep.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Interactive/Flow/Steps/CommandExecuteFlowStep.cs
@@ -8,7 +8,7 @@ using Microsoft.DotNet.Tools.Scaffold.Telemetry;
 using Spectre.Console;
 using Spectre.Console.Flow;
 
-namespace Microsoft.DotNet.Tools.Scaffold.Flow.Steps
+namespace Microsoft.DotNet.Tools.Scaffold.Interactive.Flow.Steps
 {
     /// <summary>
     /// IFlowStep where we gather all the parameter values, and then execute the chosen/given component (dotnet tool).

--- a/src/dotnet-scaffolding/dotnet-scaffold/Interactive/Flow/Steps/ComponentDiscovery.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Interactive/Flow/Steps/ComponentDiscovery.cs
@@ -4,7 +4,7 @@ using Microsoft.DotNet.Scaffolding.Core.ComponentModel;
 using Microsoft.DotNet.Tools.Scaffold.Services;
 using Spectre.Console.Flow;
 
-namespace Microsoft.DotNet.Tools.Scaffold.Flow.Steps;
+namespace Microsoft.DotNet.Tools.Scaffold.Interactive.Flow.Steps;
 
 /// <summary>
 /// Handles the discovery and selection of a scaffolding component (dotnet tool).

--- a/src/dotnet-scaffolding/dotnet-scaffold/Interactive/Flow/Steps/ParameterBasedFlowStep.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Interactive/Flow/Steps/ParameterBasedFlowStep.cs
@@ -7,7 +7,7 @@ using Microsoft.DotNet.Scaffolding.Roslyn.Services;
 using Microsoft.Extensions.Logging;
 using Spectre.Console.Flow;
 
-namespace Microsoft.DotNet.Tools.Scaffold.Flow.Steps
+namespace Microsoft.DotNet.Tools.Scaffold.Interactive.Flow.Steps
 {
     /// <summary>
     /// Represents a flow step that handles user input for a specific parameter, including validation and navigation.

--- a/src/dotnet-scaffolding/dotnet-scaffold/Interactive/Flow/Steps/ParameterDiscovery.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Interactive/Flow/Steps/ParameterDiscovery.cs
@@ -10,7 +10,7 @@ using Microsoft.DotNet.Scaffolding.Roslyn.Services;
 using Spectre.Console;
 using Spectre.Console.Flow;
 
-namespace Microsoft.DotNet.Tools.Scaffold.Flow.Steps
+namespace Microsoft.DotNet.Tools.Scaffold.Interactive.Flow.Steps
 {
     /// <summary>
     /// Handles the discovery and user input for a parameter, including interactive pickers and validation.

--- a/src/dotnet-scaffolding/dotnet-scaffold/Interactive/Flow/Steps/StartupFlowStep.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Interactive/Flow/Steps/StartupFlowStep.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.Logging;
 using Spectre.Console;
 using Spectre.Console.Flow;
 
-namespace Microsoft.DotNet.Tools.Scaffold.Flow.Steps;
+namespace Microsoft.DotNet.Tools.Scaffold.Interactive.Flow.Steps;
 
 /// <summary>
 /// Startup flow step that performs first-time initialization, telemetry setup, and argument parsing.

--- a/src/dotnet-scaffolding/dotnet-scaffold/Interactive/Services/FlowProvider.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Interactive/Services/FlowProvider.cs
@@ -2,7 +2,7 @@
 
 using Spectre.Console.Flow;
 
-namespace Microsoft.DotNet.Tools.Scaffold.Services;
+namespace Microsoft.DotNet.Tools.Scaffold.Interactive.Services;
 
 /// <summary>
 /// Provides functionality to create and manage interactive flows for CLI operations.

--- a/src/dotnet-scaffolding/dotnet-scaffold/Interactive/Services/IFlowProvider.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Interactive/Services/IFlowProvider.cs
@@ -3,7 +3,7 @@
 
 using Spectre.Console.Flow;
 
-namespace Microsoft.DotNet.Tools.Scaffold.Services;
+namespace Microsoft.DotNet.Tools.Scaffold.Interactive.Services;
 
 /// <summary>
 /// A factory interface for creating and managing interactive flows in the CLI.

--- a/src/dotnet-scaffolding/dotnet-scaffold/Program.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Program.cs
@@ -1,10 +1,10 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 using System.CommandLine;
-using Microsoft.DotNet.Tools.Scaffold;
-using Microsoft.DotNet.Tools.Scaffold.Command;
+using Microsoft.DotNet.Tools.Scaffold.Interactive.AppBuilder;
 using Microsoft.DotNet.Scaffolding.Core.Builder;
 using Microsoft.DotNet.Scaffolding.Core.Hosting;
+using Microsoft.DotNet.Tools.Scaffold.Command;
 
 IScaffoldRunnerBuilder builder = Host.CreateScaffoldBuilder();
 


### PR DESCRIPTION
fixes #3251 

In efforts to combine the aspnet and aspire experience under the `dotnet-scaffold` project. This is a pre-requisite to that work and organizes the interactive experience into this one directory.