### PR TITLE
Create AddDbSetToExistingContextStep

### DIFF
--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/AspNetCommandService.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/AspNetCommandService.cs
@@ -24,6 +24,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet
             [
                 typeof(AddClientSecretStep),
                 typeof(AddAspNetConnectionStringStep),
+                typeof(AddDbSetToExistingContextStep),
                 typeof(AddFileStep),
                 typeof(AreaScaffolderStep),
                 typeof(DetectBlazorWasmStep),
@@ -154,6 +155,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet
                 })
                 .WithEfControllerAddPackagesStep()
                 .WithDbContextStep()
+                .WithAddDbSetStep()
                 .WithAspNetConnectionStringStep()
                 .WithEfControllerTextTemplatingStep()
                 .WithEfControllerCodeChangeStep();
@@ -179,6 +181,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet
                 })
                 .WithEfControllerAddPackagesStep()
                 .WithDbContextStep()
+                .WithAddDbSetStep()
                 .WithAspNetConnectionStringStep()
                 .WithEfControllerTextTemplatingStep()
                 .WithEfControllerCodeChangeStep()
@@ -204,6 +207,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet
                 })
                 .WithBlazorCrudAddPackagesStep()
                 .WithDbContextStep()
+                .WithAddDbSetStep()
                 .WithAspNetConnectionStringStep()
                 .WithBlazorCrudTextTemplatingStep()
                 .WithBlazorCrudCodeChangeStep();
@@ -228,6 +232,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet
                 })
                 .WithRazorPagesAddPackagesStep()
                 .WithDbContextStep()
+                .WithAddDbSetStep()
                 .WithAspNetConnectionStringStep()
                 .WithRazorPagesTextTemplatingStep()
                 .WithRazorPagesCodeChangeStep();
@@ -272,6 +277,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet
                 })
                 .WithMinimalApiAddPackagesStep()
                 .WithDbContextStep()
+                .WithAddDbSetStep()
                 .WithAspNetConnectionStringStep()
                 .WithMinimalApiTextTemplatingStep()
                 .WithMinimalApiCodeChangeStep();

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Common/ClassAnalyzers.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Common/ClassAnalyzers.cs
@@ -38,7 +38,7 @@ internal static class ClassAnalyzers
             dbContextInfo.DbContextClassPath = existingDbContextClass.Locations.FirstOrDefault()?.SourceTree?.FilePath;
             dbContextInfo.DbContextNamespace = existingDbContextClass.ContainingNamespace.ToDisplayString();
             dbContextInfo.EntitySetVariableName = modelInfo is null ?
-                string.Empty : EfDbContextHelpers.GetEntitySetVariableName(existingDbContextClass, modelInfo.ModelTypeName, modelInfo.ModelFullName) ?? modelInfo.ModelTypeName;
+                string.Empty : EfDbContextHelpers.GetEntitySetVariableName(existingDbContextClass, modelInfo.ModelTypeName, modelInfo.ModelFullName) ?? string.Empty;
 
             // If the DbSet for this model doesn't exist in the existing context yet, prepare the statement to add it.
             if (string.IsNullOrEmpty(dbContextInfo.EntitySetVariableName) && modelInfo is not null)

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Common/ClassAnalyzers.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Common/ClassAnalyzers.cs
@@ -39,6 +39,12 @@ internal static class ClassAnalyzers
             dbContextInfo.DbContextNamespace = existingDbContextClass.ContainingNamespace.ToDisplayString();
             dbContextInfo.EntitySetVariableName = modelInfo is null ?
                 string.Empty : EfDbContextHelpers.GetEntitySetVariableName(existingDbContextClass, modelInfo.ModelTypeName, modelInfo.ModelFullName);
+
+            // If the DbSet for this model doesn't exist in the existing context yet, prepare the statement to add it.
+            if (string.IsNullOrEmpty(dbContextInfo.EntitySetVariableName) && modelInfo is not null)
+            {
+                dbContextInfo.NewDbSetStatement = $"public DbSet<{modelInfo.ModelFullName}> {modelInfo.ModelTypeName} {{ get; set; }} = default!;";
+            }
         }
         //properties for creating a new DbContext
         else

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Extensions/ScaffolderBuilderAspNetExtensions.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Extensions/ScaffolderBuilderAspNetExtensions.cs
@@ -64,8 +64,9 @@ internal static class ScaffolderBuilderAspNetExtensions
     }
 
     /// <summary>
