### PR TITLE
Update macOS runner to latest

### DIFF
--- a/azure-pipelines-pr.yml
+++ b/azure-pipelines-pr.yml
@@ -82,7 +82,7 @@ stages:
         - job: OSX
           timeoutInMinutes: 180
           pool:
-            vmImage: macOS-13
+            vmImage: macOS-latest
 
           strategy:
             matrix:


### PR DESCRIPTION
macOS-13 is being deprecated per https://github.com/actions/runner-images/issues/13046
