### PR TITLE
Replace some c# 13 language features with net 8

### DIFF
--- a/src/Scaffolding/VS.Web.CG.Mvc/BlazorIdentity/BlazorIdentityGenerator.cs
+++ b/src/Scaffolding/VS.Web.CG.Mvc/BlazorIdentity/BlazorIdentityGenerator.cs
@@ -92,7 +92,7 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Blazor
         private IReadOnlyList<(string TemplateFolder, string FullPath)> _allBlazorIdentityStaticFiles;
         private IReadOnlyList<(string TemplateFolder, string FullPath)> AllBlazorIdentityStaticFiles
         {
-            get => _allBlazorIdentityStaticFiles ??= [.. BlazorIdentityHelper.GetBlazorIdentityStaticFiles(FileSystem, TemplateFolders)];
+            get => _allBlazorIdentityStaticFiles ??= BlazorIdentityHelper.GetBlazorIdentityStaticFiles(FileSystem, TemplateFolders).ToList();
         }
 
         private IList<Type> _blazorIdentityTemplateTypes;

--- a/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Core/NuGet/NuGetVersionService.cs
+++ b/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Core/NuGet/NuGetVersionService.cs
@@ -62,12 +62,12 @@ internal class NuGetVersionService
             }
         }
 
-        List<SourceRepository> repositories = [.. packageSources
-            .Select(source => _cachingProvider.CreateRepository(source))];
+        List<SourceRepository> repositories = packageSources
+            .Select(source => _cachingProvider.CreateRepository(source)).ToList();
 
         if (repositories.Count == 0)
         {
-            return [];
+            return Enumerable.Empty<NuGetVersion>();
         }
 
         // Query all sources in parallel to get package metadata

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/AspNetCommandService.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/AspNetCommandService.cs
@@ -20,8 +20,8 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet
 
         public Type[] GetScaffoldSteps()
         {
-            return
-            [
+            return new[]
+            {
                 typeof(AddClientSecretStep),
                 typeof(AddAspNetConnectionStringStep),
                 typeof(AddFileStep),
@@ -43,7 +43,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet
                 typeof(WrappedAddPackagesStep),
                 typeof(WrappedCodeModificationStep),
                 typeof(WrappedTextTemplatingStep)
-            ];
+            };
         }
 
         public void AddScaffolderCommands()

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Commands/AspNetOptions.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Commands/AspNetOptions.cs
@@ -101,7 +101,7 @@ internal class AspNetOptions
             Description = string.Empty,
             Required = false,
             PickerType = InteractivePickerType.CustomPicker,
-            CustomPickerValues = [.. AspNetDbContextHelper.DbContextTypeDefaults.Keys]
+            CustomPickerValues = AspNetDbContextHelper.DbContextTypeDefaults.Keys.ToList()
         };
 
         DatabaseProviderRequired = new ScaffolderOption<string>
@@ -111,7 +111,7 @@ internal class AspNetOptions
             Description = string.Empty,
             Required = true,
             PickerType = InteractivePickerType.CustomPicker,
-            CustomPickerValues = [.. AspNetDbContextHelper.DbContextTypeDefaults.Keys]
+            CustomPickerValues = AspNetDbContextHelper.DbContextTypeDefaults.Keys.ToList()
         };
 
         IdentityDbProviderRequired = new ScaffolderOption<string>
@@ -121,7 +121,7 @@ internal class AspNetOptions
             Description = string.Empty,
             Required = true,
             PickerType = InteractivePickerType.CustomPicker,
-            CustomPickerValues = [.. AspNetDbContextHelper.IdentityDbContextTypeDefaults.Keys]
+            CustomPickerValues = AspNetDbContextHelper.IdentityDbContextTypeDefaults.Keys.ToList()
         };
 
         DataContextClass = new ScaffolderOption<string>

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Helpers/AzCliHelper.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Helpers/AzCliHelper.cs
@@ -111,9 +111,9 @@ internal static class AzCliHelper
             {
                 azCliErrors = loginErrors;
             }
-            usernames = [];
-            tenants = [];
-            appIds = [];
+            usernames = new List<string>();
+            tenants = new List<string>();
+            appIds = new List<string>();
         }
     }
 
@@ -194,13 +194,13 @@ internal static class AzCliHelper
                     }
                 }
             }