-    /// Adds a step that inserts a missing DbSet property into a pre-existing DbContext class.
-    /// This step is a no-op when a new DbContext is being created or the DbSet already exists.
+    /// Adds a step that inserts a missing DbSet property into a DbContext class.
+    /// This step may run after <c>WithDbContextStep</c>, including when a new DbContext has just been created,
+    /// and relies on the underlying step to avoid introducing duplicate DbSet properties when one already exists.
     /// Delegates modification to <see cref="Microsoft.DotNet.Scaffolding.CodeModification.CodeModificationStep"/>
     /// via an in-memory JSON config, consistent with how all other code changes are applied.
     /// </summary>

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Extensions/ScaffolderBuilderAspNetExtensions.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Extensions/ScaffolderBuilderAspNetExtensions.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 using Microsoft.DotNet.Scaffolding.Core.Builder;
+using Microsoft.DotNet.Scaffolding.Core.Scaffolders;
 using Microsoft.DotNet.Scaffolding.Core.Steps;
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 using Microsoft.DotNet.Scaffolding.TextTemplating.DbContext;
@@ -60,6 +61,36 @@ internal static class ScaffolderBuilderAspNetExtensions
         });
 
         return builder;
+    }
+
+    /// <summary>
+    /// Adds a step that inserts a missing DbSet property into a pre-existing DbContext class.
+    /// This step is a no-op when a new DbContext is being created or the DbSet already exists.
+    /// Delegates modification to <see cref="Microsoft.DotNet.Scaffolding.CodeModification.CodeModificationStep"/>
+    /// via an in-memory JSON config, consistent with how all other code changes are applied.
+    /// </summary>
+    /// <param name="builder">The scaffold builder.</param>
+    /// <returns>The updated scaffold builder.</returns>
+    public static IScaffoldBuilder WithAddDbSetStep(this IScaffoldBuilder builder)
+    {
+        return builder.WithStep<AddDbSetToExistingContextStep>(config =>
+        {
+            ScaffolderContext context = config.Context;
+            if (!context.Properties.ContainsKey(nameof(DbContextProperties)))
+            {
+                config.Step.SkipStep = true;
+                return;
+            }
+
+            string? projectPath = context.GetOptionResult<string>(CliConstants.CliOptions.ProjectCliOption);
+            if (string.IsNullOrEmpty(projectPath))
+            {
+                config.Step.SkipStep = true;
+                return;
+            }
+
+            config.Step.ProjectPath = projectPath;
+        });
     }
 
     /// <summary>

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/ScaffoldSteps/AddDbSetToExistingContextStep.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/ScaffoldSteps/AddDbSetToExistingContextStep.cs
@@ -59,6 +59,15 @@ internal class AddDbSetToExistingContextStep : ScaffoldStep
             return true;
         }
 
+        // Fast pre-check: if the DbSet property is already present in the file
+        // (e.g. because WithDbContextStep just created the file with the DbSet included),
+        // skip the modification pass to avoid a redundant Roslyn workspace update.
+        string fileContent = await File.ReadAllTextAsync(dbContextPath, cancellationToken);
+        if (DbSetAlreadyPresent(fileContent, dbSetStatement))
+        {
+            return true;
+        }
+
         string dbContextFileName = Path.GetFileName(dbContextPath);
         string configJson = BuildCodeModifierConfig(dbContextFileName, dbSetStatement);
 
@@ -103,6 +112,27 @@ internal class AddDbSetToExistingContextStep : ScaffoldStep
         };
 
         return JsonSerializer.Serialize(config);
