### PR TITLE
Add .NET 11 support and update prerelease to preview

### DIFF
--- a/eng/Versions.DotNetScaffold.props
+++ b/eng/Versions.DotNetScaffold.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <VersionPrefix>11.0.0</VersionPrefix>
-    <PreReleaseVersionLabel>alpha</PreReleaseVersionLabel>
+    <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
     <PreReleaseVersionIteration>1</PreReleaseVersionIteration>
     <IncludeSourceRevisionInInformationalVersion>False</IncludeSourceRevisionInInformationalVersion>
     <IsServicingBuild Condition="'$(PreReleaseVersionLabel)' == 'servicing'">true</IsServicingBuild>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -71,7 +71,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <VersionPrefix>11.0.0</VersionPrefix>
-    <PreReleaseVersionLabel>alpha</PreReleaseVersionLabel>
+    <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
     <PreReleaseVersionIteration>1</PreReleaseVersionIteration>
     <IncludeSourceRevisionInInformationalVersion>False</IncludeSourceRevisionInInformationalVersion>
     <IsServicingBuild Condition="'$(PreReleaseVersionLabel)' == 'servicing'">true</IsServicingBuild>

--- a/scripts/install-aspnet-codegenerator.cmd
+++ b/scripts/install-aspnet-codegenerator.cmd
@@ -1,4 +1,4 @@
-set VERSION=10.0.0-dev
+set VERSION=11.0.0-dev
 set DEFAULT_NUPKG_PATH=C:\Nuget
 set SRC_DIR=%cd%
 set NUPKG=artifacts\packages\Debug\Shipping\

--- a/scripts/install-aspnet-codegenerator.sh
+++ b/scripts/install-aspnet-codegenerator.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-VERSION=10.0.0-dev
+VERSION=11.0.0-dev
 DEFAULT_NUPKG_PATH=~/.nuget/packages
 SRC_DIR=$(pwd)
 echo $SRC_DIR

--- a/scripts/install-scaffold.cmd
+++ b/scripts/install-scaffold.cmd
@@ -1,4 +1,4 @@
-set VERSION=10.0.0-dev
+set VERSION=11.0.0-dev
 set DEFAULT_NUPKG_PATH=%userprofile%/.nuget/packages
 set SRC_DIR=%cd%
 set NUPKG=artifacts/packages/Debug/Shipping/

--- a/scripts/install-scaffold.sh
+++ b/scripts/install-scaffold.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-VERSION=10.0.0-dev
+VERSION=11.0.0-dev
 DEFAULT_NUPKG_PATH=~/.nuget/packages
 SRC_DIR=$(pwd)
 echo $SRC_DIR

--- a/src/Shared/Microsoft.DotNet.Scaffolding.Shared/ProjectModel/ProjectModelHelper.cs
+++ b/src/Shared/Microsoft.DotNet.Scaffolding.Shared/ProjectModel/ProjectModelHelper.cs
@@ -43,11 +43,12 @@ namespace Microsoft.DotNet.Scaffolding.Shared.ProjectModel
             { ".NETCoreApp,Version=v8.0", "net8.0" },
             { ".NETCoreApp,Version=v9.0", "net9.0" },
             { ".NETCoreApp,Version=v10.0", "net10.0" },
+            { ".NETCoreApp,Version=v11.0", "net11.0" },
         };
 
         internal static bool IsTfmPreRelease(string tfm)
         {
-            return tfm.Equals("net10.0", StringComparison.OrdinalIgnoreCase);
+            return tfm.Equals("net11.0", StringComparison.OrdinalIgnoreCase);
         }
 
         internal static string GetManifestResource(Assembly assembly, string shortResourceName)

--- a/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.CodeModification/Helpers/ProjectModelHelper.cs
+++ b/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.CodeModification/Helpers/ProjectModelHelper.cs
@@ -16,11 +16,12 @@ internal static class ProjectModelHelper
         { ".NETCoreApp,Version=v8.0", "net8.0" },
         { ".NETCoreApp,Version=v9.0", "net9.0" },
         { ".NETCoreApp,Version=v10.0", "net10.0" },
+        { ".NETCoreApp,Version=v11.0", "net11.0" },
     };
 
     internal static bool IsTfmPreRelease(string tfm)
     {
-        return tfm.Equals("net10.0", StringComparison.OrdinalIgnoreCase);
+        return tfm.Equals("net11.0", StringComparison.OrdinalIgnoreCase);
     }
 
     internal static string GetManifestResource(Assembly assembly, string shortResourceName)

--- a/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Core/NuGet/Package.cs
+++ b/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Core/NuGet/Package.cs
@@ -53,7 +53,7 @@ internal static class PackageExtensions
     /// langword="null"/>. For supported target frameworks, the latest available version is retrieved
     /// asynchronously.</remarks>
     /// <param name="package">The package for which to obtain the version information. Must not be null.</param>
-    /// <param name="targetFramework">The target framework identifier (for example, "net8.0", "net9.0", or "net10.0") for which the package version is
+    /// <param name="targetFramework">The target framework identifier (for example, "net8.0", "net9.0", "net10.0" or "net11.0") for which the package version is
     /// requested. Case-insensitive.</param>
     /// <param name="nugetVersionHelper">The NuGet version helper to use for version resolution.</param>
     /// <param name="logger">The logger to use for logging messages.</param>
@@ -68,7 +68,7 @@ internal static class PackageExtensions
 
         if (targetFramework is null)
         {
-            logger?.LogError("Project contains a Target Framework that is not supported. Supported Target Frameworks are .NET8, .NET9, .NET10. Installing latest stable version of '{PackageName}'. Consider upgrading your Target Framework to install a compatible package version.", package.Name);
+            logger?.LogError("Project contains a Target Framework that is not supported. Supported Target Frameworks are .NET8, .NET9, .NET10, .NET11. Installing latest stable version of '{PackageName}'. Consider upgrading your Target Framework to install a compatible package version.", package.Name);
             return Task.FromResult<NuGetVersion?>(null);
         }
 
