### PR TITLE
Fix namespace in aspnet 11 templates

### DIFF
--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Helpers/BlazorIdentityHelper.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Helpers/BlazorIdentityHelper.cs
@@ -112,7 +112,7 @@ internal static class BlazorIdentityHelper
             if (_blazorIdentityTemplateTypes is null)
             {
                 var allTypes = Assembly.GetExecutingAssembly().GetTypes();
-                _blazorIdentityTemplateTypes = allTypes.Where(t => !string.IsNullOrEmpty(t.FullName) && t.FullName.Contains("AspNet.Templates.BlazorIdentity")).ToList();
+                _blazorIdentityTemplateTypes = allTypes.Where(t => !string.IsNullOrEmpty(t.FullName) && t.FullName.Contains("AspNet.Templates.net10.BlazorIdentity")).ToList();
             }
 
             return _blazorIdentityTemplateTypes;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Helpers/EntraIdHelper.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Helpers/EntraIdHelper.cs
@@ -78,7 +78,7 @@ internal static class EntraIdHelper
             if (_blazorEntraIdTemplateTypes is null)
             {
                 var allTypes = Assembly.GetExecutingAssembly().GetTypes();
-                _blazorEntraIdTemplateTypes = allTypes.Where(t => !string.IsNullOrEmpty(t.FullName) && t.FullName.Contains("AspNet.Templates.BlazorEntraId")).ToList();
+                _blazorEntraIdTemplateTypes = allTypes.Where(t => !string.IsNullOrEmpty(t.FullName) && t.FullName.Contains("AspNet.Templates.net10.BlazorEntraId")).ToList();
             }
 
             return _blazorEntraIdTemplateTypes;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Helpers/IdentityHelper.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Helpers/IdentityHelper.cs
@@ -119,7 +119,7 @@ internal static class IdentityHelper
             if (_identityTemplateTypes is null)
             {
                 var allTypes = Assembly.GetExecutingAssembly().GetTypes();
-                _identityTemplateTypes = allTypes.Where(t => !string.IsNullOrEmpty(t.FullName) && t.FullName.Contains("AspNet.Templates.Identity")).ToList();
+                _identityTemplateTypes = allTypes.Where(t => !string.IsNullOrEmpty(t.FullName) && t.FullName.Contains("AspNet.Templates.net10.Identity")).ToList();
             }
 
             return _identityTemplateTypes;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorCrud/Create.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorCrud/Create.Interfaces.cs