+    }
+
+    /// <summary>
+    /// Returns <c>true</c> when <paramref name="fileContent"/> already contains a
+    /// <c>DbSet&lt;T&gt;</c> property for the same type as <paramref name="dbSetStatement"/>
+    /// would introduce, preventing a duplicate insertion.
+    /// </summary>
+    internal static bool DbSetAlreadyPresent(string fileContent, string dbSetStatement)
+    {
+        // dbSetStatement looks like:
+        //   "public DbSet<Full.Type.Name> TypeName { get; set; } = default!;"
+        // Extract "DbSet<Full.Type.Name>" to check whether the file already has it.
+        int start = dbSetStatement.IndexOf("DbSet<", StringComparison.Ordinal);
+        int end = start >= 0 ? dbSetStatement.IndexOf('>', start) : -1;
+        if (start < 0 || end < 0)
+        {
+            return false;
+        }
+
+        string dbSetMarker = dbSetStatement[start..(end + 1)];
+        return fileContent.Contains(dbSetMarker, StringComparison.Ordinal);
     }
 }
 

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/ScaffoldSteps/AddDbSetToExistingContextStep.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/ScaffoldSteps/AddDbSetToExistingContextStep.cs
@@ -1,0 +1,108 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+using System.Text.Json;
+using Microsoft.DotNet.Scaffolding.CodeModification;
+using Microsoft.DotNet.Scaffolding.Core.Scaffolders;
+using Microsoft.DotNet.Scaffolding.Core.Steps;
+using Microsoft.DotNet.Scaffolding.TextTemplating.DbContext;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Microsoft.DotNet.Tools.Scaffold.AspNet.ScaffoldSteps;
+
+/// <summary>
+/// Scaffold step that adds a missing DbSet property to an existing DbContext class.
+/// This is needed when a pre-existing DbContext is selected for CRUD scaffolding but does
+/// not yet contain a DbSet property for the model being scaffolded.
+/// Delegates the actual code modification to <see cref="CodeModificationStep"/> using its
+/// in-memory JSON config path, consistent with how all other code changes are applied in
+/// this project.
+/// </summary>
+internal class AddDbSetToExistingContextStep : ScaffoldStep
+{
+    /// <summary>
+    /// Path to the .csproj of the project being scaffolded. Required to open the Roslyn workspace.
+    /// </summary>
+    public string? ProjectPath { get; set; }
+
+    /// <summary>
+    /// Code change options forwarded to the underlying <see cref="CodeModificationStep"/>.
+    /// Defaults to an empty list, which is correct when no option-filtered blocks are defined.
+    /// </summary>
+    public IList<string> CodeChangeOptions { get; set; } = [];
+
+    private readonly ILogger _logger;
+
+    public AddDbSetToExistingContextStep(ILogger<AddDbSetToExistingContextStep> logger)
+    {
+        _logger = logger;
+    }
+
+    public override async Task<bool> ExecuteAsync(ScaffolderContext context, CancellationToken cancellationToken = default)
+    {
+        if (!context.Properties.TryGetValue(nameof(DbContextProperties), out object? dbContextPropertiesObj) ||
+            dbContextPropertiesObj is not DbContextProperties dbContextProperties)
+        {
+            return true;
+        }
+
+        string? dbContextPath = dbContextProperties.DbContextPath;
+        string? dbSetStatement = dbContextProperties.DbSetStatement;
+
+        // Only act when:
+        //   The target file already exists on disk (existing context — new contexts are
+        //     handled by WithDbContextStep via its T4 template which already includes the DbSet).
+        //   A DbSet statement was produced (only set when GetDbContextInfo found no existing DbSet).
+        //   The project path is available to initialise the Roslyn workspace.
+        if (string.IsNullOrEmpty(dbContextPath) || !File.Exists(dbContextPath) || string.IsNullOrEmpty(dbSetStatement) || string.IsNullOrEmpty(ProjectPath))
+        {
+            return true;
+        }
+
+        string dbContextFileName = Path.GetFileName(dbContextPath);
+        string configJson = BuildCodeModifierConfig(dbContextFileName, dbSetStatement);
+
+        _logger.LogInformation($"Adding DbSet property to '{dbContextFileName}'...");
+
+        CodeModificationStep codeModificationStep = new CodeModificationStep(NullLogger<CodeModificationStep>.Instance)
+        {
+            CodeModifierConfigJsonText = configJson,
+            ProjectPath = ProjectPath,
+            CodeChangeOptions = CodeChangeOptions
+        };
+
+        bool result = await codeModificationStep.ExecuteAsync(context, cancellationToken);
+        if (!result)
+        {
+            _logger.LogError($"Failed to add '{dbSetStatement}' to '{dbContextFileName}'.");
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Builds a <see cref="CodeModificationStep"/>-compatible JSON config that instructs
+    /// to insert <paramref name="dbSetStatement"/> as a class property via
+    /// <c>ClassProperties</c>. Duplicate detection is built into DocumentBuilder.
+    /// </summary>
+    internal static string BuildCodeModifierConfig(string dbContextFileName, string dbSetStatement)
+    {
+        object config = new
+        {
+            Files = new[]
+            {
+                new
+                {
+                    FileName = dbContextFileName,
+                    ClassProperties = new[]
+                    {
+                        new { Block = dbSetStatement }
+                    }
+                }
+            }
+        };
+
+        return JsonSerializer.Serialize(config);
+    }
+}
+

--- a/test/dotnet-scaffolding/dotnet-scaffold.Tests/AspNet/Common/ClassAnalyzersTests.cs
+++ b/test/dotnet-scaffolding/dotnet-scaffold.Tests/AspNet/Common/ClassAnalyzersTests.cs
@@ -323,19 +323,152 @@ public class Product
         Assert.False(result);
     }
 
+    [Fact]
+    public void GetDbContextInfo_WithExistingDbContext_PopulatesNewDbSetStatement_WhenDbSetIsMissing()
+    {
+        // Arrange — context exists but has NO DbSet for Movie
+        string code = @"
+using Microsoft.EntityFrameworkCore;
+namespace MyApp.Data
+{
+    public class ApplicationDbContext : DbContext
+    {
+        public DbSet<Customer> Customers { get; set; }
+    }
+
+    public class Customer { public int Id { get; set; } }
+    public class Movie { public int Id { get; set; } }
+}";
+        CSharpCompilation compilation = CreateCompilation(code);
+        INamedTypeSymbol dbContextSymbol = GetTypeSymbol(compilation, "ApplicationDbContext");
+        ModelInfo modelInfo = new ModelInfo
+        {
+            ModelTypeName = "Movie",
+            ModelFullName = "MyApp.Data.Movie"
+        };
+
+        // Act
+        DbContextInfo result = ClassAnalyzers.GetDbContextInfo(
+            "TestProject.csproj",
+            dbContextSymbol,
+            "ApplicationDbContext",
+            "SqlServer",
+            modelInfo);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal("ApplicationDbContext", result.DbContextClassName);
+        // EntitySetVariableName should be empty (not found)
+        Assert.True(string.IsNullOrEmpty(result.EntitySetVariableName));
+        // NewDbSetStatement must be set so AddDbSetToExistingContextStep can insert it
+        Assert.NotNull(result.NewDbSetStatement);
+        Assert.Contains("DbSet<MyApp.Data.Movie>", result.NewDbSetStatement);
+        Assert.Contains("Movie", result.NewDbSetStatement);
+        Assert.Contains("default!", result.NewDbSetStatement);
+    }
+
+    [Fact]
+    public void GetDbContextInfo_WithExistingDbContext_DoesNotPopulateNewDbSetStatement_WhenDbSetAlreadyPresent()
+    {
+        // Arrange — context already has a DbSet<Movie>
+        string code = @"
+using Microsoft.EntityFrameworkCore;
+namespace MyApp.Data
+{
+    public class ApplicationDbContext : DbContext
+    {
+        public DbSet<Movie> Movie { get; set; }
+    }
+
+    public class Movie { public int Id { get; set; } }
+}";
+        CSharpCompilation compilation = CreateCompilation(code);
+        INamedTypeSymbol dbContextSymbol = GetTypeSymbol(compilation, "ApplicationDbContext");
+        ModelInfo modelInfo = new ModelInfo
+        {
+            ModelTypeName = "Movie",
+            ModelFullName = "MyApp.Data.Movie"
+        };
+
+        // Act
+        DbContextInfo result = ClassAnalyzers.GetDbContextInfo(
+            "TestProject.csproj",
+            dbContextSymbol,
+            "ApplicationDbContext",
+            "SqlServer",
+            modelInfo);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal("Movie", result.EntitySetVariableName);
+        // DbSet exists → no statement to inject
+        Assert.Null(result.NewDbSetStatement);
+    }
+
+    [Fact]
+    public void GetDbContextInfo_WithExistingDbContext_NullModelInfo_DoesNotPopulateNewDbSetStatement()
+    {
+        // Arrange
+        string code = @"
+using Microsoft.EntityFrameworkCore;
+namespace MyApp.Data
+{
+    public class ApplicationDbContext : DbContext { }
+}";
+        CSharpCompilation compilation = CreateCompilation(code);
+        INamedTypeSymbol dbContextSymbol = GetTypeSymbol(compilation, "ApplicationDbContext");
+
+        // Act — no modelInfo provided
+        DbContextInfo result = ClassAnalyzers.GetDbContextInfo(
+            "TestProject.csproj",
+            dbContextSymbol,
+            "ApplicationDbContext",
+            "SqlServer",
+            modelInfo: null);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.True(string.IsNullOrEmpty(result.EntitySetVariableName));
+        Assert.Null(result.NewDbSetStatement);
+    }
+
     private static CSharpCompilation CreateCompilation(string source)
     {
         SyntaxTree syntaxTree = CSharpSyntaxTree.ParseText(source);
-        MetadataReference[] references = new[]
+        string baseDir = System.AppContext.BaseDirectory;
+
+        // Start with all currently-loaded assemblies so framework + DI/logging transitive deps are present
+        System.Collections.Generic.HashSet<string> addedFileNames =
+            new System.Collections.Generic.HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        System.Collections.Generic.List<MetadataReference> references = new System.Collections.Generic.List<MetadataReference>();
+
+        foreach (System.Reflection.Assembly asm in AppDomain.CurrentDomain.GetAssemblies())
         {
-            MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
-            MetadataReference.CreateFromFile(typeof(System.Linq.Enumerable).Assembly.Location)
-        };
+            if (!asm.IsDynamic && !string.IsNullOrEmpty(asm.Location) &&
+                addedFileNames.Add(System.IO.Path.GetFileName(asm.Location)))
+            {
+                references.Add(MetadataReference.CreateFromFile(asm.Location));
+            }
+        }
+
+        // Explicitly add EF Core assemblies from the test output directory if not already loaded
+        string[] efCoreNames = { "Microsoft.EntityFrameworkCore.dll", "Microsoft.EntityFrameworkCore.Abstractions.dll" };
+        foreach (string asmName in efCoreNames)
+        {
+            if (addedFileNames.Add(asmName))
+            {
+                string path = System.IO.Path.Combine(baseDir, asmName);
+                if (System.IO.File.Exists(path))
+                {
+                    references.Add(MetadataReference.CreateFromFile(path));
+                }
+            }
+        }
 
         return CSharpCompilation.Create(
             "TestAssembly",
             new[] { syntaxTree },
-            references,
+            references.ToArray(),
             new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
     }
 

--- a/test/dotnet-scaffolding/dotnet-scaffold.Tests/AspNet/ScaffoldSteps/AddDbSetToExistingContextStepTests.cs
+++ b/test/dotnet-scaffolding/dotnet-scaffold.Tests/AspNet/ScaffoldSteps/AddDbSetToExistingContextStepTests.cs
@@ -213,5 +213,77 @@ public class AddDbSetToExistingContextStepTests : IDisposable
         Assert.NotNull(step.CodeChangeOptions);
         Assert.Empty(step.CodeChangeOptions);
     }
