### PR TITLE
do not add unneeded packages entraId scaffold

### DIFF
--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Extensions/BlazorEntraScaffolderBuilderExtensions.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Extensions/BlazorEntraScaffolderBuilderExtensions.cs
@@ -240,9 +240,7 @@ internal static class BlazorEntraScaffolderBuilderExtensions
             var step = config.Step;
             var context = config.Context;
             List<string> packageNames = [
-                PackageConstants.AspNetCorePackages.AspNetCoreAuthenticationJwtBearerPackageName,
-                PackageConstants.AspNetCorePackages.AspNetCoreAuthenticationOpenIdConnectPackageName,
-                PackageConstants.AspNetCorePackages.MicrosoftIdentityWebPackageName,
+                PackageConstants.AspNetCorePackages.MicrosoftIdentityWebPackageName
             ];
 
             if (context.Properties.TryGetValue(nameof(EntraIdSettings), out var entraIdSettings) &&


### PR DESCRIPTION
During EntraID scaffold step, these unnecessary packages are added. This PR ensures they are not added which simplifies the resulting code and improves the scaffolding performance through not making uneed CLI calls.


