### PR TITLE
do not have duplicate usernames entra id

### DIFF
--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Helpers/AzCliHelper.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Helpers/AzCliHelper.cs
@@ -80,8 +80,8 @@ internal class AzCliHelper
     /// <returns>if successful, return true</returns>
     private static bool GetAzureUsernamesAndTenatIds(AzCliRunner runner, string output, out List<string> usernames, out List<string> tenants)
     {
-        usernames = [];
         tenants = [];
+        HashSet<string> uniqueUsernames = new HashSet<string>();
 
         try
         {
@@ -91,7 +91,6 @@ internal class AzCliHelper
 
             if (root.ValueKind == JsonValueKind.Array)
             {
-
                 foreach (JsonElement account in root.EnumerateArray())
                 {
                     if (account.TryGetProperty("user", out JsonElement user) &&
@@ -100,7 +99,7 @@ internal class AzCliHelper
                         string? username = name.GetString();
                         if (!string.IsNullOrEmpty(username))
                         {
-                            usernames.Add(username);
+                            uniqueUsernames.Add(username);
                         }
                     }
 
@@ -114,8 +113,8 @@ internal class AzCliHelper
                         }
                     }
                 }
-
             }
+            usernames = [.. uniqueUsernames];
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
Add some logic to not display the same username multiple times. Note these do not represent the tenant ids, they are options later in the flow. The repeated emails are just confusing 

referenced in #3293
fixed #3296 

before:
<img width="1152" height="655" alt="image" src="https://github.com/user-attachments/assets/56da8767-61be-4c14-8ffa-e84b98d6e93f" />

<img width="1132" height="628" alt="image" src="https://github.com/user-attachments/assets/5f3695a8-ff43-46e6-b481-430c2c8541c0" />


after:
<img width="1145" height="565" alt="image" src="https://github.com/user-attachments/assets/fafe0fe4-b66c-4860-9c43-3005829d939b" />