+
+    // -----------------------------------------------------------------------
+    // Scenario 11: File exists and already contains the DbSet
+    //              (newly-created context from WithDbContextStep) — step skips
+    // -----------------------------------------------------------------------
+    [Fact]
+    public async Task ExecuteAsync_ReturnsTrue_WhenDbSetAlreadyPresentInFile()
+    {
+        const string dbSetStatement = "public DbSet<Movie> Movie { get; set; } = default!;";
+        string path = WriteContextFile($"public class ApplicationDbContext {{ {dbSetStatement} }}");
+        DbContextProperties props = new DbContextProperties
+        {
+            DbContextPath = path,
+            DbSetStatement = dbSetStatement
+        };
+        _context.Properties[nameof(DbContextProperties)] = props;
+
+        AddDbSetToExistingContextStep step = CreateStep();
+        step.ProjectPath = Path.Combine(_tempDir, "App.csproj");
+
+        bool result = await step.ExecuteAsync(_context, CancellationToken.None);
+
+        Assert.True(result);
+    }
+
+    // -----------------------------------------------------------------------
+    // Scenario 12: DbSetAlreadyPresent returns true when marker is in file
+    // -----------------------------------------------------------------------
+    [Fact]
+    public void DbSetAlreadyPresent_ReturnsTrue_WhenDbSetIsInFile()
+    {
+        const string statement = "public DbSet<Movie> Movie { get; set; } = default!;";
+        const string fileContent = "public class Ctx { public DbSet<Movie> Movie { get; set; } = default!; }";
+
+        Assert.True(AddDbSetToExistingContextStep.DbSetAlreadyPresent(fileContent, statement));
+    }
+
+    // -----------------------------------------------------------------------
+    // Scenario 13: DbSetAlreadyPresent returns false when marker is absent
+    // -----------------------------------------------------------------------
+    [Fact]
+    public void DbSetAlreadyPresent_ReturnsFalse_WhenDbSetNotInFile()
+    {
+        const string statement = "public DbSet<Movie> Movie { get; set; } = default!;";
+        const string fileContent = "public class Ctx { }";
+
+        Assert.False(AddDbSetToExistingContextStep.DbSetAlreadyPresent(fileContent, statement));
+    }
+
+    // -----------------------------------------------------------------------
+    // Scenario 14: DbSetAlreadyPresent returns true for fully-qualified names
+    // -----------------------------------------------------------------------
+    [Fact]
+    public void DbSetAlreadyPresent_ReturnsTrue_WithFullyQualifiedTypeName()
+    {
+        const string statement = "public DbSet<MyApp.Models.Movie> Movie { get; set; } = default!;";
+        const string fileContent = "public class Ctx { public DbSet<MyApp.Models.Movie> Movie { get; set; } = default!; }";
+
+        Assert.True(AddDbSetToExistingContextStep.DbSetAlreadyPresent(fileContent, statement));
+    }
+
+    // -----------------------------------------------------------------------
+    // Scenario 15: DbSetAlreadyPresent returns false when statement lacks DbSet<
+    // -----------------------------------------------------------------------
+    [Fact]
+    public void DbSetAlreadyPresent_ReturnsFalse_WhenStatementHasNoDbSetMarker()
+    {
+        const string statement = "public string Foo { get; set; }";
+        const string fileContent = "public class Ctx { public string Foo { get; set; } }";
+
+        Assert.False(AddDbSetToExistingContextStep.DbSetAlreadyPresent(fileContent, statement));
+    }
 }
 