@@ -1,6 +1,6 @@
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorCrud;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorCrud;
 
 public partial class Create : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorCrud/Create.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorCrud/Create.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorCrud
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorCrud
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorCrud/Delete.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorCrud/Delete.Interfaces.cs
@@ -1,6 +1,6 @@
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorCrud;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorCrud;
 
 public partial class Delete : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorCrud/Delete.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorCrud/Delete.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorCrud
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorCrud
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorCrud/Details.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorCrud/Details.Interfaces.cs
@@ -1,6 +1,6 @@
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorCrud;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorCrud;
 
 public partial class Details : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorCrud/Details.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorCrud/Details.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorCrud
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorCrud
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorCrud/Edit.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorCrud/Edit.Interfaces.cs
@@ -1,6 +1,6 @@
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorCrud;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorCrud;
 
 public partial class Edit : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorCrud/Edit.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorCrud/Edit.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorCrud
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorCrud
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorCrud/Index.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorCrud/Index.Interfaces.cs
@@ -1,6 +1,6 @@
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorCrud;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorCrud;
 
 public partial class Index : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorCrud/Index.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorCrud/Index.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorCrud
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorCrud
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorCrud/NotFound.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorCrud/NotFound.Interfaces.cs
@@ -1,6 +1,6 @@
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorCrud;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorCrud;
 
 public partial class NotFound : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorCrud/NotFound.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorCrud/NotFound.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorCrud
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorCrud
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorEntraId/LoginLogoutEndpointRouteBuilderExtensions.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorEntraId/LoginLogoutEndpointRouteBuilderExtensions.Interfaces.cs
@@ -7,7 +7,7 @@ using System.Linq;
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorEntraId
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorEntraId
 {
     public partial class LoginLogoutEndpointRouteBuilderExtensions: ITextTransformation
     {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorEntraId/LoginLogoutEndpointRouteBuilderExtensions.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorEntraId/LoginLogoutEndpointRouteBuilderExtensions.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorEntraId
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorEntraId
 {
     using System;
     

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorEntraId/LoginOrLogout.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorEntraId/LoginOrLogout.Interfaces.cs
@@ -3,7 +3,7 @@
 
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorEntraId
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorEntraId
 {
     public partial class LoginOrLogout: ITextTransformation
     {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorEntraId/LoginOrLogout.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorEntraId/LoginOrLogout.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorEntraId
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorEntraId
 {
     using System;
     

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/IdentityComponentsEndpointRouteBuilderExtensions.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/IdentityComponentsEndpointRouteBuilderExtensions.Interfaces.cs
@@ -1,6 +1,6 @@
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorIdentity;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorIdentity;
 
 public partial class IdentityComponentsEndpointRouteBuilderExtensions : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/IdentityComponentsEndpointRouteBuilderExtensions.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/IdentityComponentsEndpointRouteBuilderExtensions.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorIdentity
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorIdentity
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/IdentityNoOpEmailSender.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/IdentityNoOpEmailSender.Interfaces.cs
@@ -1,6 +1,6 @@
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorIdentity;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorIdentity;
 
 public partial class IdentityNoOpEmailSender : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/IdentityNoOpEmailSender.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/IdentityNoOpEmailSender.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorIdentity
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorIdentity
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/IdentityRedirectManager.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/IdentityRedirectManager.Interfaces.cs
@@ -1,6 +1,6 @@
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorIdentity;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorIdentity;
 
 public partial class IdentityRedirectManager : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/IdentityRedirectManager.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/IdentityRedirectManager.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorIdentity
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorIdentity
 {
     using System;
     

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/IdentityRevalidatingAuthenticationStateProvider.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/IdentityRevalidatingAuthenticationStateProvider.Interfaces.cs
@@ -1,6 +1,6 @@
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorIdentity;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorIdentity;
 
 public partial class IdentityRevalidatingAuthenticationStateProvider : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/IdentityRevalidatingAuthenticationStateProvider.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/IdentityRevalidatingAuthenticationStateProvider.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorIdentity
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorIdentity
 {
     using System;
     

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/AccessDenied.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/AccessDenied.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorIdentity.Pages;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorIdentity.Pages;
 
 public partial class AccessDenied : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/AccessDenied.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/AccessDenied.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorIdentity.Pages
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorIdentity.Pages
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/ConfirmEmail.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/ConfirmEmail.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorIdentity.Pages;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorIdentity.Pages;
 
 public partial class ConfirmEmail : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/ConfirmEmail.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/ConfirmEmail.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorIdentity.Pages
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorIdentity.Pages
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/ConfirmEmailChange.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/ConfirmEmailChange.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorIdentity.Pages;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorIdentity.Pages;
 
 public partial class ConfirmEmailChange : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/ConfirmEmailChange.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/ConfirmEmailChange.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorIdentity.Pages
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorIdentity.Pages
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/ExternalLogin.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/ExternalLogin.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorIdentity.Pages;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorIdentity.Pages;
 
 public partial class ExternalLogin : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/ExternalLogin.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/ExternalLogin.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorIdentity.Pages
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorIdentity.Pages
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/ForgotPassword.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/ForgotPassword.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorIdentity.Pages;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorIdentity.Pages;
 
 public partial class ForgotPassword : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/ForgotPassword.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/ForgotPassword.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorIdentity.Pages
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorIdentity.Pages
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/ForgotPasswordConfirmation.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/ForgotPasswordConfirmation.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorIdentity.Pages;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorIdentity.Pages;
 
 public partial class ForgotPasswordConfirmation : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/ForgotPasswordConfirmation.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/ForgotPasswordConfirmation.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorIdentity.Pages
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorIdentity.Pages
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/InvalidPasswordReset.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/InvalidPasswordReset.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorIdentity.Pages;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorIdentity.Pages;
 
 public partial class InvalidPasswordReset : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/InvalidPasswordReset.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/InvalidPasswordReset.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorIdentity.Pages
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorIdentity.Pages
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/InvalidUser.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/InvalidUser.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorIdentity.Pages;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorIdentity.Pages;
 
 public partial class InvalidUser : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/InvalidUser.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/InvalidUser.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorIdentity.Pages
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorIdentity.Pages
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/Lockout.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/Lockout.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorIdentity.Pages;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorIdentity.Pages;
 
 public partial class Lockout : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/Lockout.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/Lockout.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorIdentity.Pages
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorIdentity.Pages
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/Login.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/Login.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorIdentity.Pages;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorIdentity.Pages;
 
 public partial class Login : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/Login.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/Login.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorIdentity.Pages
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorIdentity.Pages
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/LoginWith2fa.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/LoginWith2fa.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorIdentity.Pages;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorIdentity.Pages;
 
 public partial class LoginWith2fa : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/LoginWith2fa.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/LoginWith2fa.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorIdentity.Pages
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorIdentity.Pages
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/LoginWithRecoveryCode.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/LoginWithRecoveryCode.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorIdentity.Pages;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorIdentity.Pages;
 
 public partial class LoginWithRecoveryCode : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/LoginWithRecoveryCode.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/LoginWithRecoveryCode.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorIdentity.Pages
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorIdentity.Pages
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/Manage/ChangePassword.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/Manage/ChangePassword.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorIdentity.Pages.Manage;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorIdentity.Pages.Manage;
 
 public partial class ChangePassword : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/Manage/ChangePassword.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/Manage/ChangePassword.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorIdentity.Pages.Manage
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorIdentity.Pages.Manage
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/Manage/DeletePersonalData.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/Manage/DeletePersonalData.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorIdentity.Pages.Manage;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorIdentity.Pages.Manage;
 
 public partial class DeletePersonalData : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/Manage/DeletePersonalData.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/Manage/DeletePersonalData.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorIdentity.Pages.Manage
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorIdentity.Pages.Manage
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/Manage/Disable2fa.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/Manage/Disable2fa.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorIdentity.Pages.Manage;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorIdentity.Pages.Manage;
 
 public partial class Disable2fa : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/Manage/Disable2fa.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/Manage/Disable2fa.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorIdentity.Pages.Manage
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorIdentity.Pages.Manage
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/Manage/Email.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/Manage/Email.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorIdentity.Pages.Manage;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorIdentity.Pages.Manage;
 
 public partial class Email : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/Manage/Email.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/Manage/Email.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorIdentity.Pages.Manage
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorIdentity.Pages.Manage
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/Manage/EnableAuthenticator.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/Manage/EnableAuthenticator.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorIdentity.Pages.Manage;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorIdentity.Pages.Manage;
 
 public partial class EnableAuthenticator : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/Manage/EnableAuthenticator.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/Manage/EnableAuthenticator.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorIdentity.Pages.Manage
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorIdentity.Pages.Manage
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/Manage/ExternalLogins.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/Manage/ExternalLogins.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorIdentity.Pages.Manage;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorIdentity.Pages.Manage;
 
 public partial class ExternalLogins : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/Manage/ExternalLogins.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/Manage/ExternalLogins.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorIdentity.Pages.Manage
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorIdentity.Pages.Manage
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/Manage/GenerateRecoveryCodes.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/Manage/GenerateRecoveryCodes.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorIdentity.Pages.Manage;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorIdentity.Pages.Manage;
 
 public partial class GenerateRecoveryCodes : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/Manage/GenerateRecoveryCodes.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/Manage/GenerateRecoveryCodes.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorIdentity.Pages.Manage
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorIdentity.Pages.Manage
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/Manage/Index.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/Manage/Index.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorIdentity.Pages.Manage;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorIdentity.Pages.Manage;
 
 public partial class Index : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/Manage/Index.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/Manage/Index.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorIdentity.Pages.Manage
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorIdentity.Pages.Manage
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/Manage/Passkeys.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/Manage/Passkeys.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorIdentity.Pages.Manage;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorIdentity.Pages.Manage;
 
 public partial class Passkeys : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/Manage/Passkeys.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/Manage/Passkeys.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorIdentity.Pages.Manage
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorIdentity.Pages.Manage
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/Manage/PersonalData.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/Manage/PersonalData.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorIdentity.Pages.Manage;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorIdentity.Pages.Manage;
 
 public partial class PersonalData : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/Manage/PersonalData.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/Manage/PersonalData.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorIdentity.Pages.Manage
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorIdentity.Pages.Manage
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/Manage/RenamePasskey.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/Manage/RenamePasskey.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorIdentity.Pages.Manage;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorIdentity.Pages.Manage;
 
 public partial class RenamePasskey : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/Manage/RenamePasskey.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/Manage/RenamePasskey.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorIdentity.Pages.Manage
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorIdentity.Pages.Manage
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/Manage/ResetAuthenticator.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/Manage/ResetAuthenticator.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorIdentity.Pages.Manage;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorIdentity.Pages.Manage;
 
 public partial class ResetAuthenticator : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/Manage/ResetAuthenticator.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/Manage/ResetAuthenticator.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorIdentity.Pages.Manage
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorIdentity.Pages.Manage
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/Manage/SetPassword.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/Manage/SetPassword.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorIdentity.Pages.Manage;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorIdentity.Pages.Manage;
 
 public partial class SetPassword : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/Manage/SetPassword.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/Manage/SetPassword.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorIdentity.Pages.Manage
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorIdentity.Pages.Manage
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/Manage/TwoFactorAuthentication.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/Manage/TwoFactorAuthentication.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorIdentity.Pages.Manage;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorIdentity.Pages.Manage;
 
 public partial class TwoFactorAuthentication : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/Manage/TwoFactorAuthentication.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/Manage/TwoFactorAuthentication.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorIdentity.Pages.Manage
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorIdentity.Pages.Manage
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/Manage/_Imports.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/Manage/_Imports.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorIdentity.Pages.Manage;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorIdentity.Pages.Manage;
 
 public partial class _Imports : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/Manage/_Imports.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/Manage/_Imports.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorIdentity.Pages.Manage
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorIdentity.Pages.Manage
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/Register.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/Register.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorIdentity.Pages;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorIdentity.Pages;
 
 public partial class Register : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/Register.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/Register.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorIdentity.Pages
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorIdentity.Pages
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/RegisterConfirmation.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/RegisterConfirmation.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorIdentity.Pages;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorIdentity.Pages;
 
 public partial class RegisterConfirmation : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/RegisterConfirmation.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/RegisterConfirmation.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorIdentity.Pages
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorIdentity.Pages
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/ResendEmailConfirmation.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/ResendEmailConfirmation.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorIdentity.Pages;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorIdentity.Pages;
 
 public partial class ResendEmailConfirmation : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/ResendEmailConfirmation.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/ResendEmailConfirmation.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorIdentity.Pages
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorIdentity.Pages
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/ResetPassword.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/ResetPassword.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorIdentity.Pages;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorIdentity.Pages;
 
 public partial class ResetPassword : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/ResetPassword.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/ResetPassword.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorIdentity.Pages
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorIdentity.Pages
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/ResetPasswordConfirmation.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/ResetPasswordConfirmation.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorIdentity.Pages;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorIdentity.Pages;
 
 public partial class ResetPasswordConfirmation : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/ResetPasswordConfirmation.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/ResetPasswordConfirmation.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorIdentity.Pages
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorIdentity.Pages
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/_Imports.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/_Imports.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorIdentity.Pages;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorIdentity.Pages;
 
 public partial class _Imports : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/_Imports.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Pages/_Imports.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorIdentity.Pages
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorIdentity.Pages
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/PasskeyInputModel.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/PasskeyInputModel.Interfaces.cs
@@ -1,6 +1,6 @@
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorIdentity;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorIdentity;
 
 public partial class PasskeyInputModel : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/PasskeyInputModel.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/PasskeyInputModel.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorIdentity
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorIdentity
 {
     using System;
     

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/PasskeyOperation.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/PasskeyOperation.Interfaces.cs
@@ -1,6 +1,6 @@
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorIdentity;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorIdentity;
 
 public partial class PasskeyOperation : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/PasskeyOperation.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/PasskeyOperation.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorIdentity
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorIdentity
 {
     using System;
     

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Shared/ExternalLoginPicker.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Shared/ExternalLoginPicker.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorIdentity.Shared;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorIdentity.Shared;
 
 public partial class ExternalLoginPicker : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Shared/ExternalLoginPicker.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Shared/ExternalLoginPicker.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorIdentity.Shared
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorIdentity.Shared
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Shared/ManageLayout.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Shared/ManageLayout.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorIdentity.Shared;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorIdentity.Shared;
 
 public partial class ManageLayout : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Shared/ManageLayout.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Shared/ManageLayout.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorIdentity.Shared
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorIdentity.Shared
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Shared/ManageNavMenu.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Shared/ManageNavMenu.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorIdentity.Shared;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorIdentity.Shared;
 
 public partial class ManageNavMenu : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Shared/ManageNavMenu.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Shared/ManageNavMenu.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorIdentity.Shared
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorIdentity.Shared
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Shared/PasskeySubmit.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Shared/PasskeySubmit.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorIdentity.Shared;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorIdentity.Shared;
 
 public partial class PasskeySubmit : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Shared/PasskeySubmit.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Shared/PasskeySubmit.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorIdentity.Shared
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorIdentity.Shared
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Shared/RedirectToLogin.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Shared/RedirectToLogin.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorIdentity.Shared;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorIdentity.Shared;
 
 public partial class RedirectToLogin : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Shared/RedirectToLogin.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Shared/RedirectToLogin.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorIdentity.Shared
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorIdentity.Shared
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Shared/ShowRecoveryCodes.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Shared/ShowRecoveryCodes.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorIdentity.Shared;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorIdentity.Shared;
 
 public partial class ShowRecoveryCodes : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Shared/ShowRecoveryCodes.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Shared/ShowRecoveryCodes.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorIdentity.Shared
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorIdentity.Shared
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Shared/StatusMessage.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Shared/StatusMessage.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorIdentity.Shared;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorIdentity.Shared;
 
 public partial class StatusMessage : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Shared/StatusMessage.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorIdentity/Shared/StatusMessage.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorIdentity.Shared
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorIdentity.Shared
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/EfController/ApiEfController.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/EfController/ApiEfController.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.EfController;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.EfController;
 
 public partial class ApiEfController : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/EfController/ApiEfController.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/EfController/ApiEfController.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.EfController
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.EfController
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/EfController/MvcEfController.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/EfController/MvcEfController.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.EfController;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.EfController;
 
 public partial class MvcEfController : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/EfController/MvcEfController.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/EfController/MvcEfController.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.EfController
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.EfController
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Files/ApplicationUser.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Files/ApplicationUser.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Files;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Files;
 
 public partial class ApplicationUser : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Files/ApplicationUser.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Files/ApplicationUser.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Files
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Files
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/AccessDenied.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/AccessDenied.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account;
 
 public partial class AccessDenied : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/AccessDenied.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/AccessDenied.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/AccessDeniedModel.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/AccessDeniedModel.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account;
 
 public partial class AccessDeniedModel : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/AccessDeniedModel.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/AccessDeniedModel.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/ConfirmEmail.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/ConfirmEmail.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account;
 
 public partial class ConfirmEmail : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/ConfirmEmail.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/ConfirmEmail.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/ConfirmEmailChange.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/ConfirmEmailChange.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account;
 
 public partial class ConfirmEmailChange : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/ConfirmEmailChange.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/ConfirmEmailChange.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/ConfirmEmailChangeModel.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/ConfirmEmailChangeModel.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account;
 
 public partial class ConfirmEmailChangeModel : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/ConfirmEmailChangeModel.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/ConfirmEmailChangeModel.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/ConfirmEmailModel.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/ConfirmEmailModel.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account;
 
 public partial class ConfirmEmailModel : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/ConfirmEmailModel.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/ConfirmEmailModel.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/ExternalLogin.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/ExternalLogin.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account;
 
 public partial class ExternalLogin : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/ExternalLogin.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/ExternalLogin.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/ExternalLoginModel.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/ExternalLoginModel.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account;
 
 public partial class ExternalLoginModel : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/ExternalLoginModel.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/ExternalLoginModel.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/ForgotPassword.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/ForgotPassword.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account;
 
 public partial class ForgotPassword : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/ForgotPassword.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/ForgotPassword.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/ForgotPasswordConfirmation.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/ForgotPasswordConfirmation.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account;
 
 public partial class ForgotPasswordConfirmation : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/ForgotPasswordConfirmation.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/ForgotPasswordConfirmation.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/ForgotPasswordConfirmationModel.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/ForgotPasswordConfirmationModel.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account;
 
 public partial class ForgotPasswordConfirmationModel : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/ForgotPasswordConfirmationModel.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/ForgotPasswordConfirmationModel.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/ForgotPasswordModel.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/ForgotPasswordModel.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account;
 
 public partial class ForgotPasswordModel : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/ForgotPasswordModel.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/ForgotPasswordModel.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Lockout.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Lockout.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account;
 
 public partial class Lockout : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Lockout.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Lockout.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/LockoutModel.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/LockoutModel.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account;
 
 public partial class LockoutModel : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/LockoutModel.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/LockoutModel.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Login.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Login.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account;
 
 public partial class Login : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Login.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Login.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/LoginModel.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/LoginModel.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account;
 
 public partial class LoginModel : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/LoginModel.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/LoginModel.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/LoginWith2fa.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/LoginWith2fa.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account;
 
 public partial class LoginWith2fa : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/LoginWith2fa.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/LoginWith2fa.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/LoginWith2faModel.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/LoginWith2faModel.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account;
 
 public partial class LoginWith2faModel : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/LoginWith2faModel.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/LoginWith2faModel.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/LoginWithRecoveryCode.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/LoginWithRecoveryCode.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account;
 
 public partial class LoginWithRecoveryCode : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/LoginWithRecoveryCode.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/LoginWithRecoveryCode.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/LoginWithRecoveryCodeModel.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/LoginWithRecoveryCodeModel.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account;
 
 public partial class LoginWithRecoveryCodeModel : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/LoginWithRecoveryCodeModel.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/LoginWithRecoveryCodeModel.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Logout.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Logout.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account;
 
 public partial class Logout : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Logout.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Logout.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/LogoutModel.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/LogoutModel.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account;
 
 public partial class LogoutModel : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/LogoutModel.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/LogoutModel.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/ChangePassword.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/ChangePassword.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account.Manage;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account.Manage;
 
 public partial class ChangePassword : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/ChangePassword.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/ChangePassword.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account.Manage
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account.Manage
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/ChangePasswordModel.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/ChangePasswordModel.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account.Manage;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account.Manage;
 
 public partial class ChangePasswordModel : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/ChangePasswordModel.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/ChangePasswordModel.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account.Manage
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account.Manage
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/DeletePersonalData.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/DeletePersonalData.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account.Manage;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account.Manage;
 
 public partial class DeletePersonalData : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/DeletePersonalData.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/DeletePersonalData.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account.Manage
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account.Manage
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/DeletePersonalDataModel.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/DeletePersonalDataModel.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account.Manage;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account.Manage;
 
 public partial class DeletePersonalDataModel : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/DeletePersonalDataModel.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/DeletePersonalDataModel.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account.Manage
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account.Manage
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/Disable2fa.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/Disable2fa.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account.Manage;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account.Manage;
 
 public partial class Disable2fa : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/Disable2fa.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/Disable2fa.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account.Manage
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account.Manage
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/Disable2faModel.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/Disable2faModel.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account.Manage;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account.Manage;
 
 public partial class Disable2faModel : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/Disable2faModel.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/Disable2faModel.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account.Manage
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account.Manage
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/DownloadPersonalData.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/DownloadPersonalData.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account.Manage;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account.Manage;
 
 public partial class DownloadPersonalData : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/DownloadPersonalData.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/DownloadPersonalData.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account.Manage
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account.Manage
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/DownloadPersonalDataModel.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/DownloadPersonalDataModel.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account.Manage;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account.Manage;
 
 public partial class DownloadPersonalDataModel : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/DownloadPersonalDataModel.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/DownloadPersonalDataModel.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account.Manage
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account.Manage
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/Email.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/Email.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account.Manage;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account.Manage;
 
 public partial class Email : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/Email.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/Email.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account.Manage
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account.Manage
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/EmailModel.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/EmailModel.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account.Manage;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account.Manage;
 
 public partial class EmailModel : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/EmailModel.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/EmailModel.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account.Manage
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account.Manage
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/EnableAuthenticator.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/EnableAuthenticator.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account.Manage;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account.Manage;
 
 public partial class EnableAuthenticator : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/EnableAuthenticator.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/EnableAuthenticator.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account.Manage
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account.Manage
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/EnableAuthenticatorModel.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/EnableAuthenticatorModel.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account.Manage;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account.Manage;
 
 public partial class EnableAuthenticatorModel : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/EnableAuthenticatorModel.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/EnableAuthenticatorModel.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account.Manage
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account.Manage
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/ExternalLogins.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/ExternalLogins.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account.Manage;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account.Manage;
 
 public partial class ExternalLogins : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/ExternalLogins.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/ExternalLogins.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account.Manage
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account.Manage
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/ExternalLoginsModel.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/ExternalLoginsModel.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account.Manage;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account.Manage;
 
 public partial class ExternalLoginsModel : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/ExternalLoginsModel.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/ExternalLoginsModel.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account.Manage
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account.Manage
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/GenerateRecoveryCodes.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/GenerateRecoveryCodes.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account.Manage;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account.Manage;
 
 public partial class GenerateRecoveryCodes : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/GenerateRecoveryCodes.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/GenerateRecoveryCodes.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account.Manage
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account.Manage
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/GenerateRecoveryCodesModel.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/GenerateRecoveryCodesModel.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account.Manage;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account.Manage;
 
 public partial class GenerateRecoveryCodesModel : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/GenerateRecoveryCodesModel.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/GenerateRecoveryCodesModel.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account.Manage
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account.Manage
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/Index.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/Index.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account.Manage;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account.Manage;
 
 public partial class Index : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/Index.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/Index.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account.Manage
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account.Manage
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/IndexModel.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/IndexModel.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account.Manage;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account.Manage;
 
 public partial class IndexModel : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/IndexModel.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/IndexModel.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account.Manage
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account.Manage
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/ManageNavPagesModel.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/ManageNavPagesModel.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account.Manage;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account.Manage;
 
 public partial class ManageNavPagesModel : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/ManageNavPagesModel.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/ManageNavPagesModel.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account.Manage
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account.Manage
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/PersonalData.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/PersonalData.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account.Manage;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account.Manage;
 
 public partial class PersonalData : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/PersonalData.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/PersonalData.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account.Manage
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account.Manage
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/PersonalDataModel.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/PersonalDataModel.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account.Manage;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account.Manage;
 
 public partial class PersonalDataModel : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/PersonalDataModel.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/PersonalDataModel.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account.Manage
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account.Manage
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/ResetAuthenticator.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/ResetAuthenticator.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account.Manage;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account.Manage;
 
 public partial class ResetAuthenticator : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/ResetAuthenticator.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/ResetAuthenticator.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account.Manage
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account.Manage
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/ResetAuthenticatorModel.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/ResetAuthenticatorModel.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account.Manage;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account.Manage;
 
 public partial class ResetAuthenticatorModel : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/ResetAuthenticatorModel.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/ResetAuthenticatorModel.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account.Manage
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account.Manage
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/SetPassword.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/SetPassword.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account.Manage;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account.Manage;
 
 public partial class SetPassword : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/SetPassword.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/SetPassword.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account.Manage
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account.Manage
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/SetPasswordModel.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/SetPasswordModel.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account.Manage;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account.Manage;
 
 public partial class SetPasswordModel : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/SetPasswordModel.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/SetPasswordModel.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account.Manage
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account.Manage
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/ShowRecoveryCodes.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/ShowRecoveryCodes.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account.Manage;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account.Manage;
 
 public partial class ShowRecoveryCodes : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/ShowRecoveryCodes.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/ShowRecoveryCodes.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account.Manage
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account.Manage
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/ShowRecoveryCodesModel.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/ShowRecoveryCodesModel.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account.Manage;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account.Manage;
 
 public partial class ShowRecoveryCodesModel : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/ShowRecoveryCodesModel.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/ShowRecoveryCodesModel.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account.Manage
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account.Manage
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/TwoFactorAuthentication.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/TwoFactorAuthentication.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account.Manage;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account.Manage;
 
 public partial class TwoFactorAuthentication : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/TwoFactorAuthentication.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/TwoFactorAuthentication.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account.Manage
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account.Manage
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/TwoFactorAuthenticationModel.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/TwoFactorAuthenticationModel.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account.Manage;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account.Manage;
 
 public partial class TwoFactorAuthenticationModel : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/TwoFactorAuthenticationModel.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/TwoFactorAuthenticationModel.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account.Manage
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account.Manage
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/_Layout.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/_Layout.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account.Manage;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account.Manage;
 
 public partial class _Layout : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/_Layout.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/_Layout.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account.Manage
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account.Manage
 {
     using System;
     

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/_ManageNav.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/_ManageNav.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account.Manage;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account.Manage;
 
 public partial class _ManageNav : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/_ManageNav.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/_ManageNav.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account.Manage
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account.Manage
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/_StatusMessage.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/_StatusMessage.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account.Manage;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account.Manage;
 
 public partial class _StatusMessage : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/_StatusMessage.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/_StatusMessage.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account.Manage
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account.Manage
 {
     using System;
     

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/_ViewImports.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/_ViewImports.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account.Manage;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account.Manage;
 
 public partial class _ViewImports : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/_ViewImports.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Manage/_ViewImports.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account.Manage
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account.Manage
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Register.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Register.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account;
 
 public partial class Register : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Register.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/Register.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/RegisterConfirmation.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/RegisterConfirmation.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account;
 
 public partial class RegisterConfirmation : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/RegisterConfirmation.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/RegisterConfirmation.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/RegisterConfirmationModel.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/RegisterConfirmationModel.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account;
 
 public partial class RegisterConfirmationModel : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/RegisterConfirmationModel.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/RegisterConfirmationModel.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/RegisterModel.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/RegisterModel.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account;
 
 public partial class RegisterModel : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/RegisterModel.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/RegisterModel.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/ResendEmailConfirmation.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/ResendEmailConfirmation.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account;
 
 public partial class ResendEmailConfirmation : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/ResendEmailConfirmation.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/ResendEmailConfirmation.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/ResendEmailConfirmationModel.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/ResendEmailConfirmationModel.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account;
 
 public partial class ResendEmailConfirmationModel : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/ResendEmailConfirmationModel.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/ResendEmailConfirmationModel.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/ResetPassword.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/ResetPassword.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account;
 
 public partial class ResetPassword : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/ResetPassword.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/ResetPassword.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/ResetPasswordConfirmation.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/ResetPasswordConfirmation.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account;
 
 public partial class ResetPasswordConfirmation : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/ResetPasswordConfirmation.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/ResetPasswordConfirmation.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/ResetPasswordConfirmationModel.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/ResetPasswordConfirmationModel.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account;
 
 public partial class ResetPasswordConfirmationModel : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/ResetPasswordConfirmationModel.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/ResetPasswordConfirmationModel.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/ResetPasswordModel.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/ResetPasswordModel.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account;
 
 public partial class ResetPasswordModel : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/ResetPasswordModel.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/ResetPasswordModel.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/_StatusMessage.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/_StatusMessage.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account;
 
 public partial class _StatusMessage : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/_StatusMessage.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/_StatusMessage.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/_ViewImports.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/_ViewImports.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account;
 
 public partial class _ViewImports : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/_ViewImports.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Account/_ViewImports.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages.Account
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages.Account
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Error.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Error.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages;
 
 public partial class _ViewImports : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Error.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/Error.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/ErrorModel.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/ErrorModel.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages;
 
 public partial class ErrorModel : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/ErrorModel.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/ErrorModel.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/_ViewImports.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/_ViewImports.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages;
 
 public partial class Error : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/_ViewImports.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/_ViewImports.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/_ViewStart.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/_ViewStart.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages;
 
 public partial class _ViewStart : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/_ViewStart.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Identity/Pages/_ViewStart.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Identity.Pages
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Identity.Pages
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/MinimalApi/MinimalApi.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/MinimalApi/MinimalApi.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.MinimalApi;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.MinimalApi;
 
 public partial class MinimalApi : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/MinimalApi/MinimalApi.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/MinimalApi/MinimalApi.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.MinimalApi
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.MinimalApi
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/MinimalApi/MinimalApiEf.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/MinimalApi/MinimalApiEf.Interfaces.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.MinimalApi;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.MinimalApi;
 
 public partial class MinimalApiEf : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/MinimalApi/MinimalApiEf.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/MinimalApi/MinimalApiEf.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.MinimalApi
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.MinimalApi
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/RazorPages/Create.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/RazorPages/Create.Interfaces.cs
@@ -1,6 +1,6 @@
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.RazorPages;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.RazorPages;
 
 public partial class Create : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/RazorPages/Create.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/RazorPages/Create.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.RazorPages
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.RazorPages
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/RazorPages/CreateModel.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/RazorPages/CreateModel.Interfaces.cs
@@ -1,6 +1,6 @@
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.RazorPages;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.RazorPages;
 
 public partial class CreateModel : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/RazorPages/CreateModel.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/RazorPages/CreateModel.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.RazorPages
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.RazorPages
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/RazorPages/Delete.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/RazorPages/Delete.Interfaces.cs
@@ -1,6 +1,6 @@
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.RazorPages;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.RazorPages;
 
 public partial class Delete : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/RazorPages/Delete.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/RazorPages/Delete.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.RazorPages
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.RazorPages
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/RazorPages/DeleteModel.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/RazorPages/DeleteModel.Interfaces.cs
@@ -1,6 +1,6 @@
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.RazorPages;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.RazorPages;
 
 public partial class DeleteModel : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/RazorPages/DeleteModel.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/RazorPages/DeleteModel.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.RazorPages
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.RazorPages
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/RazorPages/Details.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/RazorPages/Details.Interfaces.cs
@@ -1,6 +1,6 @@
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.RazorPages;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.RazorPages;
 
 public partial class Details : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/RazorPages/Details.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/RazorPages/Details.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.RazorPages
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.RazorPages
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/RazorPages/DetailsModel.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/RazorPages/DetailsModel.Interfaces.cs
@@ -1,6 +1,6 @@
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.RazorPages;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.RazorPages;
 
 public partial class DetailsModel : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/RazorPages/DetailsModel.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/RazorPages/DetailsModel.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.RazorPages
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.RazorPages
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/RazorPages/Edit.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/RazorPages/Edit.Interfaces.cs
@@ -1,6 +1,6 @@
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.RazorPages;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.RazorPages;
 
 public partial class Edit : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/RazorPages/Edit.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/RazorPages/Edit.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.RazorPages
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.RazorPages
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/RazorPages/EditModel.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/RazorPages/EditModel.Interfaces.cs
@@ -1,6 +1,6 @@
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.RazorPages;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.RazorPages;
 
 public partial class EditModel : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/RazorPages/EditModel.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/RazorPages/EditModel.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.RazorPages
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.RazorPages
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/RazorPages/Index.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/RazorPages/Index.Interfaces.cs
@@ -1,6 +1,6 @@
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.RazorPages;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.RazorPages;
 
 public partial class Index : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/RazorPages/Index.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/RazorPages/Index.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.RazorPages
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.RazorPages
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/RazorPages/IndexModel.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/RazorPages/IndexModel.Interfaces.cs
@@ -1,6 +1,6 @@
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.RazorPages;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.RazorPages;
 
 public partial class IndexModel : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/RazorPages/IndexModel.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/RazorPages/IndexModel.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.RazorPages
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.RazorPages
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Views/Create.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Views/Create.Interfaces.cs
@@ -1,6 +1,6 @@
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Views;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Views;
 
 public partial class Create : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Views/Create.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Views/Create.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Views
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Views
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Views/Delete.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Views/Delete.Interfaces.cs
@@ -1,6 +1,6 @@
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Views;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Views;
 
 public partial class Delete : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Views/Delete.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Views/Delete.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Views
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Views
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Views/Details.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Views/Details.Interfaces.cs
@@ -1,6 +1,6 @@
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Views;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Views;
 
 public partial class Details : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Views/Details.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Views/Details.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Views
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Views
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Views/Edit.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Views/Edit.Interfaces.cs
@@ -1,6 +1,6 @@
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Views;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Views;
 
 public partial class Edit : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Views/Edit.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Views/Edit.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Views
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Views
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Views/Index.Interfaces.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Views/Index.Interfaces.cs
@@ -1,6 +1,6 @@
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Views;
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Views;
 
 public partial class Index : ITextTransformation
 {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Views/Index.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/Views/Index.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.Views
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.Views
 {
     using System.Collections.Generic;
     using System.Text;

--- a/src/dotnet-scaffolding/dotnet-scaffold/dotnet-scaffold.csproj
+++ b/src/dotnet-scaffolding/dotnet-scaffold/dotnet-scaffold.csproj
@@ -24,11 +24,7 @@
     <None Include="AspNet\Templates\net9.0\**\*.cs" />
   </ItemGroup>
 
-  <ItemGroup>
-    <!-- Exclude net10.0 folder .cs files from compilation to avoid duplicate definitions -->
-    <Compile Remove="AspNet\Templates\net10.0\**\*.cs" />
-    <None Include="AspNet\Templates\net10.0\**\*.cs" />
-  </ItemGroup>
+  <!-- net10.0 and net11.0 templates are compiled (they have distinct net10/net11 namespaces) -->
 
   <ItemGroup>
     <PackageReference Include="Spectre.Console.Flow" />
@@ -131,13 +127,13 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Link>AspNet\Templates\net9.0\%(RecursiveDir)%(Filename)%(Extension)</Link>
     </None>
-    <!-- Include net10.0 templates in build output -->
-    <None Include="AspNet\Templates\net10.0\**\*.*">
+    <!-- Include net10.0 templates in build output (exclude .cs since they are compiled) -->
+    <None Include="AspNet\Templates\net10.0\**\*.*" Exclude="AspNet\Templates\net10.0\**\*.cs">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Link>AspNet\Templates\net10.0\%(RecursiveDir)%(Filename)%(Extension)</Link>
     </None>
-    <!-- Include net11.0 templates in build output -->
-    <None Include="AspNet\Templates\net11.0\**\*.*">
+    <!-- Include net11.0 templates in build output (exclude .cs since they are compiled) -->
+    <None Include="AspNet\Templates\net11.0\**\*.*" Exclude="AspNet\Templates\net11.0\**\*.cs">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Link>AspNet\Templates\net11.0\%(RecursiveDir)%(Filename)%(Extension)</Link>
     </None>


### PR DESCRIPTION
The namespaces should not have net 10 in them. Fixes #3666 