### PR TITLE
In MiinimalApi scaffolder replace NotFound() in templates for net 8 and net 9

### DIFF
--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net8.0/MinimalApi/MinimalApiEf.cshtml
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net8.0/MinimalApi/MinimalApiEf.cshtml
@@ -28,7 +28,7 @@
     string typedTaskWithNotFound = Model.UseTypedResults ? $"Task<Results<Ok<{@modelName}>, NotFound>>" : "";
     string typedTaskOkNotFound = Model.UseTypedResults ? $"Task<Results<Ok, NotFound>>" : "";
     string typedTaskWithNoContent = Model.UseTypedResults ? $"Task<Results<NotFound, NoContent>>" : "";
-    string resultsNotFound = $"{resultsExtension}.NotFound()";
+    string resultsNotFound = $"{resultsExtension}.NavigateTo(\"notfound\");";
     string resultsOkModel = $"{resultsExtension}.Ok(model)";
     string resultsOkEmpty = $"{resultsExtension}.Ok()";
     string resultsNoContent = $"{resultsExtension}.NoContent()";

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net8.0/MinimalApi/MinimalApiEfNoClass.cshtml
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net8.0/MinimalApi/MinimalApiEfNoClass.cshtml
@@ -28,7 +28,7 @@
     string typedTaskWithNotFound = Model.UseTypedResults ? $"Task<Results<Ok<{@modelName}>, NotFound>>" : "";
     string typedTaskOkNotFound = Model.UseTypedResults ? $"Task<Results<Ok, NotFound>>" : "";
     string typedTaskWithNoContent = Model.UseTypedResults ? $"Task<Results<NotFound, NoContent>>" : "";
-    string resultsNotFound = $"{resultsExtension}.NotFound()";
+    string resultsNotFound = $"{resultsExtension}.NavigateTo(\"notfound\");";
     string resultsOkModel = $"{resultsExtension}.Ok(model)";
     string resultsOkEmpty = $"{resultsExtension}.Ok()";
     string resultsNoContent = $"{resultsExtension}.NoContent()";

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net9.0/MinimalApi/MinimalApiEf.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net9.0/MinimalApi/MinimalApiEf.cs
@@ -55,7 +55,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.MinimalApi
     string typedTaskWithNotFound = Model.UseTypedResults ? $"Task<Results<Ok<{modelName}>, NotFound>>" : "";
     string typedTaskOkNotFound = Model.UseTypedResults ? $"Task<Results<Ok, NotFound>>" : "";
     string typedTaskWithNoContent = Model.UseTypedResults ? $"Task<Results<NotFound, NoContent>>" : "";
-    string resultsNotFound = $"{resultsExtension}.NotFound()";
+    string resultsNotFound = $"{resultsExtension}.NavigateTo(\"notfound\");";
     string resultsOkModel = $"{resultsExtension}.Ok(model)";
     string resultsOkEmpty = $"{resultsExtension}.Ok()";
     string resultsNoContent = $"{resultsExtension}.NoContent()";

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net9.0/MinimalApi/MinimalApiEf.tt
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net9.0/MinimalApi/MinimalApiEf.tt
@@ -33,7 +33,7 @@
     string typedTaskWithNotFound = Model.UseTypedResults ? $"Task<Results<Ok<{modelName}>, NotFound>>" : "";
     string typedTaskOkNotFound = Model.UseTypedResults ? $"Task<Results<Ok, NotFound>>" : "";
     string typedTaskWithNoContent = Model.UseTypedResults ? $"Task<Results<NotFound, NoContent>>" : "";
-    string resultsNotFound = $"{resultsExtension}.NotFound()";
+    string resultsNotFound = $"{resultsExtension}.NavigateTo(\"notfound\");";
     string resultsOkModel = $"{resultsExtension}.Ok(model)";
     string resultsOkEmpty = $"{resultsExtension}.Ok()";
     string resultsNoContent = $"{resultsExtension}.NoContent()";


### PR DESCRIPTION
`NotFound()` exists in the templates but it does not exist on Net 8 and Net 9 
fixes #3652 #3653 