-            usernames = [.. uniqueUsernames];
-            tenants = [.. uniqueTenants];
+            usernames = uniqueUsernames.ToList();
+            tenants = uniqueTenants.ToList();
         }
         catch (Exception ex)
         {
-            usernames = [];
-            tenants = [];
+            usernames = new List<string>();
+            tenants = new List<string>();
             usernameTenantError = $"Error parsing Azure accounts JSON: {ex.Message}";
             return false;
         }
@@ -221,7 +221,7 @@ internal static class AzCliHelper
         try
         {
             failingCommand = null;
-            appIds = [];
+            appIds = new List<string>();
             // Use Microsoft Graph API via az rest
             var exitCode = runner.RunAzCli("rest --method GET --url https://graph.microsoft.com/v1.0/applications?$select=appId,displayName", out string? stdOut, out string? stdErr);
 
@@ -257,7 +257,7 @@ internal static class AzCliHelper
         }
         catch (Exception ex)
         {
-            appIds = [];
+            appIds = new List<string>();
             failingCommand = ex.Message;
         }
 

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/ScaffoldSteps/AddClientSecretStep.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/ScaffoldSteps/AddClientSecretStep.cs
@@ -176,7 +176,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.ScaffoldSteps
                     args.Add("--prerelease");
                 }
 
-                DotnetCliRunner runner = DotnetCliRunner.CreateDotNet(commandName, [.. args], GetCliEnvVars());
+                DotnetCliRunner runner = DotnetCliRunner.CreateDotNet(commandName, args.ToArray(), GetCliEnvVars());
                 int exitCode = runner.ExecuteAndCaptureOutput(out string? stdOut, out string? stdErr);
                 if (exitCode == 0)
                 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/Aspire/Command/CliStrings.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Aspire/Command/CliStrings.cs
@@ -56,7 +56,7 @@ internal class AspireCliStrings
                 { "sqlserver-efcore", DbContextHelper.SqlServerDefaults }
             };
 
-        internal static List<string> DatabaseTypeCustomValues = [.. DatabaseTypeDefaults.Keys];
+        internal static List<string> DatabaseTypeCustomValues = DatabaseTypeDefaults.Keys.ToList();
     }
 
     // aspire storage

--- a/src/dotnet-scaffolding/dotnet-scaffold/Interactive/Flow/Steps/CommandExecuteFlowStep.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Interactive/Flow/Steps/CommandExecuteFlowStep.cs
@@ -77,7 +77,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.Interactive.Flow.Steps
                     }
 
                     // Invoke the command directly (async)
-                    ParseResult aspireParseResult = runner.RootCommand.Parse([.. parameterValues]);
+                    ParseResult aspireParseResult = runner.RootCommand.Parse(parameterValues.ToArray());
                     int aspireExitCode = await aspireParseResult.InvokeAsync();
 
                     _telemetryService.TrackEvent(new CommandExecuteTelemetryEvent(dotnetToolInfo, commandInfo, aspireExitCode, chosenCategory));
@@ -97,7 +97,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.Interactive.Flow.Steps
                         return FlowStepResult.Failure("AspNet command infrastructure not available.");
                     }
                     // Invoke the command directly (async)
-                    ParseResult aspnetParseResult = runner.RootCommand.Parse([.. parameterValues]);
+                    ParseResult aspnetParseResult = runner.RootCommand.Parse(parameterValues.ToArray());
                     int aspnetExitCode = await aspnetParseResult.InvokeAsync();
                     _telemetryService.TrackEvent(new CommandExecuteTelemetryEvent(dotnetToolInfo, commandInfo, aspnetExitCode, chosenCategory));
                     if (aspnetExitCode != 0)

--- a/src/dotnet-scaffolding/dotnet-scaffold/Interactive/Flow/Steps/CommandPickerFlowStep.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Interactive/Flow/Steps/CommandPickerFlowStep.cs
@@ -140,7 +140,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.Interactive.Flow.Steps
             ParameterBasedFlowStep? firstParameterStep = null;
             if (commandInfo.Parameters != null && commandInfo.Parameters.Length != 0)
             {
-                firstParameterStep = BuildParameterFlowSteps([.. commandInfo.Parameters]);
+                firstParameterStep = BuildParameterFlowSteps(commandInfo.Parameters.ToList());
             }
 
             return firstParameterStep;