@@ -84,9 +84,13 @@ internal static class PackageExtensions
         {
             return nugetVersionHelper.GetLatestPackageForNetVersionAsync(package.Name, 10);
         }
+        else if (targetFramework.Equals(TargetFrameworkConstants.Net11, StringComparison.OrdinalIgnoreCase))
+        {
+            return nugetVersionHelper.GetLatestPackageForNetVersionAsync(package.Name, 11);
+        }
         else
         {
-            logger?.LogError("Target Framework '{TargetFramework}' is not supported. Supported Target Frameworks are .NET8, .NET9, .NET10. Installing latest stable version of '{PackageName}'. Consider upgrading your Target Framework to install a compatible package version.", targetFramework, package.Name);
+            logger?.LogError("Target Framework '{TargetFramework}' is not supported. Supported Target Frameworks are .NET8, .NET9, .NET10, .NET11. Installing latest stable version of '{PackageName}'. Consider upgrading your Target Framework to install a compatible package version.", targetFramework, package.Name);
             return Task.FromResult<NuGetVersion?>(null);
         }
     }

--- a/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Core/NuGet/TargetFrameworkConstants.cs
+++ b/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Core/NuGet/TargetFrameworkConstants.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Immutable;
+
 namespace Microsoft.DotNet.Scaffolding.Core.Model;
 
 internal static class TargetFrameworkConstants
@@ -10,5 +12,8 @@ internal static class TargetFrameworkConstants
     public const string Net8 = "net8.0";
     public const string Net9 = "net9.0";
     public const string Net10 = "net10.0";
+    public const string Net11 = "net11.0";
     public const string NetCoreApp = ".NETCoreApp";
+
+    public static readonly ImmutableArray<string> SupportedTargetFrameworks = [Net8, Net9, Net10, Net11];
 }

--- a/src/dotnet-scaffolding/dotnet-scaffold/Interactive/Flow/Steps/ParameterBasedFlowStep.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Interactive/Flow/Steps/ParameterBasedFlowStep.cs
@@ -86,6 +86,8 @@ namespace Microsoft.DotNet.Tools.Scaffold.Interactive.Flow.Steps
 
             if (NextStep is not null && NextStep.Parameter.DisplayName.Equals(AspnetStrings.Options.Prerelease.DisplayName, StringComparison.Ordinal) && ShouldSkipPrereleaseOption(context))
             {
+                // Skip the prerelease step if the target framework is not net11, prerelease only applies to net11
+                //TODO update for the next major release of .NET
                 NextStep = NextStep?.NextStep;
             }
 
@@ -174,7 +176,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.Interactive.Flow.Steps
         /// project.
         /// </summary>
         /// <remarks>The prerelease option is skipped for projects targeting frameworks other than .NET
-        /// 10. If the project file or target framework cannot be determined, the prerelease option is not
+        /// 11. If the project file or target framework cannot be determined, the prerelease option is not
         /// skipped.</remarks>
         /// <param name="context">The flow context containing project information and properties. Must not be null.</param>
         /// <returns>true if the prerelease option should be skipped for the current project; otherwise, false.</returns>
@@ -188,7 +190,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.Interactive.Flow.Steps
                 projectFileProperty.Value is string projectFilePath && !string.IsNullOrEmpty(projectFilePath))
             {
                 string? targetFramework = TargetFrameworkHelpers.GetLowestCompatibleTargetFramework(projectFilePath);
-                return targetFramework is null || !targetFramework.Equals(TargetFrameworkConstants.Net10, StringComparison.OrdinalIgnoreCase);
+                return targetFramework is null || !targetFramework.Equals(TargetFrameworkConstants.Net11, StringComparison.OrdinalIgnoreCase);
             }
             return false;
         }

--- a/test/dotnet-scaffolding/dotnet-scaffold.Tests/AspNet/Common/TargetFrameworkHelpersTests.cs
+++ b/test/dotnet-scaffolding/dotnet-scaffold.Tests/AspNet/Common/TargetFrameworkHelpersTests.cs
@@ -123,6 +123,34 @@ public class TargetFrameworkHelpersTests : IDisposable
     }
 
     [Fact]
+    public void GetLowestCompatibleTargetFramework_Net11Project_ReturnsNet11()
+    {
+        // Arrange
+        string projectPath = CreateTestProject("TestNet11.csproj", "net11.0");
+
+        // Act
+        string? result = TargetFrameworkHelpers.GetLowestCompatibleTargetFramework(projectPath);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal("net11.0", result);
+    }
+
+    [Fact]
+    public void GetLowestCompatibleTargetFramework_MultiTargetNet10AndNet11_ReturnsNet10()
+    {
+        // Arrange
+        string projectPath = CreateTestProject("TestMultiTarget4.csproj", "net10.0;net11.0", isMultiTarget: true);
+
+        // Act
+        string? result = TargetFrameworkHelpers.GetLowestCompatibleTargetFramework(projectPath);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal("net10.0", result);
+    }
+
+    [Fact]
     public void GetLowestCompatibleTargetFramework_Net7Project_ReturnsNull()
     {
         // Arrange


### PR DESCRIPTION
- Add net11.0 to TargetFrameworkConstants and SupportedTargetFrameworks
- Update prerelease option skip to check for net11 instead of net10
- Fix doc comments to include net11.0 in supported frameworks list
- Add net11 tests for TargetFrameworkHelpers
- Update PreReleaseVersionLabel from alpha to preview in version props