--- a/test/dotnet-scaffolding/dotnet-scaffold.Tests/AspNet/ScaffoldSteps/AddDbSetToExistingContextStepTests.cs
+++ b/test/dotnet-scaffolding/dotnet-scaffold.Tests/AspNet/ScaffoldSteps/AddDbSetToExistingContextStepTests.cs
@@ -1,0 +1,217 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+using System;
+using System.IO;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.DotNet.Scaffolding.Core.Scaffolders;
+using Microsoft.DotNet.Scaffolding.TextTemplating.DbContext;
+using Microsoft.DotNet.Tools.Scaffold.AspNet.ScaffoldSteps;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Microsoft.DotNet.Tools.Scaffold.Tests.AspNet.ScaffoldSteps;
+
+public class AddDbSetToExistingContextStepTests : IDisposable
+{
+    private readonly Mock<IScaffolder> _mockScaffolder;
+    private readonly ScaffolderContext _context;
+    private readonly string _tempDir;
+
+    public AddDbSetToExistingContextStepTests()
+    {
+        _mockScaffolder = new Mock<IScaffolder>();
+        _mockScaffolder.Setup(s => s.DisplayName).Returns("TestScaffolder");
+        _mockScaffolder.Setup(s => s.Name).Returns("test-scaffolder");
+        _context = new ScaffolderContext(_mockScaffolder.Object);
+        _tempDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+        {
+            Directory.Delete(_tempDir, recursive: true);
+        }
+    }
+
+    private static AddDbSetToExistingContextStep CreateStep() =>
+        new AddDbSetToExistingContextStep(NullLogger<AddDbSetToExistingContextStep>.Instance);
+
+    private string WriteContextFile(string content)
+    {
+        string path = Path.Combine(_tempDir, "ApplicationDbContext.cs");
+        File.WriteAllText(path, content);
+        return path;
+    }
+
+    // -----------------------------------------------------------------------
+    // Scenario 1: No DbContextProperties in context — step is a no-op
+    // -----------------------------------------------------------------------
+    [Fact]
+    public async Task ExecuteAsync_ReturnsTrue_WhenNoDbContextPropertiesInContext()
+    {
+        AddDbSetToExistingContextStep step = CreateStep();
+        bool result = await step.ExecuteAsync(_context, CancellationToken.None);
+        Assert.True(result);
+    }
+
+    // -----------------------------------------------------------------------
+    // Scenario 2: DbContextProperties present but DbSetStatement is null
+    //             (DbSet already existed — EntitySetVariableName was found)
+    // -----------------------------------------------------------------------
+    [Fact]
+    public async Task ExecuteAsync_ReturnsTrue_WhenDbSetStatementIsNull()
+    {
+        string path = WriteContextFile("public class ApplicationDbContext { }");
+        DbContextProperties props = new DbContextProperties { DbContextPath = path, DbSetStatement = null };
+        _context.Properties[nameof(DbContextProperties)] = props;
+
+        AddDbSetToExistingContextStep step = CreateStep();
+        bool result = await step.ExecuteAsync(_context, CancellationToken.None);
+
+        Assert.True(result);
+    }
+
+    // -----------------------------------------------------------------------
+    // Scenario 3: DbContextProperties present but DbContextPath does not exist
+    //             (new context — WithDbContextStep will create it via T4 template)
+    // -----------------------------------------------------------------------
+    [Fact]
+    public async Task ExecuteAsync_ReturnsTrue_WhenFileDoesNotExist()
+    {
+        DbContextProperties props = new DbContextProperties
+        {
+            DbContextPath = Path.Combine(_tempDir, "NonExistent.cs"),
+            DbSetStatement = "public DbSet<Movie> Movie { get; set; } = default!;"
+        };
+        _context.Properties[nameof(DbContextProperties)] = props;
+
+        AddDbSetToExistingContextStep step = CreateStep();
+        bool result = await step.ExecuteAsync(_context, CancellationToken.None);
+
+        Assert.True(result);
+    }
+
+    // -----------------------------------------------------------------------
+    // Scenario 4: DbSetStatement is null — step is a no-op regardless of file
+    // -----------------------------------------------------------------------
+    [Fact]
+    public async Task ExecuteAsync_ReturnsTrue_WhenDbSetStatementIsEmpty()
+    {
+        string path = WriteContextFile("public class ApplicationDbContext { }");
+        DbContextProperties props = new DbContextProperties { DbContextPath = path, DbSetStatement = string.Empty };
+        _context.Properties[nameof(DbContextProperties)] = props;
+
+        AddDbSetToExistingContextStep step = CreateStep();
+        bool result = await step.ExecuteAsync(_context, CancellationToken.None);
+
+        Assert.True(result);
+    }
+
+    // -----------------------------------------------------------------------
+    // Scenario 5: ProjectPath is null — step is a no-op (Roslyn workspace
+    //             cannot be opened without the .csproj path)
+    // -----------------------------------------------------------------------
+    [Fact]
+    public async Task ExecuteAsync_ReturnsTrue_WhenProjectPathIsNull()
+    {
+        string path = WriteContextFile("public class ApplicationDbContext { }");
+        DbContextProperties props = new DbContextProperties
+        {
+            DbContextPath = path,
+            DbSetStatement = "public DbSet<Movie> Movie { get; set; } = default!;"
+        };
+        _context.Properties[nameof(DbContextProperties)] = props;
+
+        AddDbSetToExistingContextStep step = CreateStep();
+        // ProjectPath intentionally left null
+        bool result = await step.ExecuteAsync(_context, CancellationToken.None);
+
+        Assert.True(result);
+    }
+
+    // -----------------------------------------------------------------------
+    // Scenario 6: BuildCodeModifierConfig produces well-formed JSON
+    // -----------------------------------------------------------------------
+    [Fact]
+    public void BuildCodeModifierConfig_ProducesValidJson()
+    {
+        const string fileName = "ApplicationDbContext.cs";
+        const string dbSetStatement = "public DbSet<Movie> Movie { get; set; } = default!;";
+
+        string json = AddDbSetToExistingContextStep.BuildCodeModifierConfig(fileName, dbSetStatement);
+
+        Assert.False(string.IsNullOrWhiteSpace(json));
+        JsonDocument doc = JsonDocument.Parse(json);
+        Assert.Equal(JsonValueKind.Object, doc.RootElement.ValueKind);
+    }
+
+    // -----------------------------------------------------------------------
+    // Scenario 7: JSON config contains FileName and ClassProperties[0].Block
+    //             matching the inputs — DocumentBuilder relies on these fields
+    // -----------------------------------------------------------------------
+    [Fact]
+    public void BuildCodeModifierConfig_ContainsCorrectFileNameAndBlock()
+    {
+        const string fileName = "MyContext.cs";
+        const string dbSetStatement = "public DbSet<Order> Orders { get; set; } = default!;";
+
+        string json = AddDbSetToExistingContextStep.BuildCodeModifierConfig(fileName, dbSetStatement);
+
+        JsonDocument doc = JsonDocument.Parse(json);
+        JsonElement filesArray = doc.RootElement.GetProperty("Files");
+        Assert.Equal(1, filesArray.GetArrayLength());
+
+        JsonElement fileEntry = filesArray[0];
+        Assert.Equal(fileName, fileEntry.GetProperty("FileName").GetString());
+
+        JsonElement classProperties = fileEntry.GetProperty("ClassProperties");
+        Assert.Equal(1, classProperties.GetArrayLength());
+        Assert.Equal(dbSetStatement, classProperties[0].GetProperty("Block").GetString());
+    }
+
+    // -----------------------------------------------------------------------
+    // Scenario 8: BuildCodeModifierConfig handles fully-qualified type names
+    // -----------------------------------------------------------------------
+    [Fact]
+    public void BuildCodeModifierConfig_HandlesFullyQualifiedModelName()
+    {
+        const string fileName = "AppDb.cs";
+        const string dbSetStatement = "public DbSet<MyApp.Models.Movie> Movie { get; set; } = default!;";
+
+        string json = AddDbSetToExistingContextStep.BuildCodeModifierConfig(fileName, dbSetStatement);
+
+        JsonDocument doc = JsonDocument.Parse(json);
+        JsonElement block = doc.RootElement
+            .GetProperty("Files")[0]
+            .GetProperty("ClassProperties")[0]
+            .GetProperty("Block");
+
+        Assert.Equal(dbSetStatement, block.GetString());
+    }
+
+    // -----------------------------------------------------------------------
+    // Scenario 9: ProjectPath is exposed as a settable property
+    // -----------------------------------------------------------------------
+    [Fact]
+    public void AddDbSetToExistingContextStep_HasProjectPathProperty()
+    {
+        Assert.NotNull(typeof(AddDbSetToExistingContextStep).GetProperty("ProjectPath"));
+    }
+
+    // -----------------------------------------------------------------------
+    // Scenario 10: CodeChangeOptions defaults to an empty list
+    // -----------------------------------------------------------------------
+    [Fact]
+    public void AddDbSetToExistingContextStep_CodeChangeOptions_DefaultsToEmpty()
+    {
+        AddDbSetToExistingContextStep step = CreateStep();
+        Assert.NotNull(step.CodeChangeOptions);
+        Assert.Empty(step.CodeChangeOptions);
+    }
+}
+


### PR DESCRIPTION

Fixes [Azdo Bug](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2941391)

This error is occuring when there is a pre-existing `ApplicationDbContext` the `DbSet<[Model]>` is not added to the `ApplicationDbContext` during scaffolding (it is added when there is a new `ApplicationDbContext` created). This change ensures that the `ApplicationDbContext` is edited during the scaffolding process to add the `DbSet` and allows for the project to build after scaffolding in this scenario. To ensure this code change, I create a new step, called the `AddDbSetToExistingContextStep` that does this edit if needed. Furthermore, more tests are added to handle this scenario. 

