### PR TITLE
Allow minimal api net 9 to build

### DIFF
--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net9.0/MinimalApi/MinimalApi.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net9.0/MinimalApi/MinimalApi.cs
@@ -25,7 +25,13 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net9.MinimalApi
         /// </summary>
         public virtual string TransformText()
         {
-            this.Write("public static class ");
+            if (!string.IsNullOrEmpty(Model.ModelInfo.ModelNamespace))
+            {
+                        this.Write("using ");
+                        this.Write(this.ToStringHelper.ToStringWithCulture(Model.ModelInfo.ModelNamespace));
+                        this.Write(";\r\n");
+            }
+            this.Write("\r\npublic static class ");
             this.Write(this.ToStringHelper.ToStringWithCulture(Model.EndpointsClassName));
             this.Write("\r\n{\r\n    public static void ");
             this.Write(this.ToStringHelper.ToStringWithCulture(Model.EndpointsMethodName));

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net9.0/MinimalApi/MinimalApi.tt
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net9.0/MinimalApi/MinimalApi.tt
@@ -3,6 +3,12 @@
 <#@  import namespace="System.Collections.Generic" #>
 <#@  import namespace="System.Text" #>
 <#@  import namespace="System.Linq" #>
+<# if (!string.IsNullOrEmpty(Model.ModelInfo.ModelNamespace))
+{#>
+using <#= Model.ModelInfo.ModelNamespace #>;
+<#
+}#>
+
 public static class <#= Model.EndpointsClassName #>
 {
     public static void <#= Model.EndpointsMethodName #>(this IEndpointRouteBuilder routes)

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net9.0/MinimalApi/MinimalApiEf.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net9.0/MinimalApi/MinimalApiEf.cs
@@ -55,7 +55,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net9.MinimalApi
     string typedTaskWithNotFound = Model.UseTypedResults ? $"Task<Results<Ok<{modelName}>, NotFound>>" : "";
     string typedTaskOkNotFound = Model.UseTypedResults ? $"Task<Results<Ok, NotFound>>" : "";
     string typedTaskWithNoContent = Model.UseTypedResults ? $"Task<Results<NotFound, NoContent>>" : "";
-    string resultsNotFound = $"{resultsExtension}.NavigateTo(\"notfound\");";
+    string resultsNotFound = $"{resultsExtension}.NotFound()";
     string resultsOkModel = $"{resultsExtension}.Ok(model)";
     string resultsOkEmpty = $"{resultsExtension}.Ok()";
     string resultsNoContent = $"{resultsExtension}.NoContent()";


### PR DESCRIPTION
fixes #3578 

build was failing for two reasons: 
1) the namespace of the model was not added to generated code after the minimal api scaffolding
2) replace `TypeResults.NavigateTo("notfound")` with `TypedResults.NotFound()` in the generated code after the minimal api scaffolding

