### PR TITLE
Allow for writing other pages not just CRUD for blazor-crud, views, razorpages-crud commands

### DIFF
--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Helpers/BlazorCrudHelper.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Helpers/BlazorCrudHelper.cs
@@ -409,7 +409,7 @@ internal static class BlazorCrudHelper
             {
                 if (!IsValidTemplate(blazorCrudModel.PageType, templateName))
                 {
-                    break;
+                    continue;
                 }
 
                 if (blazorCrudModel.ProjectInfo is null || string.IsNullOrEmpty(blazorCrudModel.ProjectInfo.ProjectPath))

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Helpers/RazorPagesHelper.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Helpers/RazorPagesHelper.cs
@@ -141,7 +141,7 @@ internal static class RazorPagesHelper
             {
                 if (!IsValidTemplate(razorPagesModel.PageType, templateName))
                 {
-                    break;
+                    continue;
                 }
 
                 string baseOutputPath = GetBaseOutputPath(

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Helpers/ViewHelper.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Helpers/ViewHelper.cs
@@ -54,7 +54,7 @@ internal class ViewHelper
                 {
                     if (!IsValidTemplate(viewModel.PageType, templateName))
                     {
-                        break;
+                        continue;
                     }
 
                     string baseOutputPath = GetBaseOutputPath(viewModel.ModelInfo.ModelTypeName, viewModel.ProjectInfo.ProjectPath);


### PR DESCRIPTION
Fixes #3664 
There was a bug in the code where the file creation would only be successful when the `--page` specified was CRUD , this change ensures that all the file creation is successful for all the available pages options. 

