### PR TITLE
Couple NuGet packages with package versions

### DIFF
--- a/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Core/Model/Package.cs
+++ b/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Core/Model/Package.cs
@@ -1,0 +1,17 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.DotNet.Scaffolding.Core.Model;
+
+/// <summary>
+/// Represents a NuGet package with a specified name and optional version.
+/// </summary>
+/// <param name="name">The name of the package. Cannot be null.</param>
+/// <param name="version">The version of the package, or null to indicate the latest version.</param>
+public class Package(string name, string? version = null)
+{
+    public string Name { get; } = name;
+
+    //null version indicates latest and version specfication is not needed
+    public string? Version { get; } = version;
+}

--- a/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Core/Steps/AddPackagesStep.cs
+++ b/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Core/Steps/AddPackagesStep.cs
@@ -1,5 +1,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.Core.CommandLine;
+using Microsoft.DotNet.Scaffolding.Core.Model;
 using Microsoft.DotNet.Scaffolding.Core.Scaffolders;
 using Microsoft.Extensions.Logging;
 
@@ -13,7 +14,7 @@ public class AddPackagesStep : ScaffoldStep
     /// <summary>
     /// Gets or sets the list of package names to add.
     /// </summary>
-    public required IList<string> PackageNames { get; set; }
+    public required IList<Package> Packages { get; set; }
 
     /// <summary>
     /// Gets or sets the path to the project file.
@@ -45,12 +46,14 @@ public class AddPackagesStep : ScaffoldStep
     /// <returns>True if the packages were added successfully; otherwise, false.</returns>
     public override Task<bool> ExecuteAsync(ScaffolderContext context, CancellationToken cancellationToken = default)
     {
-        foreach (var packageName in PackageNames)
+        foreach (Package package in Packages)
         {
+            // add package version here
             DotnetCommands.AddPackage(
-                packageName: packageName,
+                packageName: package.Name,
                 logger: _logger,
                 projectFile: ProjectPath,
+                packageVersion: package.Version,
                 includePrerelease: Prerelease);
         }
 

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Extensions/BlazorCrudScaffolderBuilderExtensions.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Extensions/BlazorCrudScaffolderBuilderExtensions.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.Core.Builder;
+using Microsoft.DotNet.Scaffolding.Core.Model;
 using Microsoft.DotNet.Scaffolding.Internal;
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 using Microsoft.DotNet.Tools.Scaffold.AspNet.Common;
@@ -72,7 +73,7 @@ internal static class BlazorCrudScaffolderBuilderExtensions
                     packageList.Add(projectPackageName);
                 }
 
-                step.PackageNames = packageList;
+                step.Packages = [.. packageList.Select(p => new Package(p))];
             }
             else
             {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Extensions/BlazorEntraScaffolderBuilderExtensions.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Extensions/BlazorEntraScaffolderBuilderExtensions.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.DotNet.Scaffolding.Core.Builder;
+using Microsoft.DotNet.Scaffolding.Core.Model;
 using Microsoft.DotNet.Scaffolding.Internal;
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 using Microsoft.DotNet.Tools.Scaffold.AspNet.Common;
@@ -253,7 +254,7 @@ internal static class BlazorEntraScaffolderBuilderExtensions
                 }
 
                 step.ProjectPath = entraSettings.Project;
-                step.PackageNames = packageList;
+                step.Packages = [.. packageList.Select(p => new Package(p))];
             }
             else
             {
@@ -294,7 +295,7 @@ internal static class BlazorEntraScaffolderBuilderExtensions
                             throw new InvalidOperationException("Project path is not set in EntraIdSettings.");
                         }
 
