### PR TITLE
Fix System.ArgumentNullException

### DIFF
--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Common/ClassAnalyzers.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Common/ClassAnalyzers.cs
@@ -38,7 +38,7 @@ internal static class ClassAnalyzers
             dbContextInfo.DbContextClassPath = existingDbContextClass.Locations.FirstOrDefault()?.SourceTree?.FilePath;
             dbContextInfo.DbContextNamespace = existingDbContextClass.ContainingNamespace.ToDisplayString();
             dbContextInfo.EntitySetVariableName = modelInfo is null ?
-                string.Empty : EfDbContextHelpers.GetEntitySetVariableName(existingDbContextClass, modelInfo.ModelTypeName, modelInfo.ModelFullName);
+                string.Empty : EfDbContextHelpers.GetEntitySetVariableName(existingDbContextClass, modelInfo.ModelTypeName, modelInfo.ModelFullName) ?? modelInfo.ModelTypeName;
         }
         //properties for creating a new DbContext
         else

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net10.0/BlazorCrud/Create.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net10.0/BlazorCrud/Create.cs
@@ -114,7 +114,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorCrud
             this.Write(this.ToStringHelper.ToStringWithCulture(modelName));
             this.Write("()\r\n    {\r\n        using var context = DbFactory.CreateDbContext();\r\n        cont" +
                     "ext.");
