### PR TITLE
Do not recognize old aspire package

### DIFF
--- a/src/dotnet-scaffolding/dotnet-scaffold/Services/DotNetToolService.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Services/DotNetToolService.cs
@@ -300,7 +300,9 @@ internal class DotNetToolService : IDotNetToolService
     /// <returns>True if valid; otherwise, false.</returns>
     private static bool IsValidDotNetTool(DotNetToolInfo dotnetToolInfo)
     {
-        return
-            !dotnetToolInfo.PackageName.Equals("package", StringComparison.OrdinalIgnoreCase);
+        // ignore dotnet-scaffold-aspire if the has a previous version on their machine.
+        // it is no longer relevant since aspire has been folded into dotnet-scaffold
+        return !dotnetToolInfo.Command.Equals("dotnet-scaffold-aspire", StringComparison.OrdinalIgnoreCase) &&
+        !dotnetToolInfo.PackageName.Equals("package", StringComparison.OrdinalIgnoreCase);
     }
 }


### PR DESCRIPTION
Since the `dotnet-scaffold-aspire` scaffolding is folded into the main `dotnet-scaffold` package, we don't need to recognize it and parse it anymore. It might still be on user's machine from old installations, but we don't want to use it.


