### PR TITLE
remove unneeded using

### DIFF
--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/BlazorEntraId/LoginOrLogout.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/BlazorEntraId/LoginOrLogout.cs
@@ -24,7 +24,6 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.BlazorEntraId
         {
 			this.Write("\n");
 			this.Write(@"
-@using Microsoft.AspNetCore.Components.Authorization
 @implements IDisposable
 @inject NavigationManager Navigation
 


### PR DESCRIPTION
fixes #3330 
This using gets folded in to `_Imports.razor` via #3343 so this using here is not needed. 