--- a/src/dotnet-scaffolding/dotnet-scaffold/Interactive/Flow/Steps/ParameterDiscovery.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Interactive/Flow/Steps/ParameterDiscovery.cs
@@ -92,7 +92,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.Interactive.Flow.Steps
         /// </summary>
         private async Task<string?> PromptInteractivePicker(IFlowContext context, InteractivePickerType? pickerType)
         {
-            List<StepOption> stepOptions = [];
+            List<StepOption> stepOptions = new List<StepOption>();
             var codeService = context.GetCodeService();
             var converter = GetDisplayName;
             switch (pickerType)
@@ -101,7 +101,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.Interactive.Flow.Steps
                     // ICodeService might be null if no InteractivePickerType.ProjectPicker was passed.
                     if (codeService is null)
                     {
-                        stepOptions = [];
+                        stepOptions = new List<StepOption>();
                     }
                     else
                     {
@@ -111,7 +111,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.Interactive.Flow.Steps
                 case InteractivePickerType.FilePicker:
                     if (codeService is null)
                     {
-                        stepOptions = [];
+                        stepOptions = new List<StepOption>();
                     }
                     else
                     {
@@ -124,7 +124,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.Interactive.Flow.Steps
                     converter = GetDisplayNameForProjects;
                     break;
                 case InteractivePickerType.YesNo:
-                    stepOptions = [new() { Name = "Yes", Value = "true" }, new() { Name = "No", Value = "false" }];
+                    stepOptions = new List<StepOption> { new() { Name = "Yes", Value = "true" }, new() { Name = "No", Value = "false" } };
                     converter = GetDisplayNameForYesNo;
                     break;
                 case InteractivePickerType.CustomPicker:
@@ -215,7 +215,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.Interactive.Flow.Steps
                         return AzCliHelper.GetAppIdParameterValuesDynamically(context);
                     });
             }
-            return [.. values.Select(x => new StepOption() { Name = x, Value = x })];
+            return values.Select(x => new StepOption() { Name = x, Value = x }).ToList();
         }
 
         /// <summary>
@@ -284,13 +284,13 @@ namespace Microsoft.DotNet.Tools.Scaffold.Interactive.Flow.Steps
                 {
                     if (codeService is null)
                     {
-                        return [];
+                        return new List<INamedTypeSymbol>();
                     }
 
                     return await codeService.GetAllClassSymbolsAsync();
                 });
 
-            List<StepOption> classNames = [];
+            List<StepOption> classNames = new List<StepOption>();
             if (allClassSymbols != null && allClassSymbols.Count != 0)
             {
                 allClassSymbols.ForEach(
@@ -311,7 +311,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.Interactive.Flow.Steps
         /// </summary>
         internal static List<StepOption> GetDocumentNames(List<Document> documents)
         {
-            List<StepOption> classNames = [];
+            List<StepOption> classNames = new List<StepOption>();
             if (documents != null && documents.Count != 0)
             {
                 documents.ForEach(
@@ -427,13 +427,13 @@ namespace Microsoft.DotNet.Tools.Scaffold.Interactive.Flow.Steps
         {
             get
             {
-                _dbProviders ??=
-                [
+                _dbProviders ??= new List<StepOption>
+                {
                     new() { Name = "SQL Server", Value = "sqlserver" },
                     new() { Name = "SQLite", Value = "sqlite" },
                     new() { Name = "PostgreSQL", Value = "postgres" },
                     new() { Name = "Cosmos DB", Value = "cosmos" }
-                ];
+                };
 
                 return _dbProviders;
             }

--- a/src/dotnet-scaffolding/dotnet-scaffold/Program.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Program.cs
@@ -33,7 +33,7 @@ IScaffoldRunner runner = builder.Build();
 // are routed through System.CommandLine experience
 builder.AddHandler(async (parseResult, cancellationToken) =>
 {
-    ScaffoldCommandAppBuilder appBuilder = new(runner, [.. parseResult.Tokens.Select(t => t.Value)]);
+    ScaffoldCommandAppBuilder appBuilder = new(runner, parseResult.Tokens.Select(t => t.Value).ToArray());
     ScaffoldCommandApp app = appBuilder.Build();
     await app.RunAsync();
 });

--- a/src/dotnet-scaffolding/dotnet-scaffold/Services/DotNetToolService.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Services/DotNetToolService.cs
@@ -31,7 +31,7 @@ internal class DotNetToolService : IDotNetToolService
         _logger = logger;
         _environmentService = environmentService;
         _fileSystem = fileSystem;
-        _dotNetTools = [];
+        _dotNetTools = new List<DotNetToolInfo>();
     }
 
     // Cached list of discovered .NET tools.
@@ -249,7 +249,7 @@ internal class DotNetToolService : IDotNetToolService
                     }
                 }
 
-                _dotNetTools = [.. dotnetToolList];
+                _dotNetTools = dotnetToolList.ToList();
             }
 
             // Parse through global tools

--- a/test/Shared/Microsoft.DotNet.Scaffolding.ComponentModel.Tests/CommandInfoTests.cs
+++ b/test/Shared/Microsoft.DotNet.Scaffolding.ComponentModel.Tests/CommandInfoTests.cs
@@ -48,7 +48,7 @@ namespace Microsoft.DotNet.Scaffolding.ComponentModel.Tests
                 DisplayName = "Command 1",
                 DisplayCategory = "General",
                 Description = "Description 1",
-                Parameters = [ValidParameter]
+                Parameters = new[] { ValidParameter }
             };
 
             PartialCommandInfo = new()
@@ -56,10 +56,10 @@ namespace Microsoft.DotNet.Scaffolding.ComponentModel.Tests
                 Name = "command2",
                 DisplayName = "Command 2",
                 DisplayCategory = "General",
-                Parameters =
-                [
+                Parameters = new[]
+                {
                     ValidParameter, PartialParameter
-                ]
+                }
             };
 
             PartialCommandInfo2 = new()
