### PR TITLE
Pack copies for files not existing for net 8 or net 9

### DIFF
--- a/src/dotnet-scaffolding/dotnet-scaffold/dotnet-scaffold.csproj
+++ b/src/dotnet-scaffolding/dotnet-scaffold/dotnet-scaffold.csproj
@@ -52,12 +52,40 @@
   <ItemGroup>
     <None Pack="true" Include="$(RepoRoot)src\dotnet-scaffolding\Microsoft.DotNet.Scaffolding.TextTemplating\DbContext\net10.0\*.tt" PackagePath="AspNet\Templates\net10.0\DbContext\" />
     <None Pack="true" Include="$(RepoRoot)src\dotnet-scaffolding\Microsoft.DotNet.Scaffolding.TextTemplating\DbContext\net11.0\*.tt" PackagePath="AspNet\Templates\net11.0\DbContext\" />
+    <!-- DbContext templates don't exist in net8.0/net9.0 folders, so we use copies from net10.0 -->
+    <None Pack="true" Include="$(RepoRoot)src\dotnet-scaffolding\Microsoft.DotNet.Scaffolding.TextTemplating\DbContext\net10.0\NewDbContext.tt" PackagePath="AspNet\Templates\net8.0\DbContext\" />
+    <None Pack="true" Include="$(RepoRoot)src\dotnet-scaffolding\Microsoft.DotNet.Scaffolding.TextTemplating\DbContext\net10.0\NewDbContext.tt" PackagePath="AspNet\Templates\net9.0\DbContext\" />
     <None Pack="true" Include="AspNet\Templates\**\*.tt" PackagePath="AspNet\Templates\" />
     <None Pack="true" Include="README.md" PackagePath="\" />
     <!-- Pack AspNet CodeModificationConfigs into AspNet folder -->
     <None Pack="true" Include="AspNet\Templates\net8.0\CodeModificationConfigs\*.json">
       <PackagePath>AspNet\CodeModificationConfigs\net8.0</PackagePath>
     </None>
+    <!-- 
+      The following net8.0 templates do not exist in the net8.0 folder, so we use copies from net9.0.
+      These folders/files were added in net9.0 and are not present in net8.0 Templates:
+      - EfController\*.tt (ApiEfController, MvcEfController)
+      - Identity\Pages\**\*.tt (full Identity scaffolding pages)
+      - MinimalApi\*.tt (MinimalApi, MinimalApiEf)
+      - RazorPages\*.tt (CRUD pages)
+      - Views\*.tt (MVC views)
+      - BlazorIdentity\Pages\AccessDenied.tt
+      - Files\ApplicationUser.tt, _ValidationScriptsPartial.cshtml
+      - CodeModificationConfigs (efControllerChanges.json, identityChanges.json, razorPagesChanges.json)
+    -->
+    <None Pack="true" Include="AspNet\Templates\net9.0\EfController\*.tt" PackagePath="AspNet\Templates\net8.0\EfController\" />
+    <None Pack="true" Include="AspNet\Templates\net9.0\Identity\Pages\**\*.tt" PackagePath="AspNet\Templates\net8.0\Identity\Pages\" />
+    <None Pack="true" Include="AspNet\Templates\net9.0\MinimalApi\*.tt" PackagePath="AspNet\Templates\net8.0\MinimalApi\" />
+    <None Pack="true" Include="AspNet\Templates\net9.0\RazorPages\*.tt" PackagePath="AspNet\Templates\net8.0\RazorPages\" />
+    <None Pack="true" Include="AspNet\Templates\net9.0\Views\*.tt" PackagePath="AspNet\Templates\net8.0\Views\" />
+    <None Pack="true" Include="AspNet\Templates\net9.0\BlazorIdentity\Pages\AccessDenied.tt" PackagePath="AspNet\Templates\net8.0\BlazorIdentity\Pages\" />
+    <None Pack="true" Include="AspNet\Templates\net9.0\Files\ApplicationUser.tt" PackagePath="AspNet\Templates\net8.0\Files\" />
+    <None Pack="true" Include="AspNet\Templates\net9.0\Files\_ValidationScriptsPartial.cshtml" PackagePath="AspNet\Templates\net8.0\Files\" />
+    <!-- Only copy CodeModificationConfigs that don't exist in net8.0 (efControllerChanges, identityChanges, razorPagesChanges) -->
+    <!-- minimalApiChanges.json, blazorWebCrudChanges.json, blazorIdentityChanges.json already exist in net8.0 -->
+    <None Pack="true" Include="AspNet\Templates\net9.0\CodeModificationConfigs\efControllerChanges.json" PackagePath="AspNet\CodeModificationConfigs\net8.0\" />
+    <None Pack="true" Include="AspNet\Templates\net9.0\CodeModificationConfigs\identityChanges.json" PackagePath="AspNet\CodeModificationConfigs\net8.0\" />
+    <None Pack="true" Include="AspNet\Templates\net9.0\CodeModificationConfigs\razorPagesChanges.json" PackagePath="AspNet\CodeModificationConfigs\net8.0\" />
     <None Pack="true" Include="AspNet\Templates\net9.0\CodeModificationConfigs\*.json">
       <PackagePath>AspNet\CodeModificationConfigs\net9.0</PackagePath>
     </None>
@@ -84,6 +112,11 @@
 
   <!-- Copy templates to output for runtime but exclude from publish/pack -->
   <ItemGroup>
+    <!-- Include net8.0 templates in build output -->
+    <None Include="AspNet\Templates\net8.0\**\*.*">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>AspNet\Templates\net8.0\%(RecursiveDir)%(Filename)%(Extension)</Link>
+    </None>
     <!-- Include net9.0 templates in build output -->
     <None Include="AspNet\Templates\net9.0\**\*.*">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>


### PR DESCRIPTION
- pack and stores copies of files for net 8 from the net 9 version to provide parity for net 8 AspNet scaffolding
- pack and store copies of NewDBContext.tt files for net 8 and net 9 for parity
- Note does not add parity for Aspire or Entra Id, only other AspNet Scaffolders

When running scaffolding for net 8 and 9 it looks for these files (for example the NEwDBContext.tt) and fails when that file is not stored for net 8 and net 9, but there is not reason this file should be not added in those scenario. Hence, a copy of this file is packed into those folders and used in the scaffolding proccess.

fixes #3561 
fixes #3556 