### PR TITLE
add descriptions to dotnet scaffold --help

### DIFF
--- a/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Core/CommandLine/CommandLineExtensions.cs
+++ b/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Core/CommandLine/CommandLineExtensions.cs
@@ -70,7 +70,7 @@ internal static class CommandLineExtensions
     /// <returns>The created command.</returns>
     private static Command ToCommand(this IScaffolder scaffolder)
     {
-        var command = new Command(scaffolder.Name);
+        Command command = new(scaffolder.Name, scaffolder.Description);
 
         foreach (var option in scaffolder.Options)
         {
@@ -130,7 +130,7 @@ internal static class CommandLineExtensions
     /// <param name="commandInfo">The list of command info objects.</param>
     private static void AddGetCommandsCommand(this RootCommand rootCommand, List<CommandInfo> commandInfo)
     {
-        var getCommandsCommand = new Command("get-commands");
+        Command getCommandsCommand = new("get-commands");
         getCommandsCommand.SetHandler(() =>
         {
             var json = System.Text.Json.JsonSerializer.Serialize(commandInfo);


### PR DESCRIPTION
fixes #3276 

before:
<img width="1472" height="1017" alt="image" src="https://github.com/user-attachments/assets/5e978341-972f-46bc-b545-b72518b6b32a" />

<img width="1115" height="630" alt="image" src="https://github.com/user-attachments/assets/87bb810d-68e2-4f59-942e-a096aa20ad11" />

<img width="1227" height="547" alt="image" src="https://github.com/user-attachments/assets/10d34fcd-11b3-42ab-a87b-c845baa31072" />






after:
<img width="1290" height="607" alt="image" src="https://github.com/user-attachments/assets/cb425af9-82a1-4d34-8d7e-1d7b468b79dc" />

<img width="2265" height="1127" alt="image" src="https://github.com/user-attachments/assets/333a551a-fe1c-459e-9c94-83636c0bafe8" />

<img width="1980" height="565" alt="image" src="https://github.com/user-attachments/assets/f1d3b429-0d99-4e4b-9957-a1c490566a59" />