-                        step.PackageNames = packageList;
+                        step.Packages = [.. packageList.Select(p => new Package(p))];
                     }
                 }
                 else

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Extensions/BlazorIdentityScaffolderBuilderExtensions.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Extensions/BlazorIdentityScaffolderBuilderExtensions.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.Core.Builder;
+using Microsoft.DotNet.Scaffolding.Core.Model;
 using Microsoft.DotNet.Scaffolding.Internal;
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 using Microsoft.DotNet.Tools.Scaffold.AspNet.Common;
@@ -123,7 +124,7 @@ internal static class BlazorIdentityScaffolderBuilderExtensions
                     packageList.Add(projectPackageName);
                 }
 
-                step.PackageNames = packageList;
+                step.Packages = packageList.Select(p => new Package(p)).ToList();
             }
             else
             {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Extensions/EfControllerScaffolderBuilderExtensions.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Extensions/EfControllerScaffolderBuilderExtensions.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.Core.Builder;
+using Microsoft.DotNet.Scaffolding.Core.Model;
 using Microsoft.DotNet.Scaffolding.Internal;
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 using Microsoft.DotNet.Tools.Scaffold.AspNet.Common;
@@ -69,7 +70,7 @@ internal static class EfControllerScaffolderBuilderExtensions
                     packageList.Add(projectPackageName);
                 }
 
-                step.PackageNames = packageList;
+                step.Packages = [.. packageList.Select(p => new Package(p))];
             }
             else
             {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Extensions/IdentityScaffolderBuilderExtensions.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Extensions/IdentityScaffolderBuilderExtensions.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.Core.Builder;
+using Microsoft.DotNet.Scaffolding.Core.Model;
 using Microsoft.DotNet.Scaffolding.Internal;
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 using Microsoft.DotNet.Tools.Scaffold.AspNet.Common;
@@ -44,7 +45,7 @@ internal static class IdentityScaffolderBuilderExtensions
                     packageList.Add(dbProviderPackageName);
                 }
 
-                step.PackageNames = packageList;
+                step.Packages = [.. packageList.Select(p => new Package(p))];
             }
             else
             {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Extensions/MinimalApiScaffolderBuilderExtensions.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Extensions/MinimalApiScaffolderBuilderExtensions.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.Core.Builder;
+using Microsoft.DotNet.Scaffolding.Core.Model;
 using Microsoft.DotNet.Scaffolding.Internal;
 using Microsoft.DotNet.Tools.Scaffold.AspNet.Common;
 using Microsoft.DotNet.Tools.Scaffold.AspNet.Helpers;
@@ -91,7 +92,7 @@ internal static class MinimalApiScaffolderBuilderExtensions
                     packageList.Add(PackageConstants.AspNetCorePackages.OpenApiPackageName);
                 }
 
-                step.PackageNames = packageList;
+                step.Packages = [.. packageList.Select(p => new Package(p))];
             }
             else
             {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Extensions/RazorPagesScaffolderBuilderExtensions.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Extensions/RazorPagesScaffolderBuilderExtensions.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.Core.Builder;
+using Microsoft.DotNet.Scaffolding.Core.Model;
 using Microsoft.DotNet.Scaffolding.Internal;
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 using Microsoft.DotNet.Tools.Scaffold.AspNet.Common;
@@ -113,7 +114,7 @@ internal static class RazorPagesScaffolderBuilderExtensions
                     packageList.Add(projectPackageName);
                 }
 
-                step.PackageNames = packageList;
+                step.Packages = [.. packageList.Select(p => new Package(p))];
             }
             else
             {

--- a/src/dotnet-scaffolding/dotnet-scaffold/Aspire/Extensions/CachingScaffolderBuilderExtensions.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Aspire/Extensions/CachingScaffolderBuilderExtensions.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.Core.Builder;
+using Microsoft.DotNet.Scaffolding.Core.Model;
 using Microsoft.DotNet.Scaffolding.Internal;
 using Microsoft.DotNet.Tools.Scaffold.Aspire;
 using Microsoft.DotNet.Tools.Scaffold.Aspire.Helpers;
@@ -30,7 +31,7 @@ internal static class CachingScaffolderBuilderExtensions
                 commandSettingsObj is CommandSettings commandSettings)
             {
                 // Set package details for AppHost Redis
-                step.PackageNames = [PackageConstants.CachingPackages.AppHostRedisPackageName];
+                step.Packages = [new Package(PackageConstants.CachingPackages.AppHostRedisPackageName)];
                 step.ProjectPath = commandSettings.AppHostProject;
                 step.Prerelease = commandSettings.Prerelease;
             }
