### PR TITLE
put AddCascadingAuthenticationState after entra id

### DIFF
--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/CodeModificationConfigs/blazorEntraChanges.json
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/CodeModificationConfigs/blazorEntraChanges.json
@@ -17,6 +17,13 @@
                     },
                     {
                       "InsertBefore": [ "var app = WebApplication.CreateBuilder.Build();" ],
+                      "Block": "builder.Services.AddCascadingAuthenticationState();",
+                      "LeadingTrivia": {
+                        "Newline": true
+                      }
+                    },
+                    {
+                      "InsertBefore": [ "var app = WebApplication.CreateBuilder.Build();" ],
                       "MultiLineBlock": [
                         "builder.Services.AddAuthorization(options =>",
                         "{",

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/CodeModificationConfigs/test.json
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/CodeModificationConfigs/test.json
@@ -11,6 +11,7 @@
                 "builder.Services.AddAuthentication(OpenIdConnectDefaults.AuthenticationScheme)",
                 "    .AddMicrosoftIdentityWebApp(builder.Configuration.GetSection(\"AzureAd\"));",
                 "",
+                "builder.Services.AddCascadingAuthenticationState();",
                 "builder.Services.AddAuthorization(options =>",
                 "{",
                 "    // By default, all incoming requests will be authorized according to the default policy.",


### PR DESCRIPTION
via conversation with @danroth27 

`builder.Services.AddCascadingAuthenticationState(); ` is required in code after running the Entra ID scaffolder