-            this.Write(this.ToStringHelper.ToStringWithCulture(Model.DbContextInfo.EntitySetVariableName));
+            this.Write(this.ToStringHelper.ToStringWithCulture(Model.DbContextInfo.EntitySetVariableName ?? modelName));
             this.Write(".Add(");
             this.Write(this.ToStringHelper.ToStringWithCulture(modelName));
             this.Write(");\r\n        await context.SaveChangesAsync();\r\n        NavigationManager.Navigate" +

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net10.0/BlazorCrud/Create.tt
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net10.0/BlazorCrud/Create.tt
@@ -75,7 +75,7 @@
     private async Task Add<#= modelName #>()
     {
         using var context = DbFactory.CreateDbContext();
-        context.<#= Model.DbContextInfo.EntitySetVariableName #>.Add(<#= modelName #>);
+        context.<#= Model.DbContextInfo.EntitySetVariableName ?? modelName #>.Add(<#= modelName #>);
         await context.SaveChangesAsync();
         NavigationManager.NavigateTo("/<#= pluralModelLowerInv #>");
     }

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net10.0/BlazorCrud/Delete.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net10.0/BlazorCrud/Delete.cs
@@ -39,7 +39,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorCrud
     string primaryKeyName = Model.ModelInfo.PrimaryKeyName;
     string primaryKeyNameLowerInv = primaryKeyName.ToLowerInvariant();
     string primaryKeyShortTypeName = Model.ModelInfo.PrimaryKeyTypeName;
-    string entitySetName = Model.DbContextInfo.EntitySetVariableName;
+    string entitySetName = Model.DbContextInfo.EntitySetVariableName ?? modelName;
 
             this.Write("@page \"/");
             this.Write(this.ToStringHelper.ToStringWithCulture(pluralModelLowerInv));

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net10.0/BlazorCrud/Delete.tt
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net10.0/BlazorCrud/Delete.tt
@@ -17,7 +17,7 @@
     string primaryKeyName = Model.ModelInfo.PrimaryKeyName;
     string primaryKeyNameLowerInv = primaryKeyName.ToLowerInvariant();
     string primaryKeyShortTypeName = Model.ModelInfo.PrimaryKeyTypeName;
-    string entitySetName = Model.DbContextInfo.EntitySetVariableName;
+    string entitySetName = Model.DbContextInfo.EntitySetVariableName ?? modelName;
 #>
 @page "/<#= pluralModelLowerInv #>/delete"
 @using Microsoft.EntityFrameworkCore

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net10.0/BlazorCrud/Details.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net10.0/BlazorCrud/Details.cs
@@ -39,7 +39,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorCrud
     string primaryKeyName = Model.ModelInfo.PrimaryKeyName;
     string primaryKeyNameLowerInv = primaryKeyName.ToLowerInvariant();
     string primaryKeyShortTypeName = Model.ModelInfo.PrimaryKeyTypeName;
-    string entitySetName = Model.DbContextInfo.EntitySetVariableName;
+    string entitySetName = Model.DbContextInfo.EntitySetVariableName ?? modelName;
 
             this.Write("@page \"/");
             this.Write(this.ToStringHelper.ToStringWithCulture(pluralModelLowerInv));

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net10.0/BlazorCrud/Details.tt
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net10.0/BlazorCrud/Details.tt
@@ -17,7 +17,7 @@
     string primaryKeyName = Model.ModelInfo.PrimaryKeyName;
     string primaryKeyNameLowerInv = primaryKeyName.ToLowerInvariant();
     string primaryKeyShortTypeName = Model.ModelInfo.PrimaryKeyTypeName;
-    string entitySetName = Model.DbContextInfo.EntitySetVariableName;
+    string entitySetName = Model.DbContextInfo.EntitySetVariableName ?? modelName;
 #>
 @page "/<#= pluralModelLowerInv #>/details"
 @using Microsoft.EntityFrameworkCore

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net10.0/BlazorCrud/Edit.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net10.0/BlazorCrud/Edit.cs
@@ -40,7 +40,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorCrud
     string primaryKeyName = Model.ModelInfo.PrimaryKeyName;
     string primaryKeyNameLowerInv = primaryKeyName.ToLowerInvariant();
     string primaryKeyShortTypeName = Model.ModelInfo.PrimaryKeyTypeName;
-    string entitySetName = Model.DbContextInfo.EntitySetVariableName;
+    string entitySetName = Model.DbContextInfo.EntitySetVariableName ?? modelName;
 
             this.Write("@page \"/");
             this.Write(this.ToStringHelper.ToStringWithCulture(pluralModelLowerInv));

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net10.0/BlazorCrud/Edit.tt
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net10.0/BlazorCrud/Edit.tt
@@ -18,7 +18,7 @@
     string primaryKeyName = Model.ModelInfo.PrimaryKeyName;
     string primaryKeyNameLowerInv = primaryKeyName.ToLowerInvariant();
     string primaryKeyShortTypeName = Model.ModelInfo.PrimaryKeyTypeName;
-    string entitySetName = Model.DbContextInfo.EntitySetVariableName;
+    string entitySetName = Model.DbContextInfo.EntitySetVariableName ?? modelName;
 #>
 @page "/<#= pluralModelLowerInv #>/edit"
 @using Microsoft.EntityFrameworkCore

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net10.0/BlazorCrud/Index.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net10.0/BlazorCrud/Index.cs
@@ -39,7 +39,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.BlazorCrud
     string primaryKeyName = Model.ModelInfo.PrimaryKeyName;
     string primaryKeyNameLowerInv = primaryKeyName.ToLowerInvariant();
     string primaryKeyShortTypeName = Model.ModelInfo.PrimaryKeyTypeName;
-    string entitySetName = Model.DbContextInfo.EntitySetVariableName;
+    string entitySetName = Model.DbContextInfo.EntitySetVariableName ?? modelName;
 
             this.Write("@page \"/");
             this.Write(this.ToStringHelper.ToStringWithCulture(pluralModelLowerInv));

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net10.0/BlazorCrud/Index.tt
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net10.0/BlazorCrud/Index.tt
@@ -17,7 +17,7 @@
     string primaryKeyName = Model.ModelInfo.PrimaryKeyName;
     string primaryKeyNameLowerInv = primaryKeyName.ToLowerInvariant();
     string primaryKeyShortTypeName = Model.ModelInfo.PrimaryKeyTypeName;
-    string entitySetName = Model.DbContextInfo.EntitySetVariableName;
+    string entitySetName = Model.DbContextInfo.EntitySetVariableName ?? modelName;
 #>
 @page "/<#= pluralModelLowerInv #>"
 @using Microsoft.AspNetCore.Components.QuickGrid

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorCrud/Create.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorCrud/Create.cs
@@ -114,7 +114,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorCrud
             this.Write(this.ToStringHelper.ToStringWithCulture(modelName));
             this.Write("()\r\n    {\r\n        using var context = DbFactory.CreateDbContext();\r\n        cont" +
                     "ext.");
-            this.Write(this.ToStringHelper.ToStringWithCulture(Model.DbContextInfo.EntitySetVariableName));
+            this.Write(this.ToStringHelper.ToStringWithCulture(Model.DbContextInfo.EntitySetVariableName ?? modelName));
             this.Write(".Add(");
             this.Write(this.ToStringHelper.ToStringWithCulture(modelName));
             this.Write(");\r\n        await context.SaveChangesAsync();\r\n        NavigationManager.Navigate" +

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorCrud/Create.tt
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorCrud/Create.tt
@@ -75,7 +75,7 @@
     private async Task Add<#= modelName #>()
     {
         using var context = DbFactory.CreateDbContext();
-        context.<#= Model.DbContextInfo.EntitySetVariableName #>.Add(<#= modelName #>);
+        context.<#= Model.DbContextInfo.EntitySetVariableName ?? modelName #>.Add(<#= modelName #>);
         await context.SaveChangesAsync();
         NavigationManager.NavigateTo("/<#= pluralModelLowerInv #>");
     }

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorCrud/Delete.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorCrud/Delete.cs
@@ -39,7 +39,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorCrud
     string primaryKeyName = Model.ModelInfo.PrimaryKeyName;
     string primaryKeyNameLowerInv = primaryKeyName.ToLowerInvariant();
     string primaryKeyShortTypeName = Model.ModelInfo.PrimaryKeyTypeName;
-    string entitySetName = Model.DbContextInfo.EntitySetVariableName;
+    string entitySetName = Model.DbContextInfo.EntitySetVariableName ?? modelName;
 
             this.Write("@page \"/");
             this.Write(this.ToStringHelper.ToStringWithCulture(pluralModelLowerInv));

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorCrud/Delete.tt
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorCrud/Delete.tt
@@ -17,7 +17,7 @@
     string primaryKeyName = Model.ModelInfo.PrimaryKeyName;
     string primaryKeyNameLowerInv = primaryKeyName.ToLowerInvariant();
     string primaryKeyShortTypeName = Model.ModelInfo.PrimaryKeyTypeName;
-    string entitySetName = Model.DbContextInfo.EntitySetVariableName;
+    string entitySetName = Model.DbContextInfo.EntitySetVariableName ?? modelName;
 #>
 @page "/<#= pluralModelLowerInv #>/delete"
 @using Microsoft.EntityFrameworkCore

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorCrud/Details.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorCrud/Details.cs
@@ -39,7 +39,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorCrud
     string primaryKeyName = Model.ModelInfo.PrimaryKeyName;
     string primaryKeyNameLowerInv = primaryKeyName.ToLowerInvariant();
     string primaryKeyShortTypeName = Model.ModelInfo.PrimaryKeyTypeName;
-    string entitySetName = Model.DbContextInfo.EntitySetVariableName;
+    string entitySetName = Model.DbContextInfo.EntitySetVariableName ?? modelName;
 
             this.Write("@page \"/");
             this.Write(this.ToStringHelper.ToStringWithCulture(pluralModelLowerInv));

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorCrud/Details.tt
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorCrud/Details.tt
@@ -17,7 +17,7 @@
     string primaryKeyName = Model.ModelInfo.PrimaryKeyName;
     string primaryKeyNameLowerInv = primaryKeyName.ToLowerInvariant();
     string primaryKeyShortTypeName = Model.ModelInfo.PrimaryKeyTypeName;
-    string entitySetName = Model.DbContextInfo.EntitySetVariableName;
+    string entitySetName = Model.DbContextInfo.EntitySetVariableName ?? modelName;
 #>
 @page "/<#= pluralModelLowerInv #>/details"
 @using Microsoft.EntityFrameworkCore

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorCrud/Edit.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorCrud/Edit.cs
@@ -40,7 +40,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorCrud
     string primaryKeyName = Model.ModelInfo.PrimaryKeyName;
     string primaryKeyNameLowerInv = primaryKeyName.ToLowerInvariant();
     string primaryKeyShortTypeName = Model.ModelInfo.PrimaryKeyTypeName;
-    string entitySetName = Model.DbContextInfo.EntitySetVariableName;
+    string entitySetName = Model.DbContextInfo.EntitySetVariableName ?? modelName;
 
             this.Write("@page \"/");
             this.Write(this.ToStringHelper.ToStringWithCulture(pluralModelLowerInv));

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorCrud/Edit.tt
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorCrud/Edit.tt
@@ -18,7 +18,7 @@
     string primaryKeyName = Model.ModelInfo.PrimaryKeyName;
     string primaryKeyNameLowerInv = primaryKeyName.ToLowerInvariant();
     string primaryKeyShortTypeName = Model.ModelInfo.PrimaryKeyTypeName;
-    string entitySetName = Model.DbContextInfo.EntitySetVariableName;
+    string entitySetName = Model.DbContextInfo.EntitySetVariableName ?? modelName;
 #>
 @page "/<#= pluralModelLowerInv #>/edit"
 @using Microsoft.EntityFrameworkCore

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorCrud/Index.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorCrud/Index.cs
@@ -39,7 +39,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.BlazorCrud
     string primaryKeyName = Model.ModelInfo.PrimaryKeyName;
     string primaryKeyNameLowerInv = primaryKeyName.ToLowerInvariant();
     string primaryKeyShortTypeName = Model.ModelInfo.PrimaryKeyTypeName;
-    string entitySetName = Model.DbContextInfo.EntitySetVariableName;
+    string entitySetName = Model.DbContextInfo.EntitySetVariableName ?? modelName;
 
             this.Write("@page \"/");
             this.Write(this.ToStringHelper.ToStringWithCulture(pluralModelLowerInv));

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorCrud/Index.tt
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/BlazorCrud/Index.tt
@@ -17,7 +17,7 @@
     string primaryKeyName = Model.ModelInfo.PrimaryKeyName;
     string primaryKeyNameLowerInv = primaryKeyName.ToLowerInvariant();
     string primaryKeyShortTypeName = Model.ModelInfo.PrimaryKeyTypeName;
-    string entitySetName = Model.DbContextInfo.EntitySetVariableName;
+    string entitySetName = Model.DbContextInfo.EntitySetVariableName ?? modelName;
 #>
 @page "/<#= pluralModelLowerInv #>"
 @using Microsoft.AspNetCore.Components.QuickGrid

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net8.0/BlazorCrud/Create.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net8.0/BlazorCrud/Create.cs
@@ -111,7 +111,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net8.BlazorCrud
             this.Write(this.ToStringHelper.ToStringWithCulture(modelName));
             this.Write("()\r\n    {\r\n        using var context = DbFactory.CreateDbContext();\r\n        cont" +
                     "ext.");
-            this.Write(this.ToStringHelper.ToStringWithCulture(Model.DbContextInfo.EntitySetVariableName));
+            this.Write(this.ToStringHelper.ToStringWithCulture(Model.DbContextInfo.EntitySetVariableName ?? modelName));
             this.Write(".Add(");
             this.Write(this.ToStringHelper.ToStringWithCulture(modelName));
             this.Write(");\r\n        await context.SaveChangesAsync();\r\n        NavigationManager.Navigate" +

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net8.0/BlazorCrud/Delete.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net8.0/BlazorCrud/Delete.cs
@@ -37,7 +37,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net8.BlazorCrud
     string primaryKeyName = Model.ModelInfo.PrimaryKeyName;
     string primaryKeyNameLowerInv = primaryKeyName.ToLowerInvariant();
     string primaryKeyShortTypeName = Model.ModelInfo.PrimaryKeyTypeName;
-    string entitySetName = Model.DbContextInfo.EntitySetVariableName;
+    string entitySetName = Model.DbContextInfo.EntitySetVariableName ?? modelName;
     var entityProperties = Model.ModelInfo.ModelProperties.Where(x => !x.Name.Equals(Model.ModelInfo.PrimaryKeyName, StringComparison.OrdinalIgnoreCase)).ToList();
 
             this.Write("@page \"/");

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net8.0/BlazorCrud/Details.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net8.0/BlazorCrud/Details.cs
@@ -37,7 +37,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net8.BlazorCrud
     string primaryKeyName = Model.ModelInfo.PrimaryKeyName;
     string primaryKeyShortTypeName = Model.ModelInfo.PrimaryKeyTypeName;
     string primaryKeyNameLowerInv = primaryKeyName.ToLowerInvariant();
-    string entitySetName = Model.DbContextInfo.EntitySetVariableName;
+    string entitySetName = Model.DbContextInfo.EntitySetVariableName ?? modelName;
     var entityProperties = Model.ModelInfo.ModelProperties.Where(x => !x.Name.Equals(Model.ModelInfo.PrimaryKeyName, StringComparison.OrdinalIgnoreCase)).ToList();
 
             this.Write("@page \"/");

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net8.0/BlazorCrud/Edit.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net8.0/BlazorCrud/Edit.cs
@@ -38,7 +38,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net8.BlazorCrud
     string primaryKeyName = Model.ModelInfo.PrimaryKeyName;
     string primaryKeyNameLowerInv = primaryKeyName.ToLowerInvariant();
     string primaryKeyShortTypeName = Model.ModelInfo.PrimaryKeyTypeName;
-    string entitySetName = Model.DbContextInfo.EntitySetVariableName;
+    string entitySetName = Model.DbContextInfo.EntitySetVariableName ?? modelName;
     var entityProperties = Model.ModelInfo.ModelProperties.Where(x => !x.Name.Equals(Model.ModelInfo.PrimaryKeyName, StringComparison.OrdinalIgnoreCase)).ToList();
 
             this.Write("@page \"/");

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net8.0/BlazorCrud/Index.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net8.0/BlazorCrud/Index.cs
@@ -66,7 +66,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net8.BlazorCrud
             this.Write("\r\n\r\n<PageTitle>Index</PageTitle>\r\n\r\n<h1>Index</h1>\r\n\r\n<p>\r\n    <a href=\"");
             this.Write(this.ToStringHelper.ToStringWithCulture(pluralModelLowerInv));
             this.Write("/create\">Create New</a>\r\n</p>\r\n\r\n<QuickGrid Class=\"table\" Items=\"context.");
-            this.Write(this.ToStringHelper.ToStringWithCulture(Model.DbContextInfo.EntitySetVariableName));
+            this.Write(this.ToStringHelper.ToStringWithCulture(Model.DbContextInfo.EntitySetVariableName ?? modelName));
             this.Write("\">\r\n");
 
     foreach (var property in entityProperties)

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net9.0/BlazorCrud/Create.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net9.0/BlazorCrud/Create.cs
@@ -114,7 +114,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net9.BlazorCrud
             this.Write(this.ToStringHelper.ToStringWithCulture(modelName));
             this.Write("()\r\n    {\r\n        using var context = DbFactory.CreateDbContext();\r\n        cont" +
                     "ext.");
-            this.Write(this.ToStringHelper.ToStringWithCulture(Model.DbContextInfo.EntitySetVariableName));
+            this.Write(this.ToStringHelper.ToStringWithCulture(Model.DbContextInfo.EntitySetVariableName ?? modelName));
             this.Write(".Add(");
             this.Write(this.ToStringHelper.ToStringWithCulture(modelName));
             this.Write(");\r\n        await context.SaveChangesAsync();\r\n        NavigationManager.Navigate" +

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net9.0/BlazorCrud/Create.tt
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net9.0/BlazorCrud/Create.tt
@@ -75,7 +75,7 @@
     private async Task Add<#= modelName #>()
     {
         using var context = DbFactory.CreateDbContext();
-        context.<#= Model.DbContextInfo.EntitySetVariableName #>.Add(<#= modelName #>);
+        context.<#= Model.DbContextInfo.EntitySetVariableName ?? modelName #>.Add(<#= modelName #>);
         await context.SaveChangesAsync();
         NavigationManager.NavigateTo("/<#= pluralModelLowerInv #>");
     }

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net9.0/BlazorCrud/Delete.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net9.0/BlazorCrud/Delete.cs
@@ -39,7 +39,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net9.BlazorCrud
     string primaryKeyName = Model.ModelInfo.PrimaryKeyName;
     string primaryKeyNameLowerInv = primaryKeyName.ToLowerInvariant();
     string primaryKeyShortTypeName = Model.ModelInfo.PrimaryKeyTypeName;
-    string entitySetName = Model.DbContextInfo.EntitySetVariableName;
+    string entitySetName = Model.DbContextInfo.EntitySetVariableName ?? modelName;
 
             this.Write("@page \"/");
             this.Write(this.ToStringHelper.ToStringWithCulture(pluralModelLowerInv));

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net9.0/BlazorCrud/Delete.tt
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net9.0/BlazorCrud/Delete.tt
@@ -17,7 +17,7 @@
     string primaryKeyName = Model.ModelInfo.PrimaryKeyName;
     string primaryKeyNameLowerInv = primaryKeyName.ToLowerInvariant();
     string primaryKeyShortTypeName = Model.ModelInfo.PrimaryKeyTypeName;
-    string entitySetName = Model.DbContextInfo.EntitySetVariableName;
+    string entitySetName = Model.DbContextInfo.EntitySetVariableName ?? modelName;
 #>
 @page "/<#= pluralModelLowerInv #>/delete"
 @using Microsoft.EntityFrameworkCore

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net9.0/BlazorCrud/Details.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net9.0/BlazorCrud/Details.cs
@@ -39,7 +39,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net9.BlazorCrud
     string primaryKeyName = Model.ModelInfo.PrimaryKeyName;
     string primaryKeyNameLowerInv = primaryKeyName.ToLowerInvariant();
     string primaryKeyShortTypeName = Model.ModelInfo.PrimaryKeyTypeName;
-    string entitySetName = Model.DbContextInfo.EntitySetVariableName;
+    string entitySetName = Model.DbContextInfo.EntitySetVariableName ?? modelName;
 
             this.Write("@page \"/");
             this.Write(this.ToStringHelper.ToStringWithCulture(pluralModelLowerInv));

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net9.0/BlazorCrud/Details.tt
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net9.0/BlazorCrud/Details.tt
@@ -17,7 +17,7 @@
     string primaryKeyName = Model.ModelInfo.PrimaryKeyName;
     string primaryKeyNameLowerInv = primaryKeyName.ToLowerInvariant();
     string primaryKeyShortTypeName = Model.ModelInfo.PrimaryKeyTypeName;
-    string entitySetName = Model.DbContextInfo.EntitySetVariableName;
+    string entitySetName = Model.DbContextInfo.EntitySetVariableName ?? modelName;
 #>
 @page "/<#= pluralModelLowerInv #>/details"
 @using Microsoft.EntityFrameworkCore

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net9.0/BlazorCrud/Edit.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net9.0/BlazorCrud/Edit.cs
@@ -40,7 +40,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net9.BlazorCrud
     string primaryKeyName = Model.ModelInfo.PrimaryKeyName;
     string primaryKeyNameLowerInv = primaryKeyName.ToLowerInvariant();
     string primaryKeyShortTypeName = Model.ModelInfo.PrimaryKeyTypeName;
-    string entitySetName = Model.DbContextInfo.EntitySetVariableName;
+    string entitySetName = Model.DbContextInfo.EntitySetVariableName ?? modelName;
 
             this.Write("@page \"/");
             this.Write(this.ToStringHelper.ToStringWithCulture(pluralModelLowerInv));

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net9.0/BlazorCrud/Edit.tt
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net9.0/BlazorCrud/Edit.tt
@@ -18,7 +18,7 @@
     string primaryKeyName = Model.ModelInfo.PrimaryKeyName;
     string primaryKeyNameLowerInv = primaryKeyName.ToLowerInvariant();
     string primaryKeyShortTypeName = Model.ModelInfo.PrimaryKeyTypeName;
-    string entitySetName = Model.DbContextInfo.EntitySetVariableName;
+    string entitySetName = Model.DbContextInfo.EntitySetVariableName ?? modelName;
 #>
 @page "/<#= pluralModelLowerInv #>/edit"
 @using Microsoft.EntityFrameworkCore

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net9.0/BlazorCrud/Index.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net9.0/BlazorCrud/Index.cs
@@ -39,7 +39,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net9.BlazorCrud
     string primaryKeyName = Model.ModelInfo.PrimaryKeyName;
     string primaryKeyNameLowerInv = primaryKeyName.ToLowerInvariant();
     string primaryKeyShortTypeName = Model.ModelInfo.PrimaryKeyTypeName;
-    string entitySetName = Model.DbContextInfo.EntitySetVariableName;
+    string entitySetName = Model.DbContextInfo.EntitySetVariableName ?? modelName;
 
             this.Write("@page \"/");
             this.Write(this.ToStringHelper.ToStringWithCulture(pluralModelLowerInv));

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net9.0/BlazorCrud/Index.tt
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net9.0/BlazorCrud/Index.tt
@@ -17,7 +17,7 @@
     string primaryKeyName = Model.ModelInfo.PrimaryKeyName;
     string primaryKeyNameLowerInv = primaryKeyName.ToLowerInvariant();
     string primaryKeyShortTypeName = Model.ModelInfo.PrimaryKeyTypeName;
-    string entitySetName = Model.DbContextInfo.EntitySetVariableName;
+    string entitySetName = Model.DbContextInfo.EntitySetVariableName ?? modelName;
 #>
 @page "/<#= pluralModelLowerInv #>"
 @using Microsoft.AspNetCore.Components.QuickGrid


### PR DESCRIPTION
This exception is coming from having no fall back when `Model.DbContextInfo.EntitySetVariableName` is not set in the `Create.cs` that is written to code. To fix, fallback values are added in this failing spot and other possible null exceptions. 

Fixes [ AzDo bug 2941401
](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2941401)