@@ -68,16 +68,16 @@ namespace Microsoft.DotNet.Scaffolding.ComponentModel.Tests
                 DisplayName = "Command 3",
                 DisplayCategory = "General",
                 Description = null,
-                Parameters =
-                [
+                Parameters = new[]
+                {
                     ValidParameter, PartialParameter, PartialParameter2
-                ]
+                }
             };
 
-            CommandInfos =
-            [
+            CommandInfos = new[]
+            {
                 ValidCommandInfo, PartialCommandInfo, PartialCommandInfo2
-            ];
+            };
         }
     
         [Fact]

--- a/test/dotnet-scaffolding/dotnet-scaffold.Tests/AspNet/Helpers/BlazorIdentityHelperTests.cs
+++ b/test/dotnet-scaffolding/dotnet-scaffold.Tests/AspNet/Helpers/BlazorIdentityHelperTests.cs
@@ -19,7 +19,7 @@ public class BlazorIdentityHelperTests
     public void GetTextTemplatingProperties_WithEmptyTemplatePaths_ReturnsEmpty()
     {
         // Arrange
-        List<string> templatePaths = [];
+        List<string> templatePaths = new List<string>();
         IdentityModel identityModel = CreateTestIdentityModel();
 
         // Act

--- a/test/dotnet-scaffolding/dotnet-scaffold.Tests/AspNet/Helpers/EntraIdHelperTests.cs
+++ b/test/dotnet-scaffolding/dotnet-scaffold.Tests/AspNet/Helpers/EntraIdHelperTests.cs
@@ -18,7 +18,7 @@ public class EntraIdHelperTests
     public void GetTextTemplatingProperties_WithEmptyTemplatePaths_ReturnsEmpty()
     {
         // Arrange
-        List<string> templatePaths = [];
+        List<string> templatePaths = new List<string>();
         EntraIdModel entraIdModel = CreateTestEntraIdModel();
 
         // Act

--- a/test/dotnet-scaffolding/dotnet-scaffold.Tests/AspNet/Helpers/IdentityHelperTests.cs
+++ b/test/dotnet-scaffolding/dotnet-scaffold.Tests/AspNet/Helpers/IdentityHelperTests.cs
@@ -19,7 +19,7 @@ public class IdentityHelperTests
     public void GetTextTemplatingProperties_WithEmptyFilePaths_ReturnsEmpty()
     {
         // Arrange
-        List<string> filePaths = [];
+        List<string> filePaths = new List<string>();
         IdentityModel identityModel = CreateTestIdentityModel();
 
         // Act

--- a/test/dotnet-scaffolding/dotnet-scaffold.Tests/AspNet/Helpers/ViewHelperTests.cs
+++ b/test/dotnet-scaffolding/dotnet-scaffold.Tests/AspNet/Helpers/ViewHelperTests.cs
@@ -120,7 +120,7 @@ public class ViewHelperTests
     {
         // Arrange
         string projectPath = Path.Combine("test", "project", "TestProject.csproj");
-        List<string> templatePaths = [];
+        List<string> templatePaths = new List<string>();
         
         ViewModel viewModel = new ViewModel
         {

--- a/test/dotnet-scaffolding/dotnet-scaffold.Tests/AspNet/ScaffoldSteps/WrappedAddPackagesStepTests.cs
+++ b/test/dotnet-scaffolding/dotnet-scaffold.Tests/AspNet/ScaffoldSteps/WrappedAddPackagesStepTests.cs
@@ -41,7 +41,7 @@ public class WrappedAddPackagesStepTests
             mockTelemetryService.Object,
             nugetVersionService)
         {
-            Packages = [],
+            Packages = Array.Empty<string>(),
             ProjectPath = string.Empty
         };
 
@@ -66,7 +66,7 @@ public class WrappedAddPackagesStepTests
             mockTelemetryService.Object,
             nugetVersionService)
         {
-            Packages = [],
+            Packages = Array.Empty<string>(),
             ProjectPath = string.Empty
         };
 
@@ -95,7 +95,7 @@ public class WrappedAddPackagesStepTests
             mockTelemetryService.Object,
             nugetVersionService)
         {
-            Packages = [],
+            Packages = Array.Empty<string>(),
             ProjectPath = string.Empty
         };
 

--- a/test/dotnet-scaffolding/dotnet-scaffold.Tests/AspNet/ScaffoldSteps/WrappedCodeModificationStepTests.cs
+++ b/test/dotnet-scaffolding/dotnet-scaffold.Tests/AspNet/ScaffoldSteps/WrappedCodeModificationStepTests.cs
@@ -37,7 +37,7 @@ public class WrappedCodeModificationStepTests
             NullLogger<WrappedCodeModificationStep>.Instance,
             mockTelemetryService.Object)
         {
-            CodeChangeOptions = [],
+            CodeChangeOptions = Array.Empty<CodeChangeOptions>(),
             ProjectPath = string.Empty
         };
 
@@ -74,7 +74,7 @@ public class WrappedCodeModificationStepTests
             NullLogger<WrappedCodeModificationStep>.Instance,
             mockTelemetryService.Object)
         {
-            CodeChangeOptions = [],
+            CodeChangeOptions = Array.Empty<CodeChangeOptions>(),
             ProjectPath = string.Empty
         };
 

