### PR TITLE
Do not create static scaffolder options

### DIFF
--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/AspNetCommandService.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/AspNetCommandService.cs
@@ -46,18 +46,20 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet
 
         public void AddScaffolderCommands()
         {
+            AspNetOptions options = new();
+
             _builder.AddScaffolder(ScaffolderCatagory.AspNet, AspnetStrings.Blazor.Empty)
                 .WithDisplayName(AspnetStrings.Blazor.EmptyDisplayName)
                 .WithCategory(AspnetStrings.Catagories.Blazor)
                 .WithDescription(AspnetStrings.Blazor.EmptyDescription)
-                .WithOption(AspNetOptions.Project)
-                .WithOption(AspNetOptions.FileName)
+                .WithOption(options.Project)
+                .WithOption(options.FileName)
                 .WithStep<DotnetNewScaffolderStep>(config =>
                 {
                     var step = config.Step;
                     var context = config.Context;
-                    step.ProjectPath = context.GetOptionResult(AspNetOptions.Project);
-                    step.FileName = context.GetOptionResult(AspNetOptions.FileName);
+                    step.ProjectPath = context.GetOptionResult(options.Project);
+                    step.FileName = context.GetOptionResult(options.FileName);
                     step.CommandName = Constants.DotnetCommands.RazorComponentCommandName;
                 });
 
@@ -65,14 +67,14 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet
                 .WithDisplayName(AspnetStrings.RazorView.EmptyDisplayName)
                 .WithCategory(AspnetStrings.Catagories.MVC)
                 .WithDescription(AspnetStrings.RazorView.EmptyDescription)
-                .WithOption(AspNetOptions.Project)
-                .WithOption(AspNetOptions.FileName)
+                .WithOption(options.Project)
+                .WithOption(options.FileName)
                 .WithStep<DotnetNewScaffolderStep>(config =>
                 {
                     var step = config.Step;
                     var context = config.Context;
-                    step.ProjectPath = context.GetOptionResult(AspNetOptions.Project);
-                    step.FileName = context.GetOptionResult(AspNetOptions.FileName);
+                    step.ProjectPath = context.GetOptionResult(options.Project);
+                    step.FileName = context.GetOptionResult(options.FileName);
                     step.CommandName = Constants.DotnetCommands.ViewCommandName;
                 });
 
@@ -80,15 +82,15 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet
                 .WithDisplayName(AspnetStrings.RazorPage.EmptyDisplayName)
                 .WithCategory(AspnetStrings.Catagories.RazorPages)
                 .WithDescription(AspnetStrings.RazorPage.EmptyDescription)
-                .WithOption(AspNetOptions.Project)
-                .WithOption(AspNetOptions.FileName)
+                .WithOption(options.Project)
+                .WithOption(options.FileName)
                 .WithStep<DotnetNewScaffolderStep>(config =>
                 {
                     var step = config.Step;
                     var context = config.Context;
-                    step.ProjectPath = context.GetOptionResult(AspNetOptions.Project);
+                    step.ProjectPath = context.GetOptionResult(options.Project);
                     step.NamespaceName = Path.GetFileNameWithoutExtension(step.ProjectPath);
-                    step.FileName = context.GetOptionResult(AspNetOptions.FileName);
+                    step.FileName = context.GetOptionResult(options.FileName);
                     step.CommandName = Constants.DotnetCommands.RazorPageCommandName;
                 });
 
@@ -96,14 +98,14 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet
                 .WithDisplayName(AspnetStrings.Api.ApiControllerDisplayName)
                 .WithCategory(AspnetStrings.Catagories.API)
                 .WithDescription(AspnetStrings.Api.ApiControllerDescription)
-                .WithOptions([AspNetOptions.Project, AspNetOptions.FileName, AspNetOptions.Actions])
+                .WithOptions([options.Project, options.FileName, options.Actions])
                 .WithStep<EmptyControllerScaffolderStep>(config =>
                 {
                     var step = config.Step;
                     var context = config.Context;
-                    step.ProjectPath = context.GetOptionResult(AspNetOptions.Project);
-                    step.FileName = context.GetOptionResult(AspNetOptions.FileName);
-                    step.Actions = context.GetOptionResult(AspNetOptions.Actions);
+                    step.ProjectPath = context.GetOptionResult(options.Project);
+                    step.FileName = context.GetOptionResult(options.FileName);
+                    step.Actions = context.GetOptionResult(options.Actions);
                     step.CommandName = AspnetStrings.Api.ApiController;
                 });
 
@@ -111,14 +113,14 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet
                 .WithDisplayName(AspnetStrings.MVC.DisplayName)
                 .WithCategory(AspnetStrings.Catagories.MVC)
                 .WithDescription(AspnetStrings.MVC.Description)
-                .WithOptions([AspNetOptions.Project, AspNetOptions.FileName, AspNetOptions.Actions])
+                .WithOptions([options.Project, options.FileName, options.Actions])
                 .WithStep<EmptyControllerScaffolderStep>(config =>
                 {
                     var step = config.Step;
                     var context = config.Context;
-                    step.ProjectPath = context.GetOptionResult(AspNetOptions.Project);
-                    step.FileName = context.GetOptionResult(AspNetOptions.FileName);
-                    step.Actions = context.GetOptionResult(AspNetOptions.Actions);
+                    step.ProjectPath = context.GetOptionResult(options.Project);
+                    step.FileName = context.GetOptionResult(options.FileName);
+                    step.Actions = context.GetOptionResult(options.Actions);
                     step.CommandName = AspnetStrings.MVC.Controller;
                 });
 
@@ -126,18 +128,18 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet
                 .WithDisplayName(AspnetStrings.Api.ApiControllerCrudDisplayName)
                 .WithCategory(AspnetStrings.Catagories.API)
                 .WithDescription(AspnetStrings.Api.ApiControllerCrudDescription)
-                .WithOptions([AspNetOptions.Project, AspNetOptions.ModelName, AspNetOptions.ControllerName, AspNetOptions.DataContextClassRequired, AspNetOptions.DatabaseProviderRequired, AspNetOptions.Prerelease])
+                .WithOptions([options.Project, options.ModelName, options.ControllerName, options.DataContextClassRequired, options.DatabaseProviderRequired, options.Prerelease])
                 .WithStep<ValidateEfControllerStep>(config =>
                 {
                     var step = config.Step;
                     var context = config.Context;
-                    step.Project = context.GetOptionResult(AspNetOptions.Project);
-                    step.Model = context.GetOptionResult(AspNetOptions.ModelName);
-                    step.DataContext = context.GetOptionResult(AspNetOptions.DataContextClassRequired);
-                    step.DatabaseProvider = context.GetOptionResult(AspNetOptions.DatabaseProviderRequired);
-                    step.Prerelease = context.GetOptionResult(AspNetOptions.Prerelease);
+                    step.Project = context.GetOptionResult(options.Project);
+                    step.Model = context.GetOptionResult(options.ModelName);
+                    step.DataContext = context.GetOptionResult(options.DataContextClassRequired);
+                    step.DatabaseProvider = context.GetOptionResult(options.DatabaseProviderRequired);
+                    step.Prerelease = context.GetOptionResult(options.Prerelease);
                     step.ControllerType = AspnetStrings.Catagories.API;
-                    step.ControllerName = context.GetOptionResult(AspNetOptions.ControllerName);
+                    step.ControllerName = context.GetOptionResult(options.ControllerName);
                 })
                 .WithEfControllerAddPackagesStep()
                 .WithDbContextStep()
@@ -149,18 +151,18 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet
                 .WithDisplayName(AspnetStrings.MVC.CrudDisplayName)
                 .WithCategory(AspnetStrings.Catagories.MVC)
                 .WithDescription(AspnetStrings.MVC.CrudDescription)
-                .WithOptions([AspNetOptions.Project, AspNetOptions.ModelName, AspNetOptions.ControllerName, AspNetOptions.Views, AspNetOptions.DataContextClassRequired, AspNetOptions.DatabaseProviderRequired, AspNetOptions.Prerelease])
+                .WithOptions([options.Project, options.ModelName, options.ControllerName, options.Views, options.DataContextClassRequired, options.DatabaseProviderRequired, options.Prerelease])
                 .WithStep<ValidateEfControllerStep>(config =>
                 {
                     var step = config.Step;
                     var context = config.Context;
-                    step.Project = context.GetOptionResult(AspNetOptions.Project);
-                    step.Model = context.GetOptionResult(AspNetOptions.ModelName);
-                    step.DataContext = context.GetOptionResult(AspNetOptions.DataContextClassRequired);
-                    step.DatabaseProvider = context.GetOptionResult(AspNetOptions.DatabaseProviderRequired);
-                    step.Prerelease = context.GetOptionResult(AspNetOptions.Prerelease);
+                    step.Project = context.GetOptionResult(options.Project);
+                    step.Model = context.GetOptionResult(options.ModelName);
+                    step.DataContext = context.GetOptionResult(options.DataContextClassRequired);
+                    step.DatabaseProvider = context.GetOptionResult(options.DatabaseProviderRequired);
+                    step.Prerelease = context.GetOptionResult(options.Prerelease);
                     step.ControllerType = AspnetStrings.Catagories.MVC;
-                    step.ControllerName = context.GetOptionResult(AspNetOptions.ControllerName);
+                    step.ControllerName = context.GetOptionResult(options.ControllerName);
                 })
                 .WithEfControllerAddPackagesStep()
                 .WithDbContextStep()
@@ -173,17 +175,17 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet
                 .WithDisplayName(AspnetStrings.Blazor.CrudDisplayName)
                 .WithCategory(AspnetStrings.Catagories.Blazor)
                 .WithDescription(AspnetStrings.Blazor.CrudDescription)
-                .WithOptions([AspNetOptions.Project, AspNetOptions.ModelName, AspNetOptions.DataContextClassRequired, AspNetOptions.DatabaseProviderRequired, AspNetOptions.PageType, AspNetOptions.Prerelease])
+                .WithOptions([options.Project, options.ModelName, options.DataContextClassRequired, options.DatabaseProviderRequired, options.PageType, options.Prerelease])
                 .WithStep<ValidateBlazorCrudStep>(config =>
                 {
                     var step = config.Step;
                     var context = config.Context;
-                    step.Project = context.GetOptionResult(AspNetOptions.Project);
-                    step.Model = context.GetOptionResult(AspNetOptions.ModelName);
-                    step.DataContext = context.GetOptionResult(AspNetOptions.DataContextClassRequired);
-                    step.DatabaseProvider = context.GetOptionResult(AspNetOptions.DatabaseProviderRequired);
-                    step.Prerelease = context.GetOptionResult(AspNetOptions.Prerelease);
-                    step.Page = context.GetOptionResult(AspNetOptions.PageType);
+                    step.Project = context.GetOptionResult(options.Project);
+                    step.Model = context.GetOptionResult(options.ModelName);
+                    step.DataContext = context.GetOptionResult(options.DataContextClassRequired);
+                    step.DatabaseProvider = context.GetOptionResult(options.DatabaseProviderRequired);
+                    step.Prerelease = context.GetOptionResult(options.Prerelease);
+                    step.Page = context.GetOptionResult(options.PageType);
                 })
                 .WithBlazorCrudAddPackagesStep()
                 .WithDbContextStep()
@@ -195,17 +197,17 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet
                 .WithDisplayName(AspnetStrings.RazorPage.CrudDisplayName)
                 .WithCategory(AspnetStrings.Catagories.RazorPages)
                 .WithDescription(AspnetStrings.RazorPage.CrudDescription)
-                .WithOptions([AspNetOptions.Project, AspNetOptions.ModelName, AspNetOptions.DataContextClassRequired, AspNetOptions.DatabaseProviderRequired, AspNetOptions.PageType, AspNetOptions.Prerelease])
+                .WithOptions([options.Project, options.ModelName, options.DataContextClassRequired, options.DatabaseProviderRequired, options.PageType, options.Prerelease])
                 .WithStep<ValidateRazorPagesStep>(config =>
                 {
                     var step = config.Step;
                     var context = config.Context;
-                    step.Project = context.GetOptionResult(AspNetOptions.Project);
-                    step.Model = context.GetOptionResult(AspNetOptions.ModelName);
-                    step.DataContext = context.GetOptionResult(AspNetOptions.DataContextClassRequired);
-                    step.DatabaseProvider = context.GetOptionResult(AspNetOptions.DatabaseProviderRequired);
-                    step.Prerelease = context.GetOptionResult(AspNetOptions.Prerelease);
-                    step.Page = context.GetOptionResult(AspNetOptions.PageType);
+                    step.Project = context.GetOptionResult(options.Project);
+                    step.Model = context.GetOptionResult(options.ModelName);
+                    step.DataContext = context.GetOptionResult(options.DataContextClassRequired);
+                    step.DatabaseProvider = context.GetOptionResult(options.DatabaseProviderRequired);
+                    step.Prerelease = context.GetOptionResult(options.Prerelease);
+                    step.Page = context.GetOptionResult(options.PageType);
                 })
                 .WithRazorPagesAddPackagesStep()
                 .WithDbContextStep()
@@ -217,14 +219,14 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet
                 .WithDisplayName(AspnetStrings.RazorView.ViewsDisplayName)
                 .WithCategory(AspnetStrings.Catagories.MVC)
                 .WithDescription(AspnetStrings.RazorView.ViewsDescription)
-                .WithOptions([AspNetOptions.Project, AspNetOptions.ModelName, AspNetOptions.PageType])
+                .WithOptions([options.Project, options.ModelName, options.PageType])
                 .WithStep<ValidateViewsStep>(config =>
                 {
                     var step = config.Step;
                     var context = config.Context;
-                    step.Project = context.GetOptionResult(AspNetOptions.Project);
-                    step.Model = context.GetOptionResult(AspNetOptions.ModelName);
-                    step.Page = context.GetOptionResult(AspNetOptions.PageType);
+                    step.Project = context.GetOptionResult(options.Project);
+                    step.Model = context.GetOptionResult(options.ModelName);
+                    step.Page = context.GetOptionResult(options.PageType);
                 })
                 .WithViewsTextTemplatingStep()
                 .WithViewsAddFileStep();
@@ -233,18 +235,18 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet
                 .WithDisplayName(AspnetStrings.Api.MinimalApiDisplayName)
                 .WithCategory(AspnetStrings.Catagories.API)
                 .WithDescription(AspnetStrings.Api.MinimalApiDescription)
-                .WithOptions([AspNetOptions.Project, AspNetOptions.ModelName, AspNetOptions.EndpointsClass, AspNetOptions.OpenApi, AspNetOptions.DataContextClass, AspNetOptions.DatabaseProvider, AspNetOptions.Prerelease])
+                .WithOptions([options.Project, options.ModelName, options.EndpointsClass, options.OpenApi, options.DataContextClass, options.DatabaseProvider, options.Prerelease])
                 .WithStep<ValidateMinimalApiStep>(config =>
                 {
                     var step = config.Step;
                     var context = config.Context;
-                    step.Project = context.GetOptionResult(AspNetOptions.Project);
-                    step.Model = context.GetOptionResult(AspNetOptions.ModelName);
-                    step.DataContext = context.GetOptionResult(AspNetOptions.DataContextClass);
-                    step.DatabaseProvider = context.GetOptionResult(AspNetOptions.DatabaseProvider);
-                    step.Prerelease = context.GetOptionResult(AspNetOptions.Prerelease);
-                    step.OpenApi = context.GetOptionResult(AspNetOptions.OpenApi);
-                    step.Endpoints = context.GetOptionResult(AspNetOptions.EndpointsClass);
+                    step.Project = context.GetOptionResult(options.Project);
+                    step.Model = context.GetOptionResult(options.ModelName);
+                    step.DataContext = context.GetOptionResult(options.DataContextClass);
+                    step.DatabaseProvider = context.GetOptionResult(options.DatabaseProvider);
+                    step.Prerelease = context.GetOptionResult(options.Prerelease);
+                    step.OpenApi = context.GetOptionResult(options.OpenApi);
+                    step.Endpoints = context.GetOptionResult(options.EndpointsClass);
                 })
                 .WithMinimalApiAddPackagesStep()
                 .WithDbContextStep()
@@ -256,13 +258,13 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet
                 .WithDisplayName(AspnetStrings.Area.DisplayName)
                 .WithCategory(AspnetStrings.Catagories.MVC)
                 .WithDescription(AspnetStrings.Area.Description)
-                .WithOptions([AspNetOptions.Project, AspNetOptions.AreaName])
+                .WithOptions([options.Project, options.AreaName])
                 .WithStep<AreaScaffolderStep>(config =>
                 {
                     var step = config.Step;
                     var context = config.Context;
-                    step.Project = context.GetOptionResult(AspNetOptions.Project);
-                    step.Name = context.GetOptionResult(AspNetOptions.AreaName);
+                    step.Project = context.GetOptionResult(options.Project);
+                    step.Name = context.GetOptionResult(options.AreaName);
                 });
 
             _builder.AddScaffolder(ScaffolderCatagory.AspNet, AspnetStrings.Blazor.Identity)
@@ -270,16 +272,16 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet
                 .WithCategory(AspnetStrings.Catagories.Blazor)
                 .WithCategory(AspnetStrings.Catagories.Identity)
                 .WithDescription(AspnetStrings.Blazor.IdentityDescription)
-                .WithOptions([AspNetOptions.Project, AspNetOptions.DataContextClassRequired, AspNetOptions.IdentityDbProviderRequired, AspNetOptions.Overwrite, AspNetOptions.Prerelease])
+                .WithOptions([options.Project, options.DataContextClassRequired, options.IdentityDbProviderRequired, options.Overwrite, options.Prerelease])
                 .WithStep<ValidateIdentityStep>(config =>
                 {
                     var step = config.Step;
                     var context = config.Context;
-                    step.Project = context.GetOptionResult(AspNetOptions.Project);
-                    step.DataContext = context.GetOptionResult(AspNetOptions.DataContextClassRequired);
-                    step.DatabaseProvider = context.GetOptionResult(AspNetOptions.IdentityDbProviderRequired);
-                    step.Prerelease = context.GetOptionResult(AspNetOptions.Prerelease);
-                    step.Overwrite = context.GetOptionResult(AspNetOptions.Overwrite);
+                    step.Project = context.GetOptionResult(options.Project);
+                    step.DataContext = context.GetOptionResult(options.DataContextClassRequired);
+                    step.DatabaseProvider = context.GetOptionResult(options.IdentityDbProviderRequired);
+                    step.Prerelease = context.GetOptionResult(options.Prerelease);
+                    step.Overwrite = context.GetOptionResult(options.Overwrite);
                     step.BlazorScenario = true;
                 })
                 .WithBlazorIdentityAddPackagesStep()
@@ -292,16 +294,16 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet
                 .WithDisplayName(AspnetStrings.Identity.DisplayName)
                 .WithCategory(AspnetStrings.Catagories.Identity)
                 .WithDescription(AspnetStrings.Identity.Description)
-                .WithOptions([AspNetOptions.Project, AspNetOptions.DataContextClassRequired, AspNetOptions.IdentityDbProviderRequired, AspNetOptions.Overwrite, AspNetOptions.Prerelease])
+                .WithOptions([options.Project, options.DataContextClassRequired, options.IdentityDbProviderRequired, options.Overwrite, options.Prerelease])
                 .WithStep<ValidateIdentityStep>(config =>
                 {
                     var step = config.Step;
                     var context = config.Context;
-                    step.Project = context.GetOptionResult(AspNetOptions.Project);
-                    step.DataContext = context.GetOptionResult(AspNetOptions.DataContextClassRequired);
-                    step.DatabaseProvider = context.GetOptionResult(AspNetOptions.IdentityDbProviderRequired);
-                    step.Prerelease = context.GetOptionResult(AspNetOptions.Prerelease);
-                    step.Overwrite = context.GetOptionResult(AspNetOptions.Overwrite);
+                    step.Project = context.GetOptionResult(options.Project);
+                    step.DataContext = context.GetOptionResult(options.DataContextClassRequired);
+                    step.DatabaseProvider = context.GetOptionResult(options.IdentityDbProviderRequired);
+                    step.Prerelease = context.GetOptionResult(options.Prerelease);
+                    step.Overwrite = context.GetOptionResult(options.Overwrite);
                 })
                 .WithIdentityAddPackagesStep()
                 .WithIdentityDbContextStep()
@@ -309,23 +311,21 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet
                 .WithIdentityTextTemplatingStep()
                 .WithIdentityCodeChangeStep();
 
-            AspNetOptions options = new();
-
             if (options.AreAzCliCommandsSuccessful())
             {
                 _builder.AddScaffolder(ScaffolderCatagory.AspNet, AspnetStrings.EntraId.Name)
                     .WithDisplayName(AspnetStrings.EntraId.DisplayName)
                     .WithCategory(AspnetStrings.Catagories.EntraId)
                     .WithDescription(AspnetStrings.EntraId.Description)
-                    .WithOptions([options.Username, AspNetOptions.Project, options.TenantId, AspNetOptions.Application, options.SelectApplication])
+                    .WithOptions([options.Username, options.Project, options.TenantId, options.Application, options.SelectApplication])
                     .WithStep<ValidateEntraIdStep>(config =>
                     {
                         var step = config.Step;
                         var context = config.Context;
                         step.Username = context.GetOptionResult(options.Username);
-                        step.Project = context.GetOptionResult(AspNetOptions.Project);
+                        step.Project = context.GetOptionResult(options.Project);
                         step.TenantId = context.GetOptionResult(options.TenantId);
-                        step.Application = context.GetOptionResult(AspNetOptions.Application);
+                        step.Application = context.GetOptionResult(options.Application);
                         step.SelectApplication = context.GetOptionResult(options.SelectApplication);
                     })
                     .WithRegisterAppStep()

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Commands/AspNetOptions.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Commands/AspNetOptions.cs
@@ -10,156 +10,24 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Commands;
 
 internal class AspNetOptions
 {
-    public static  ScaffolderOption<string> Project => new()
-    {
-        DisplayName = AspnetStrings.Options.Project.DisplayName,
-        CliOption = Constants.CliOptions.ProjectCliOption,
-        Description = AspnetStrings.Options.Project.Description,
-        Required = true,
-        PickerType = InteractivePickerType.ProjectPicker
-    };
-
-    public static ScaffolderOption<bool> Prerelease => new()
-    {
-        DisplayName = AspnetStrings.Options.Prerelease.DisplayName,
-        CliOption = Constants.CliOptions.PrereleaseCliOption,
-        Description = AspnetStrings.Options.Prerelease.Description,
-        Required = false,
-        PickerType = InteractivePickerType.YesNo
-    };
-
-    public static ScaffolderOption<string> FileName => new()
-    {
-        DisplayName = AspnetStrings.Options.FileName.DisplayName,
-        CliOption = Constants.CliOptions.NameOption,
-        Description = AspnetStrings.Options.FileName.Description,
-        Required = true,
-    };
-
-    public static ScaffolderOption<bool> Actions => new()
-    {
-        DisplayName = AspnetStrings.Options.Actions.DisplayName,
-        CliOption = Constants.CliOptions.ActionsOption,
-        Description = AspnetStrings.Options.Actions.Description,
-        Required = true,
-        PickerType = InteractivePickerType.YesNo
-    };
-
-    public static ScaffolderOption<string> AreaName => new()
-    {
-        DisplayName = AspnetStrings.Options.AreaName.DisplayName,
-        CliOption = Constants.CliOptions.NameOption,
-        Description = AspnetStrings.Options.AreaName.Description,
-        Required = true
-    };
-
-    public static ScaffolderOption<string> ModelName => new()
-    {
-        DisplayName = AspnetStrings.Options.ModelName.DisplayName,
-        CliOption = Constants.CliOptions.ModelCliOption,
-        Description = AspnetStrings.Options.ModelName.Description,
-        Required = true,
-        PickerType = InteractivePickerType.ClassPicker
-    };
-
-    public static ScaffolderOption<string> EndpointsClass => new()
-    {
-        DisplayName = AspnetStrings.Options.EndpointClassDisplayName,
-        CliOption = Constants.CliOptions.EndpointsOption,
-        Description = string.Empty,
-        Required = true
-    };
-
-    public static ScaffolderOption<string> DatabaseProvider => new()
-    {
-        DisplayName = AspnetStrings.Options.DbProviderDisplayName,
-        CliOption = Constants.CliOptions.DbProviderOption,
-        Description = string.Empty,
-        Required = false,
-        PickerType = InteractivePickerType.CustomPicker,
-        CustomPickerValues = [.. AspNetDbContextHelper.DbContextTypeDefaults.Keys]
-    };
-
-    public static ScaffolderOption<string> DatabaseProviderRequired => new()
-    {
-        DisplayName = AspnetStrings.Options.DbProviderDisplayName,
-        CliOption = Constants.CliOptions.DbProviderOption,
-        Description = string.Empty,
-        Required = true,
-        PickerType = InteractivePickerType.CustomPicker,
-        CustomPickerValues = [.. AspNetDbContextHelper.DbContextTypeDefaults.Keys]
-    };
-
-    public static ScaffolderOption<string> IdentityDbProviderRequired => new()
-    {
-        DisplayName = AspnetStrings.Options.DbProviderDisplayName,
-        CliOption = Constants.CliOptions.DbProviderOption,
-        Description = string.Empty,
-        Required = true,
-        PickerType = InteractivePickerType.CustomPicker,
-        CustomPickerValues = [.. AspNetDbContextHelper.IdentityDbContextTypeDefaults.Keys]
-    };
-
-    public static ScaffolderOption<string> DataContextClass => new()
-    {
-        DisplayName = AspnetStrings.Options.DataContextClassDisplayName,
-        CliOption = Constants.CliOptions.DataContextOption,
-        Description = string.Empty,
-        Required = false
-    };
-
-    public static ScaffolderOption<string> DataContextClassRequired => new()
-    {
-        DisplayName = AspnetStrings.Options.DataContextClassDisplayName,
-        CliOption = Constants.CliOptions.DataContextOption,
-        Description = string.Empty,
-        Required = true
-    };
-
-    public static ScaffolderOption<bool> OpenApi => new()
-    {
-        DisplayName = AspnetStrings.Options.OpenApiDisplayName,
-        CliOption = Constants.CliOptions.OpenApiOption,
-        Description = string.Empty,
-        Required = false,
-        PickerType = InteractivePickerType.YesNo
-    };
-
-    public static ScaffolderOption<string> PageType => new()
-    {
-        DisplayName = AspnetStrings.Options.PageType.DisplayName,
-        CliOption = Constants.CliOptions.PageTypeOption,
-        Description = AspnetStrings.Options.PageType.Description,
-        Required = true,
-        PickerType = InteractivePickerType.CustomPicker,
-        CustomPickerValues = BlazorCrudHelper.CRUDPages
-    };
-
-    public static ScaffolderOption<string> ControllerName => new()
-    {
-        DisplayName = AspnetStrings.Options.ControllerName.DisplayName,
-        CliOption = Constants.CliOptions.ControllerNameOption,
-        Description = AspnetStrings.Options.ControllerName.Description,
-        Required = true
-    };
-
-    public static ScaffolderOption<bool> Views => new()
-    {
-        DisplayName = AspnetStrings.Options.View.DisplayName,
-        CliOption = Constants.CliOptions.ViewsOption,
-        Description = AspnetStrings.Options.View.Description,
-        Required = true,
-        PickerType = InteractivePickerType.YesNo
-    };
-
-    public static ScaffolderOption<bool> Overwrite => new()
-    {
-        DisplayName = AspnetStrings.Options.Overwrite.DisplayName,
-        CliOption = Constants.CliOptions.OverwriteOption,
-        Description = AspnetStrings.Options.Overwrite.Description,
-        Required = true,
-        PickerType = InteractivePickerType.YesNo
-    };
+    public ScaffolderOption<string> Project { get; }
+    public ScaffolderOption<bool> Prerelease { get; }
+    public ScaffolderOption<string> FileName { get; }
+    public ScaffolderOption<bool> Actions { get; }
+    public ScaffolderOption<string> AreaName { get; }
+    public ScaffolderOption<string> ModelName { get; }
+    public ScaffolderOption<string> EndpointsClass { get; }
+    public ScaffolderOption<string> DatabaseProvider { get; }
+    public ScaffolderOption<string> DatabaseProviderRequired { get; }
+    public ScaffolderOption<string> IdentityDbProviderRequired { get; }
+    public ScaffolderOption<string> DataContextClass { get; }
+    public ScaffolderOption<string> DataContextClassRequired { get; }
+    public ScaffolderOption<bool> OpenApi { get; }
+    public ScaffolderOption<string> PageType { get; }
+    public ScaffolderOption<string> ControllerName { get; }
+    public ScaffolderOption<bool> Views { get; }
+    public ScaffolderOption<bool> Overwrite { get; }
+    public ScaffolderOption<string> Application { get; }
 
     private readonly bool _areAzCliCommandsSuccessful;
     private readonly List<string> _usernames = [];
@@ -171,6 +39,163 @@ internal class AspNetOptions
 
     public AspNetOptions()
     {
+        Project = new ScaffolderOption<string>
+        {
+            DisplayName = AspnetStrings.Options.Project.DisplayName,
+            CliOption = Constants.CliOptions.ProjectCliOption,
+            Description = AspnetStrings.Options.Project.Description,
+            Required = true,
+            PickerType = InteractivePickerType.ProjectPicker
+        };
+
+        Prerelease = new ScaffolderOption<bool>
+        {
+            DisplayName = AspnetStrings.Options.Prerelease.DisplayName,
+            CliOption = Constants.CliOptions.PrereleaseCliOption,
+            Description = AspnetStrings.Options.Prerelease.Description,
+            Required = false,
+            PickerType = InteractivePickerType.YesNo
+        };
+
+        FileName = new ScaffolderOption<string>
+        {
+            DisplayName = AspnetStrings.Options.FileName.DisplayName,
+            CliOption = Constants.CliOptions.NameOption,
+            Description = AspnetStrings.Options.FileName.Description,
+            Required = true,
+        };
+
+        Actions = new ScaffolderOption<bool>
+        {
+            DisplayName = AspnetStrings.Options.Actions.DisplayName,
+            CliOption = Constants.CliOptions.ActionsOption,
+            Description = AspnetStrings.Options.Actions.Description,
+            Required = true,
+            PickerType = InteractivePickerType.YesNo
+        };
+        AreaName = new ScaffolderOption<string>
+        {
+            DisplayName = AspnetStrings.Options.AreaName.DisplayName,
+            CliOption = Constants.CliOptions.NameOption,
+            Description = AspnetStrings.Options.AreaName.Description,
+            Required = true
+        };
+
+        ModelName = new ScaffolderOption<string>
+        {
+            DisplayName = AspnetStrings.Options.ModelName.DisplayName,
+            CliOption = Constants.CliOptions.ModelCliOption,
+            Description = AspnetStrings.Options.ModelName.Description,
+            Required = true,
+            PickerType = InteractivePickerType.ClassPicker
+        };
+
+        EndpointsClass = new ScaffolderOption<string>
+        {
+            DisplayName = AspnetStrings.Options.EndpointClassDisplayName,
+            CliOption = Constants.CliOptions.EndpointsOption,
+            Description = string.Empty,
+            Required = true
+        };
+        DatabaseProvider = new ScaffolderOption<string>
+        {
+            DisplayName = AspnetStrings.Options.DbProviderDisplayName,
+            CliOption = Constants.CliOptions.DbProviderOption,
+            Description = string.Empty,
+            Required = false,
+            PickerType = InteractivePickerType.CustomPicker,
+            CustomPickerValues = [.. AspNetDbContextHelper.DbContextTypeDefaults.Keys]
+        };
+
+        DatabaseProviderRequired = new ScaffolderOption<string>
+        {
+            DisplayName = AspnetStrings.Options.DbProviderDisplayName,
+            CliOption = Constants.CliOptions.DbProviderOption,
+            Description = string.Empty,
+            Required = true,
+            PickerType = InteractivePickerType.CustomPicker,
+            CustomPickerValues = [.. AspNetDbContextHelper.DbContextTypeDefaults.Keys]
+        };
+
+        IdentityDbProviderRequired = new ScaffolderOption<string>
+        {
+            DisplayName = AspnetStrings.Options.DbProviderDisplayName,
+            CliOption = Constants.CliOptions.DbProviderOption,
+            Description = string.Empty,
+            Required = true,
+            PickerType = InteractivePickerType.CustomPicker,
+            CustomPickerValues = [.. AspNetDbContextHelper.IdentityDbContextTypeDefaults.Keys]
+        };
+
+        DataContextClass = new ScaffolderOption<string>
+        {
+            DisplayName = AspnetStrings.Options.DataContextClassDisplayName,
+            CliOption = Constants.CliOptions.DataContextOption,
+            Description = string.Empty,
+            Required = false
+        };
+        DataContextClassRequired = new ScaffolderOption<string>
+        {
+            DisplayName = AspnetStrings.Options.DataContextClassDisplayName,
+            CliOption = Constants.CliOptions.DataContextOption,
+            Description = string.Empty,
+            Required = true
+        };
+
+        OpenApi = new ScaffolderOption<bool>
+        {
+            DisplayName = AspnetStrings.Options.OpenApiDisplayName,
+            CliOption = Constants.CliOptions.OpenApiOption,
+            Description = string.Empty,
+            Required = false,
+            PickerType = InteractivePickerType.YesNo
+        };
+
+        PageType = new ScaffolderOption<string>
+        {
+            DisplayName = AspnetStrings.Options.PageType.DisplayName,
+            CliOption = Constants.CliOptions.PageTypeOption,
+            Description = AspnetStrings.Options.PageType.Description,
+            Required = true,
+            PickerType = InteractivePickerType.CustomPicker,
+            CustomPickerValues = BlazorCrudHelper.CRUDPages
+        };
+
+        ControllerName = new ScaffolderOption<string>
+        {
+            DisplayName = AspnetStrings.Options.ControllerName.DisplayName,
+            CliOption = Constants.CliOptions.ControllerNameOption,
+            Description = AspnetStrings.Options.ControllerName.Description,
+            Required = true
+        };
+
+        Views = new ScaffolderOption<bool>
+        {
+            DisplayName = AspnetStrings.Options.View.DisplayName,
+            CliOption = Constants.CliOptions.ViewsOption,
+            Description = AspnetStrings.Options.View.Description,
+            Required = true,
+            PickerType = InteractivePickerType.YesNo
+        };
+
+        Overwrite = new ScaffolderOption<bool>
+        {
+            DisplayName = AspnetStrings.Options.Overwrite.DisplayName,
+            CliOption = Constants.CliOptions.OverwriteOption,
+            Description = AspnetStrings.Options.Overwrite.Description,
+            Required = true,
+            PickerType = InteractivePickerType.YesNo
+        };
+
+        Application = new ScaffolderOption<string>
+        {
+            DisplayName = AspnetStrings.Options.Application.DisplayName,
+            Description = AspnetStrings.Options.Application.Description,
+            Required = true,
+            PickerType = InteractivePickerType.ConditionalPicker,
+            CustomPickerValues = AspnetStrings.Options.Application.Values
+        };
+
         _areAzCliCommandsSuccessful = AzCliHelper.GetAzureInformation(out List<string> usernames, out List<string> tenants, out List<string> appIds);
         _usernames = usernames;
         _tenants = tenants;
@@ -198,15 +223,6 @@ internal class AspNetOptions
         Required = true,
         PickerType = InteractivePickerType.CustomPicker,
         CustomPickerValues = _tenants
-    };
-
-    public static ScaffolderOption<string> Application => new()
-    {
-        DisplayName = AspnetStrings.Options.Application.DisplayName,
-        Description = AspnetStrings.Options.Application.Description,
-        Required = true,
-        PickerType = InteractivePickerType.ConditionalPicker,
-        CustomPickerValues = AspnetStrings.Options.Application.Values
     };
 
     public ScaffolderOption<string> SelectApplication => _applicationId ??= new()


### PR DESCRIPTION
fixes #3299 #3300 

Issue: creating entra ID scaffolder failed with `Missing/Invalid --project option` this is because the retrieval of the project option was not working. 

Because of how these options were set up, they were not getting set and retrieved correctly. Setting these Options in the constructor allows them to be set and retrieved correctly. 