@@ -62,7 +63,7 @@ internal static class CachingScaffolderBuilderExtensions
                 }
 
                 // Set package details for the project
-                step.PackageNames = [projectPackageName];
+                step.Packages = [new Package(projectPackageName)];
                 step.ProjectPath = commandSettings.Project;
                 step.Prerelease = commandSettings.Prerelease;
             }

--- a/src/dotnet-scaffolding/dotnet-scaffold/Aspire/Extensions/DatabaseScaffolderBuilderExtensions.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Aspire/Extensions/DatabaseScaffolderBuilderExtensions.cs
@@ -6,6 +6,7 @@ using Microsoft.DotNet.Tools.Scaffold.Aspire;
 using Microsoft.DotNet.Tools.Scaffold.Aspire.Helpers;
 using Microsoft.DotNet.Tools.Scaffold.Aspire.ScaffoldSteps;
 using Microsoft.DotNet.Tools.Scaffold.Aspire.Command;
+using Microsoft.DotNet.Scaffolding.Core.Model;
 
 namespace Microsoft.DotNet.Scaffolding.Core.Hosting;
 
@@ -39,7 +40,7 @@ internal static class DatabaseScaffolderBuilderExtensions
                 }
 
                 // Set package details for AppHost
-                step.PackageNames = [appHostPackageName];
+                step.Packages = [new Package(appHostPackageName)];
                 step.ProjectPath = commandSettings.AppHostProject;
                 step.Prerelease = commandSettings.Prerelease;
             }
@@ -71,7 +72,7 @@ internal static class DatabaseScaffolderBuilderExtensions
                 }
 
                 // Set package details for the API service project
-                step.PackageNames = [projectPackageName];
+                step.Packages = [new Package(projectPackageName)];
                 step.ProjectPath = commandSettings.Project;
                 step.Prerelease = commandSettings.Prerelease;
             }

--- a/src/dotnet-scaffolding/dotnet-scaffold/Aspire/Extensions/StorageScaffolderBuilderExtensions.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Aspire/Extensions/StorageScaffolderBuilderExtensions.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.Core.Builder;
+using Microsoft.DotNet.Scaffolding.Core.Model;
 using Microsoft.DotNet.Scaffolding.Internal;
 using Microsoft.DotNet.Tools.Scaffold.Aspire;
 using Microsoft.DotNet.Tools.Scaffold.Aspire.Helpers;
@@ -30,7 +31,7 @@ internal static class StorageScaffolderBuilderExtensions
                 commandSettingsObj is CommandSettings commandSettings)
             {
                 // Set package details for AppHost storage
-                step.PackageNames = [PackageConstants.StoragePackages.AppHostStoragePackageName];
+                step.Packages = [new Package(PackageConstants.StoragePackages.AppHostStoragePackageName)];
                 step.ProjectPath = commandSettings.AppHostProject;
                 step.Prerelease = commandSettings.Prerelease;
             }
@@ -62,7 +63,7 @@ internal static class StorageScaffolderBuilderExtensions
                 }
 
                 // Set package details for the project
-                step.PackageNames = [projectPackageName];
+                step.Packages = [new Package(projectPackageName)];
                 step.ProjectPath = commandSettings.Project;
                 step.Prerelease = commandSettings.Prerelease;
             }


### PR DESCRIPTION
Right now, only the newest NuGet package versions are installed with `dotnet scaffold`. This will need to change when `dotnet scaffold` CLI commands are used inside of VS. This is an early step in the process to get there, allowing for specified package versions to be installed. 

fixes #3310 

