### PR TITLE
Do not hard code ApplicationDbContext with Blazor Identity Scaffolder

### DIFF
--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/CodeModificationConfigs/blazorIdentityChanges.json
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/CodeModificationConfigs/blazorIdentityChanges.json
@@ -56,7 +56,7 @@
                 "        options.SignIn.RequireConfirmedAccount = true;",
                 "        options.Stores.SchemaVersion = IdentitySchemaVersions.Version3;",
                 "    })",
-                "    .AddEntityFrameworkStores<ApplicationDbContext>()",
+                "    .AddEntityFrameworkStores<$(DbContextName)>()",
                 "    .AddSignInManager()",
                 "    .AddDefaultTokenProviders()"
               ],


### PR DESCRIPTION
fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2651366
this was accidently hard coded leading to a build failure, this is fix corrects that and allows for build to succeed.



