### PR TITLE
add missing using that was causing a warning after entra ID scaffolding

### DIFF
--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/BlazorEntraId/LoginOrLogout.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/BlazorEntraId/LoginOrLogout.cs
@@ -22,8 +22,9 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.BlazorEntraId
         /// </summary>
         public virtual string TransformText()
         {
-            this.Write("\n");
-            this.Write(@"
+			this.Write("\n");
+			this.Write(@"
+@using Microsoft.AspNetCore.Components.Authorization
 @implements IDisposable
 @inject NavigationManager Navigation
 


### PR DESCRIPTION
After Entra ID scaffolding, building the project results in a warning. This PR fixes that.  Eventually, moving this warning to `_imports.razor` will be needed, but for now it is fine directly in the `LoginOrLogout.razor` file. #3330 to track 

<img width="2432" height="175" alt="image" src="https://github.com/user-attachments/assets/9219b8b9-1aed-46fa-94f3-a710d615a166" />
 


