### PR TITLE
bump NuGet package version to 20.0.0 prerelease

### DIFF
--- a/eng/Versions.DotNetScaffold.props
+++ b/eng/Versions.DotNetScaffold.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <VersionPrefix>11.0.0</VersionPrefix>
+    <VersionPrefix>20.0.0</VersionPrefix>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
     <PreReleaseVersionIteration>1</PreReleaseVersionIteration>
     <IncludeSourceRevisionInInformationalVersion>False</IncludeSourceRevisionInInformationalVersion>

--- a/scripts/install-scaffold.cmd
+++ b/scripts/install-scaffold.cmd
@@ -1,4 +1,4 @@
-set VERSION=11.0.0-dev
+set VERSION=20.0.0-dev
 set DEFAULT_NUPKG_PATH=%userprofile%/.nuget/packages
 set SRC_DIR=%cd%
 set NUPKG=artifacts/packages/Debug/Shipping/

--- a/scripts/install-scaffold.sh
+++ b/scripts/install-scaffold.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-VERSION=11.0.0-dev
+VERSION=20.0.0-dev
 DEFAULT_NUPKG_PATH=~/.nuget/packages
 SRC_DIR=$(pwd)
 echo $SRC_DIR

--- a/src/dotnet-scaffolding/dotnet-scaffold/Interactive/AppBuilder/ScaffoldCommandAppBuilder.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/Interactive/AppBuilder/ScaffoldCommandAppBuilder.cs
@@ -18,7 +18,7 @@ internal class ScaffoldCommandAppBuilder(IScaffoldRunner runnner, string[] args)
     // Command-line arguments passed to the application.
     private readonly string[] _args = args;
     // Backup version string for dotnet-scaffold, updated every release.
-    private readonly string _backupDotNetScaffoldVersion = "10.0.0";
+    private readonly string _backupDotNetScaffoldVersion = "20.0.0";
 
     private readonly IScaffoldRunner _scaffoldRunner = runnner;
 


### PR DESCRIPTION
the package version for `Microsoft.dotnet-scaffold` is no longer SDK dependent, so update the prerelease version name to `20.0.0-prerelease`. This new version of scaffolding supports net 8, net 9, net 10, and net 11 scaffolding. 

