### PR TITLE
do not show the same tenantID more than once

### DIFF
--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Helpers/AzCliHelper.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Helpers/AzCliHelper.cs
@@ -160,8 +160,8 @@ internal static class AzCliHelper
     /// <returns>if successful, return true</returns>
     private static bool GetAzureUsernamesAndTenatIds(string output, out List<string> usernames, out List<string> tenants, out string? usernameTenantError)
     {
-        tenants = [];
         HashSet<string> uniqueUsernames = [];
+        HashSet<string> uniqueTenants = [];
 
         try
         {
@@ -189,12 +189,13 @@ internal static class AzCliHelper
                         string? id = tenant.GetString();
                         if (!string.IsNullOrEmpty(id))
                         {
-                            tenants.Add(id);
+                            uniqueTenants.Add(id);
                         }
                     }
                 }
             }
             usernames = [.. uniqueUsernames];
+            tenants = [.. uniqueTenants];
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
Before, tenant IDs would be showed there were multiple of the same name registered. This corrects the issue and does not show duplicates. 