--- a/test/dotnet-scaffolding/dotnet-scaffold.Tests/AspNet/ScaffoldSteps/WrappedTextTemplatingStepTests.cs
+++ b/test/dotnet-scaffolding/dotnet-scaffold.Tests/AspNet/ScaffoldSteps/WrappedTextTemplatingStepTests.cs
@@ -35,7 +35,7 @@ public class WrappedTextTemplatingStepTests
             NullLogger<WrappedTextTemplatingStep>.Instance,
             mockTelemetryService.Object)
         {
-            TextTemplatingProperties = []
+            TextTemplatingProperties = Array.Empty<TextTemplatingProperty>()
         };
 
         // Act
@@ -54,7 +54,7 @@ public class WrappedTextTemplatingStepTests
             NullLogger<WrappedTextTemplatingStep>.Instance,
             mockTelemetryService.Object)
         {
-            TextTemplatingProperties = []
+            TextTemplatingProperties = Array.Empty<TextTemplatingProperty>()
         };
 
         CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
@@ -78,7 +78,7 @@ public class WrappedTextTemplatingStepTests
             NullLogger<WrappedTextTemplatingStep>.Instance,
             mockTelemetryService.Object)
         {
-            TextTemplatingProperties = []
+            TextTemplatingProperties = Array.Empty<TextTemplatingProperty>()
         };
 
         // Assert
@@ -94,7 +94,7 @@ public class WrappedTextTemplatingStepTests
             NullLogger<WrappedTextTemplatingStep>.Instance,
             mockTelemetryService.Object)
         {
-            TextTemplatingProperties = []
+            TextTemplatingProperties = Array.Empty<TextTemplatingProperty>()
         };
 
         ScaffolderContext testContext = new ScaffolderContext(_mockScaffolder.Object);


### PR DESCRIPTION
Replace some of the newer list syntax like `[]` list declaration and `[.. ]` with syntax available in .NET 8. This is in efforts to work towards backwards compatibility of `dotnet scaffold`


