### PR TITLE
Fix writing to console breaking UI

### DIFF
--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/AspNetCommandService.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/AspNetCommandService.cs
@@ -17,6 +17,8 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet
     {
         IScaffoldRunnerBuilder _builder = builder;
 
+        public string? AzCliErrors { get; private set; }
+
         public Type[] GetScaffoldSteps()
         {
             return
@@ -47,6 +49,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet
         public void AddScaffolderCommands()
         {
             AspNetOptions options = new();
+            AzCliErrors = options.AzCliErrors;
 
             _builder.AddScaffolder(ScaffolderCatagory.AspNet, AspnetStrings.Blazor.Empty)
                 .WithDisplayName(AspnetStrings.Blazor.EmptyDisplayName)

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Commands/AspNetOptions.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Commands/AspNetOptions.cs
@@ -196,13 +196,17 @@ internal class AspNetOptions
             CustomPickerValues = AspnetStrings.Options.Application.Values
         };
 
-        _areAzCliCommandsSuccessful = AzCliHelper.GetAzureInformation(out List<string> usernames, out List<string> tenants, out List<string> appIds);
+        _areAzCliCommandsSuccessful = AzCliHelper.GetAzureInformation(out List<string> usernames, out List<string> tenants, out List<string> appIds, out string? azCliErrors);
+        AzCliErrors = azCliErrors;
+
         _usernames = usernames;
         _tenants = tenants;
         _appIds = appIds;
     }
 
     public bool AreAzCliCommandsSuccessful() => _areAzCliCommandsSuccessful;
+
+    public string? AzCliErrors { get; }
 
     public ScaffolderOption<string> Username => _username ??=  new()
     {

--- a/src/dotnet-scaffolding/dotnet-scaffold/Interactive/Command/ScaffoldCommand.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Interactive/Command/ScaffoldCommand.cs
@@ -25,6 +25,8 @@ internal class ScaffoldCommand : BaseCommand<ScaffoldCommand.Settings>
     private readonly IEnvironmentService _environmentService;
     // Sentinel for first-time use notice.
     private readonly IFirstTimeUseNoticeSentinel _firstTimeUseNoticeSentinel;
+    // Service for Azure CLI startup errors.
+    private readonly IStartUpErrorService _startUpErrorService;
 
     private readonly IScaffoldRunner _scaffoldRunner;
 
@@ -39,6 +41,7 @@ internal class ScaffoldCommand : BaseCommand<ScaffoldCommand.Settings>
     /// <param name="telemetry">The telemetry service.</param>
     /// <param name="firstTimeUseNoticeSentinel">The first-time use notice sentinel.</param>
     /// <param name="scaffoldRunner">The command runner, implemeneted with System.CommandLine</param>
+    /// <param name="startUpErrorService">The startup error service.</param>
     public ScaffoldCommand(
         IDotNetToolService dotnetToolService,
         IEnvironmentService environmentService,
@@ -47,7 +50,8 @@ internal class ScaffoldCommand : BaseCommand<ScaffoldCommand.Settings>
         ILogger<ScaffoldCommand> logger,
         ITelemetryService telemetry,
         IFirstTimeUseNoticeSentinel firstTimeUseNoticeSentinel,
-        IScaffoldRunner scaffoldRunner)
+        IScaffoldRunner scaffoldRunner,
+        IStartUpErrorService startUpErrorService)
         : base(flowProvider, telemetry)
     {
         _dotnetToolService = dotnetToolService;
@@ -56,6 +60,7 @@ internal class ScaffoldCommand : BaseCommand<ScaffoldCommand.Settings>
         _logger = logger;
         _firstTimeUseNoticeSentinel = firstTimeUseNoticeSentinel;
         _scaffoldRunner = scaffoldRunner;
+        _startUpErrorService = startUpErrorService;
     }
 
     /// <summary>
@@ -95,7 +100,7 @@ internal class ScaffoldCommand : BaseCommand<ScaffoldCommand.Settings>
         IEnumerable<IFlowStep> flowSteps =
         [
             new StartupFlowStep(_dotnetToolService, _environmentService, _fileSystem, _logger, _firstTimeUseNoticeSentinel),
-            new CategoryPickerFlowStep(_logger, _dotnetToolService),
+            new CategoryPickerFlowStep(_logger, _dotnetToolService, _startUpErrorService),
             new CommandPickerFlowStep(_logger, _dotnetToolService, _environmentService, _fileSystem),
             new CommandExecuteFlowStep(TelemetryService, _scaffoldRunner)
         ];

--- a/src/dotnet-scaffolding/dotnet-scaffold/Interactive/Flow/Steps/CategoryPickerFlowStep.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Interactive/Flow/Steps/CategoryPickerFlowStep.cs
@@ -15,14 +15,16 @@ namespace Microsoft.DotNet.Tools.Scaffold.Interactive.Flow.Steps
     {
         private readonly ILogger _logger;
         private readonly IDotNetToolService _dotnetToolService;
+        private readonly IStartUpErrorService _startUpErrorService;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CategoryPickerFlowStep"/> class.
         /// </summary>
-        public CategoryPickerFlowStep(ILogger logger, IDotNetToolService dotnetToolService)
+        public CategoryPickerFlowStep(ILogger logger, IDotNetToolService dotnetToolService, IStartUpErrorService startUpErrorService)
         {
             _logger = logger;
             _dotnetToolService = dotnetToolService;
+            _startUpErrorService = startUpErrorService;
         }
 
         /// <inheritdoc/>
@@ -52,7 +54,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.Interactive.Flow.Steps
             var dotnetTools = _dotnetToolService.GetDotNetTools();
             var dotnetToolComponent = dotnetTools.FirstOrDefault(x => x.Command.Equals(componentName, StringComparison.OrdinalIgnoreCase));
 
-            CategoryDiscovery categoryDiscovery = new(_dotnetToolService, dotnetToolComponent);
+            CategoryDiscovery categoryDiscovery = new(_dotnetToolService, dotnetToolComponent, _startUpErrorService);
             displayCategory = categoryDiscovery.Discover(context);
             if (categoryDiscovery.State.IsNavigation())
             {

--- a/src/dotnet-scaffolding/dotnet-scaffold/Program.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Program.cs
@@ -44,8 +44,8 @@ builder.AddHandler(async (context) =>
     }
     else
     {
-        ScaffoldCommandAppBuilder builder = new(runner, [.. context.ParseResult.Tokens.Select(t => t.Value)]);
-        ScaffoldCommandApp app = builder.Build();
+        ScaffoldCommandAppBuilder appBuilder = new(runner, [.. context.ParseResult.Tokens.Select(t => t.Value)]);
+        ScaffoldCommandApp app = appBuilder.Build(aspNetCommandService.AzCliErrors);
         await app.RunAsync();
     }
 });

--- a/src/dotnet-scaffolding/dotnet-scaffold/Services/IStartUpErrorService.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Services/IStartUpErrorService.cs
@@ -1,0 +1,11 @@
+namespace Microsoft.DotNet.Tools.Scaffold.Services
+{
+    /// <summary>
+    /// Interface for StartUpErrorService to store and retrieve Azure CLI startup errors.
+    /// </summary>
+    public interface IStartUpErrorService
+    {
+        void SetError(string? error);
+        string? GetError();
+    }
+}

--- a/src/dotnet-scaffolding/dotnet-scaffold/Services/StartUpErrorService.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Services/StartUpErrorService.cs
@@ -1,0 +1,25 @@
+using System;
+
+namespace Microsoft.DotNet.Tools.Scaffold.Services
+{
+    /// <summary>
+    /// Service to store and retrieve Azure CLI startup errors.
+    /// </summary>
+    public class StartUpErrorService : IStartUpErrorService
+    {
+        private string? _azureCliError;
+
+        public void SetError(string? error)
+        {
+            if (!string.IsNullOrWhiteSpace(error))
+            {
+                _azureCliError = error;
+            }
+        }
+
+        public string? GetError()
+        {
+            return _azureCliError;
+        }
+    }
+}


### PR DESCRIPTION
When testing `dotnet scaffold`, I was trying a subscription I normally don't use. With this subscription, I don't have full permissions. The `az ad app list` failed because of this lack of permissions. Previously, when any of the `az` commands an error message is written to the CLI, but these `az` commands fail during the construction of the CLI tools. This writing of errors was disrupting the visibility of the Scaffolders (even though they were available). Not writing these errors to the CLI allows the Scaffolders to appear correctly. 

To see this issue see bug.

fixes #3303 

Instead of surfacing these `az cli` errors when they occur using `AnsiConsole`, the errors will be passed and later surfaced after it is safe to render the UI. These errors are added to an error service and using DI are retrieved to be rendered with the other elements of the UI. An image of what this UI will look like is displayed below. 


update: 
shows the error late in the flow
<img width="1611" height="604" alt="image" src="https://github.com/user-attachments/assets/b4b572a2-0ec6-436c-a90b-501ae7205ee7" />


