### PR TITLE
ensure that hard there are no hard coded values in the templates

### DIFF
--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net10.0/EfController/MvcEfController.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net10.0/EfController/MvcEfController.cs
@@ -37,6 +37,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.EfController
     string primaryKeyName = Model.ModelInfo.PrimaryKeyName;
     string primaryKeyNameLowerInv = primaryKeyName.ToLowerInvariant();
     string primaryKeyTypeName = Model.ModelInfo.PrimaryKeyTypeName;
+    string bindProperties = string.Join(",", Model.ModelInfo.ModelProperties?.Select(p => p.Name) ?? Enumerable.Empty<string>());
 
             this.Write("\r\nusing Microsoft.AspNetCore.Mvc;\r\nusing Microsoft.EntityFrameworkCore;\r\n");
 
@@ -101,7 +102,9 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.EfController
     // For more details, see http://go.microsoft.com/fwlink/?LinkId=317598.
     [HttpPost]
     [ValidateAntiForgeryToken]
-    public async Task<IActionResult> Create([Bind(""Title,ReleaseDate,Genre,Price"")] ");
+    public async Task<IActionResult> Create([Bind(""");
+            this.Write(this.ToStringHelper.ToStringWithCulture(bindProperties));
+            this.Write(@""")] ");
             this.Write(this.ToStringHelper.ToStringWithCulture(modelName));
             this.Write(" ");
             this.Write(this.ToStringHelper.ToStringWithCulture(modelNameLowerInv));
@@ -140,7 +143,9 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.EfController
             this.Write(this.ToStringHelper.ToStringWithCulture(primaryKeyTypeName));
             this.Write("? ");
             this.Write(this.ToStringHelper.ToStringWithCulture(primaryKeyNameLowerInv));
-            this.Write(", [Bind(\"Id,Title,ReleaseDate,Genre,Price\")] ");
+            this.Write(", [Bind(\"");
+            this.Write(this.ToStringHelper.ToStringWithCulture(bindProperties));
+            this.Write("\")] ");
             this.Write(this.ToStringHelper.ToStringWithCulture(modelName));
             this.Write(" ");
             this.Write(this.ToStringHelper.ToStringWithCulture(modelNameLowerInv));

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net10.0/EfController/MvcEfController.tt
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net10.0/EfController/MvcEfController.tt
@@ -15,6 +15,7 @@
     string primaryKeyName = Model.ModelInfo.PrimaryKeyName;
     string primaryKeyNameLowerInv = primaryKeyName.ToLowerInvariant();
     string primaryKeyTypeName = Model.ModelInfo.PrimaryKeyTypeName;
+    string bindProperties = string.Join(",", Model.ModelInfo.ModelProperties?.Select(p => p.Name) ?? Enumerable.Empty<string>());
 #>
 
 using Microsoft.AspNetCore.Mvc;
@@ -76,7 +77,7 @@ public class <#= Model.ControllerName #> : Controller
     // For more details, see http://go.microsoft.com/fwlink/?LinkId=317598.
     [HttpPost]
     [ValidateAntiForgeryToken]
-    public async Task<IActionResult> Create([Bind("Title,ReleaseDate,Genre,Price")] <#= modelName #> <#= modelNameLowerInv #>)
+    public async Task<IActionResult> Create([Bind("<#= bindProperties #>")] <#= modelName #> <#= modelNameLowerInv #>)
     {
         if (ModelState.IsValid)
         {
@@ -108,7 +109,7 @@ public class <#= Model.ControllerName #> : Controller
     // For more details, see http://go.microsoft.com/fwlink/?LinkId=317598.
     [HttpPost]
     [ValidateAntiForgeryToken]
-    public async Task<IActionResult> Edit(<#= primaryKeyTypeName #>? <#= primaryKeyNameLowerInv #>, [Bind("Id,Title,ReleaseDate,Genre,Price")] <#= modelName #> <#= modelNameLowerInv #>)
+    public async Task<IActionResult> Edit(<#= primaryKeyTypeName #>? <#= primaryKeyNameLowerInv #>, [Bind("<#= bindProperties #>")] <#= modelName #> <#= modelNameLowerInv #>)
     {
         if (<#= primaryKeyNameLowerInv #> != <#= modelNameLowerInv #>.<#= primaryKeyName #>)
         {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/EfController/MvcEfController.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/EfController/MvcEfController.cs
@@ -37,6 +37,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.EfController
     string primaryKeyName = Model.ModelInfo.PrimaryKeyName;
     string primaryKeyNameLowerInv = primaryKeyName.ToLowerInvariant();
     string primaryKeyTypeName = Model.ModelInfo.PrimaryKeyTypeName;
+    string bindProperties = string.Join(",", Model.ModelInfo.ModelProperties?.Select(p => p.Name) ?? Enumerable.Empty<string>());
 
             this.Write("\r\nusing Microsoft.AspNetCore.Mvc;\r\nusing Microsoft.EntityFrameworkCore;\r\n");
 
@@ -101,7 +102,9 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.EfController
     // For more details, see http://go.microsoft.com/fwlink/?LinkId=317598.
     [HttpPost]
     [ValidateAntiForgeryToken]
-    public async Task<IActionResult> Create([Bind(""Title,ReleaseDate,Genre,Price"")] ");
+    public async Task<IActionResult> Create([Bind(""");
+            this.Write(this.ToStringHelper.ToStringWithCulture(bindProperties));
+            this.Write(@""")] ");
             this.Write(this.ToStringHelper.ToStringWithCulture(modelName));
             this.Write(" ");
             this.Write(this.ToStringHelper.ToStringWithCulture(modelNameLowerInv));
@@ -140,7 +143,9 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.EfController
             this.Write(this.ToStringHelper.ToStringWithCulture(primaryKeyTypeName));
             this.Write("? ");
             this.Write(this.ToStringHelper.ToStringWithCulture(primaryKeyNameLowerInv));
-            this.Write(", [Bind(\"Id,Title,ReleaseDate,Genre,Price\")] ");
+            this.Write(", [Bind(\"");
+            this.Write(this.ToStringHelper.ToStringWithCulture(bindProperties));
+            this.Write("\")] ");
             this.Write(this.ToStringHelper.ToStringWithCulture(modelName));
             this.Write(" ");
             this.Write(this.ToStringHelper.ToStringWithCulture(modelNameLowerInv));

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/EfController/MvcEfController.tt
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/EfController/MvcEfController.tt
@@ -15,6 +15,7 @@
     string primaryKeyName = Model.ModelInfo.PrimaryKeyName;
     string primaryKeyNameLowerInv = primaryKeyName.ToLowerInvariant();
     string primaryKeyTypeName = Model.ModelInfo.PrimaryKeyTypeName;
+    string bindProperties = string.Join(",", Model.ModelInfo.ModelProperties?.Select(p => p.Name) ?? Enumerable.Empty<string>());
 #>
 
 using Microsoft.AspNetCore.Mvc;
@@ -76,7 +77,7 @@ public class <#= Model.ControllerName #> : Controller
     // For more details, see http://go.microsoft.com/fwlink/?LinkId=317598.
     [HttpPost]
     [ValidateAntiForgeryToken]
-    public async Task<IActionResult> Create([Bind("Title,ReleaseDate,Genre,Price")] <#= modelName #> <#= modelNameLowerInv #>)
+    public async Task<IActionResult> Create([Bind("<#= bindProperties #>")] <#= modelName #> <#= modelNameLowerInv #>)
     {
         if (ModelState.IsValid)
         {
@@ -108,7 +109,7 @@ public class <#= Model.ControllerName #> : Controller
     // For more details, see http://go.microsoft.com/fwlink/?LinkId=317598.
     [HttpPost]
     [ValidateAntiForgeryToken]
-    public async Task<IActionResult> Edit(<#= primaryKeyTypeName #>? <#= primaryKeyNameLowerInv #>, [Bind("Id,Title,ReleaseDate,Genre,Price")] <#= modelName #> <#= modelNameLowerInv #>)
+    public async Task<IActionResult> Edit(<#= primaryKeyTypeName #>? <#= primaryKeyNameLowerInv #>, [Bind("<#= bindProperties #>")] <#= modelName #> <#= modelNameLowerInv #>)
     {
         if (<#= primaryKeyNameLowerInv #> != <#= modelNameLowerInv #>.<#= primaryKeyName #>)
         {

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net9.0/EfController/MvcEfController.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net9.0/EfController/MvcEfController.cs
@@ -37,6 +37,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net9.EfController
     string primaryKeyName = Model.ModelInfo.PrimaryKeyName;
     string primaryKeyNameLowerInv = primaryKeyName.ToLowerInvariant();
     string primaryKeyTypeName = Model.ModelInfo.PrimaryKeyTypeName;
+    string bindProperties = string.Join(",", Model.ModelInfo.ModelProperties?.Select(p => p.Name) ?? Enumerable.Empty<string>());
 
             this.Write("\r\nusing Microsoft.AspNetCore.Mvc;\r\nusing Microsoft.EntityFrameworkCore;\r\n");
 
@@ -101,9 +102,13 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net9.EfController
     // For more details, see http://go.microsoft.com/fwlink/?LinkId=317598.
     [HttpPost]
     [ValidateAntiForgeryToken]
-    public async Task<IActionResult> Create([Bind(""Title,ReleaseDate,Genre,Price"")] ");
+    public async Task<IActionResult> Create([Bind(""");
+            this.Write(this.ToStringHelper.ToStringWithCulture(bindProperties));
+            this.Write(@""")] ");
             this.Write(this.ToStringHelper.ToStringWithCulture(modelName));
-            this.Write(" movie)\r\n    {\r\n        if (ModelState.IsValid)\r\n        {\r\n            _context." +
+            this.Write(" ");
+            this.Write(this.ToStringHelper.ToStringWithCulture(modelNameLowerInv));
+            this.Write(")\r\n    {\r\n        if (ModelState.IsValid)\r\n        {\r\n            _context." +
                     "Add(");
             this.Write(this.ToStringHelper.ToStringWithCulture(modelNameLowerInv));
             this.Write(");\r\n            await _context.SaveChangesAsync();\r\n            return RedirectTo" +
@@ -139,9 +144,13 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net9.EfController
             this.Write(this.ToStringHelper.ToStringWithCulture(primaryKeyTypeName));
             this.Write("? ");
             this.Write(this.ToStringHelper.ToStringWithCulture(primaryKeyNameLowerInv));
-            this.Write(", [Bind(\"Id,Title,ReleaseDate,Genre,Price\")] ");
+            this.Write(", [Bind(\"");
+            this.Write(this.ToStringHelper.ToStringWithCulture(bindProperties));
+            this.Write("\")] ");
             this.Write(this.ToStringHelper.ToStringWithCulture(modelName));
-            this.Write(" movie)\r\n    {\r\n        if (");
+            this.Write(" ");
+            this.Write(this.ToStringHelper.ToStringWithCulture(modelNameLowerInv));
+            this.Write(")\r\n    {\r\n        if (");
             this.Write(this.ToStringHelper.ToStringWithCulture(primaryKeyNameLowerInv));
             this.Write(" != ");
             this.Write(this.ToStringHelper.ToStringWithCulture(modelNameLowerInv));

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net9.0/EfController/MvcEfController.tt
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net9.0/EfController/MvcEfController.tt
@@ -15,6 +15,7 @@
     string primaryKeyName = Model.ModelInfo.PrimaryKeyName;
     string primaryKeyNameLowerInv = primaryKeyName.ToLowerInvariant();
     string primaryKeyTypeName = Model.ModelInfo.PrimaryKeyTypeName;
+    string bindProperties = string.Join(",", Model.ModelInfo.ModelProperties?.Select(p => p.Name) ?? Enumerable.Empty<string>());
 #>
 
 using Microsoft.AspNetCore.Mvc;
@@ -76,7 +77,7 @@ public class <#= Model.ControllerName #> : Controller
     // For more details, see http://go.microsoft.com/fwlink/?LinkId=317598.
     [HttpPost]
     [ValidateAntiForgeryToken]
-    public async Task<IActionResult> Create([Bind("Title,ReleaseDate,Genre,Price")] <#= modelName #> movie)
+    public async Task<IActionResult> Create([Bind("<#= bindProperties #>")] <#= modelName #> <#= modelNameLowerInv #>)
     {
         if (ModelState.IsValid)
         {
@@ -108,7 +109,7 @@ public class <#= Model.ControllerName #> : Controller
     // For more details, see http://go.microsoft.com/fwlink/?LinkId=317598.
     [HttpPost]
     [ValidateAntiForgeryToken]
-    public async Task<IActionResult> Edit(<#= primaryKeyTypeName #>? <#= primaryKeyNameLowerInv #>, [Bind("Id,Title,ReleaseDate,Genre,Price")] <#= modelName #> movie)
+    public async Task<IActionResult> Edit(<#= primaryKeyTypeName #>? <#= primaryKeyNameLowerInv #>, [Bind("<#= bindProperties #>")] <#= modelName #> <#= modelNameLowerInv #>)
     {
         if (<#= primaryKeyNameLowerInv #> != <#= modelNameLowerInv #>.<#= primaryKeyName #>)
         {

--- a/test/dotnet-scaffolding/dotnet-scaffold.Tests/AspNet/Templates/MvcEfControllerTemplateTests.cs
+++ b/test/dotnet-scaffolding/dotnet-scaffold.Tests/AspNet/Templates/MvcEfControllerTemplateTests.cs
@@ -284,7 +284,7 @@ namespace Models
                 PrimaryKeyShortTypeName = "int",
                 ModelProperties = properties
             },
-            ProjectInfo = new AspNetProjectInfo(Path.Combine("test", "TestProject.csproj"))
+            ProjectInfo = new AspNetProjectInfo(null)
         };
     }
 

--- a/test/dotnet-scaffolding/dotnet-scaffold.Tests/AspNet/Templates/MvcEfControllerTemplateTests.cs
+++ b/test/dotnet-scaffolding/dotnet-scaffold.Tests/AspNet/Templates/MvcEfControllerTemplateTests.cs
@@ -1,0 +1,387 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.DotNet.Tools.Scaffold.AspNet.Common;
+using Microsoft.DotNet.Tools.Scaffold.AspNet.Models;
+using Xunit;
+
+using AspNetProjectInfo = Microsoft.DotNet.Tools.Scaffold.AspNet.Common.ProjectInfo;
+
+using Net9MvcEfController = Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net9.EfController.MvcEfController;
+using Net10MvcEfController = Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.EfController.MvcEfController;
+using Net11MvcEfController = Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.EfController.MvcEfController;
+
+namespace Microsoft.DotNet.Tools.Scaffold.Tests.AspNet.Templates;
+
+/// <summary>
+/// Tests for the MvcEfController template to verify that the [Bind] attribute and
+/// action parameter names are generated from the actual model properties, not
+/// hardcoded values (regression for "movie" bug).
+/// </summary>
+public class MvcEfControllerTemplateTests
+{
+    #region Net9 — [Bind] uses actual model properties
+
+    [Fact]
+    public void Net9_Create_BindAttribute_ContainsActualModelProperties()
+    {
+        // Arrange – Blog model: BlogId (PK), Url
+        EfControllerModel model = CreateBlogEfControllerModel();
+        var template = CreateNet9Template(model);
+
+        // Act
+        string result = template.TransformText();
+
+        // Assert – must contain the real property names, not "Title,ReleaseDate,Genre,Price"
+        Assert.Contains("[Bind(\"BlogId,Url\")]", result);
+    }
+
+    [Fact]
+    public void Net9_Create_ParameterName_UsesModelNameLowerCase()
+    {
+        // Arrange
+        EfControllerModel model = CreateBlogEfControllerModel();
+        var template = CreateNet9Template(model);
+
+        // Act
+        string result = template.TransformText();
+
+        // Assert – parameter must be named 'blog', not 'movie'
+        Assert.Contains("Create([Bind(", result);
+        Assert.Contains("] Blog blog)", result);
+        Assert.DoesNotContain("] Blog movie)", result);
+    }
+
+    [Fact]
+    public void Net9_Edit_BindAttribute_ContainsActualModelProperties()
+    {
+        // Arrange
+        EfControllerModel model = CreateBlogEfControllerModel();
+        var template = CreateNet9Template(model);
+
+        // Act
+        string result = template.TransformText();
+
+        // Assert – Edit POST [Bind] must use real properties, not "Id,Title,ReleaseDate,Genre,Price"
+        // There are two [Bind] occurrences; both should reference the real property names.
+        int bindOccurrences = CountOccurrences(result, "[Bind(\"BlogId,Url\")]");
+        Assert.Equal(2, bindOccurrences);
+    }
+
+    [Fact]
+    public void Net9_Edit_ParameterName_UsesModelNameLowerCase()
+    {
+        // Arrange
+        EfControllerModel model = CreateBlogEfControllerModel();
+        var template = CreateNet9Template(model);
+
+        // Act
+        string result = template.TransformText();
+
+        // Assert – Edit POST parameter must be named 'blog', not 'movie'
+        Assert.DoesNotContain("] Blog movie)", result);
+        Assert.Contains("] Blog blog)", result);
+    }
+
+    [Fact]
+    public void Net9_DoesNotContainHardcodedMovieProperties()
+    {
+        // Arrange
+        EfControllerModel model = CreateBlogEfControllerModel();
+        var template = CreateNet9Template(model);
+
+        // Act
+        string result = template.TransformText();
+
+        // Assert
+        Assert.DoesNotContain("Title,ReleaseDate,Genre,Price", result);
+        Assert.DoesNotContain("Id,Title,ReleaseDate,Genre,Price", result);
+        Assert.DoesNotContain(" movie)", result);
+    }
+
+    [Fact]
+    public void Net9_Create_BindAttribute_UsesProductProperties()
+    {
+        // Arrange – Product model: ProductId (PK), Name, Price
+        EfControllerModel model = CreateProductEfControllerModel();
+        var template = CreateNet9Template(model);
+
+        // Act
+        string result = template.TransformText();
+
+        // Assert
+        Assert.Contains("[Bind(\"ProductId,Name,Price\")]", result);
+        Assert.Contains("] Product product)", result);
+    }
+
+    #endregion
+
+    #region Net10 — [Bind] uses actual model properties
+
+    [Fact]
+    public void Net10_Create_BindAttribute_ContainsActualModelProperties()
+    {
+        // Arrange
+        EfControllerModel model = CreateBlogEfControllerModel();
+        var template = CreateNet10Template(model);
+
+        // Act
+        string result = template.TransformText();
+
+        // Assert
+        Assert.Contains("[Bind(\"BlogId,Url\")]", result);
+    }
+
+    [Fact]
+    public void Net10_Create_ParameterName_UsesModelNameLowerCase()
+    {
+        // Arrange
+        EfControllerModel model = CreateBlogEfControllerModel();
+        var template = CreateNet10Template(model);
+
+        // Act
+        string result = template.TransformText();
+
+        // Assert
+        Assert.Contains("] Blog blog)", result);
+        Assert.DoesNotContain("] Blog movie)", result);
+    }
+
+    [Fact]
+    public void Net10_Edit_BindAttribute_ContainsActualModelProperties()
+    {
+        // Arrange
+        EfControllerModel model = CreateBlogEfControllerModel();
+        var template = CreateNet10Template(model);
+
+        // Act
+        string result = template.TransformText();
+
+        // Assert
+        int bindOccurrences = CountOccurrences(result, "[Bind(\"BlogId,Url\")]");
+        Assert.Equal(2, bindOccurrences);
+    }
+
+    [Fact]
+    public void Net10_DoesNotContainHardcodedMovieProperties()
+    {
+        // Arrange
+        EfControllerModel model = CreateBlogEfControllerModel();
+        var template = CreateNet10Template(model);
+
+        // Act
+        string result = template.TransformText();
+
+        // Assert
+        Assert.DoesNotContain("Title,ReleaseDate,Genre,Price", result);
+        Assert.DoesNotContain("Id,Title,ReleaseDate,Genre,Price", result);
+        Assert.DoesNotContain(" movie)", result);
+    }
+
+    #endregion
+
+    #region Net11 — [Bind] uses actual model properties
+
+    [Fact]
+    public void Net11_Create_BindAttribute_ContainsActualModelProperties()
+    {
+        // Arrange
+        EfControllerModel model = CreateBlogEfControllerModel();
+        var template = CreateNet11Template(model);
+
+        // Act
+        string result = template.TransformText();
+
+        // Assert
+        Assert.Contains("[Bind(\"BlogId,Url\")]", result);
+    }
+
+    [Fact]
+    public void Net11_Create_ParameterName_UsesModelNameLowerCase()
+    {
+        // Arrange
+        EfControllerModel model = CreateBlogEfControllerModel();
+        var template = CreateNet11Template(model);
+
+        // Act
+        string result = template.TransformText();
+
+        // Assert
+        Assert.Contains("] Blog blog)", result);
+        Assert.DoesNotContain("] Blog movie)", result);
+    }
+
+    [Fact]
+    public void Net11_Edit_BindAttribute_ContainsActualModelProperties()
+    {
+        // Arrange
+        EfControllerModel model = CreateBlogEfControllerModel();
+        var template = CreateNet11Template(model);
+
+        // Act
+        string result = template.TransformText();
+
+        // Assert
+        int bindOccurrences = CountOccurrences(result, "[Bind(\"BlogId,Url\")]");
+        Assert.Equal(2, bindOccurrences);
+    }
+
+    [Fact]
+    public void Net11_DoesNotContainHardcodedMovieProperties()
+    {
+        // Arrange
+        EfControllerModel model = CreateBlogEfControllerModel();
+        var template = CreateNet11Template(model);
+
+        // Act
+        string result = template.TransformText();
+
+        // Assert
+        Assert.DoesNotContain("Title,ReleaseDate,Genre,Price", result);
+        Assert.DoesNotContain("Id,Title,ReleaseDate,Genre,Price", result);
+        Assert.DoesNotContain(" movie)", result);
+    }
+
+    #endregion
+
+    #region Helpers
+
+    private static EfControllerModel CreateBlogEfControllerModel()
+    {
+        List<IPropertySymbol> properties = GetPropertiesFromCode(@"
+namespace Models
+{
+    public class Blog
+    {
+        public int BlogId { get; set; }
+        public string? Url { get; set; }
+    }
+}", "Blog");
+
+        return new EfControllerModel
+        {
+            ControllerType = "MVC",
+            ControllerName = "BlogsController",
+            ControllerOutputPath = Path.Combine("Controllers", "BlogsController.cs"),
+            DbContextInfo = new DbContextInfo
+            {
+                DbContextClassName = "BloggingContext",
+                DbContextNamespace = "Models",
+                EfScenario = true,
+                EntitySetVariableName = "Blogs"
+            },
+            ModelInfo = new ModelInfo
+            {
+                ModelTypeName = "Blog",
+                ModelNamespace = "Models",
+                ModelFullName = "Models.Blog",
+                PrimaryKeyName = "BlogId",
+                PrimaryKeyTypeName = "int",
+                PrimaryKeyShortTypeName = "int",
+                ModelProperties = properties
+            },
+            ProjectInfo = new AspNetProjectInfo(Path.Combine("test", "TestProject.csproj"))
+        };
+    }
+
+    private static EfControllerModel CreateProductEfControllerModel()
+    {
+        List<IPropertySymbol> properties = GetPropertiesFromCode(@"
+namespace Models
+{
+    public class Product
+    {
+        public int ProductId { get; set; }
+        public string Name { get; set; }
+        public decimal Price { get; set; }
+    }
+}", "Product");
+
+        return new EfControllerModel
+        {
+            ControllerType = "MVC",
+            ControllerName = "ProductsController",
+            ControllerOutputPath = Path.Combine("Controllers", "ProductsController.cs"),
+            DbContextInfo = new DbContextInfo
+            {
+                DbContextClassName = "AppDbContext",
+                DbContextNamespace = "Models",
+                EfScenario = true,
+                EntitySetVariableName = "Products"
+            },
+            ModelInfo = new ModelInfo
+            {
+                ModelTypeName = "Product",
+                ModelNamespace = "Models",
+                ModelFullName = "Models.Product",
+                PrimaryKeyName = "ProductId",
+                PrimaryKeyTypeName = "int",
+                PrimaryKeyShortTypeName = "int",
+                ModelProperties = properties
+            },
+            ProjectInfo = new AspNetProjectInfo(Path.Combine("test", "TestProject.csproj"))
+        };
+    }
+
+    private static List<IPropertySymbol> GetPropertiesFromCode(string source, string typeName)
+    {
+        SyntaxTree syntaxTree = CSharpSyntaxTree.ParseText(source);
+        MetadataReference[] references =
+        [
+            MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+        ];
+        CSharpCompilation compilation = CSharpCompilation.Create(
+            "TestAssembly",
+            [syntaxTree],
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        INamedTypeSymbol? symbol = compilation.GetTypeByMetadataName($"Models.{typeName}")
+            ?? compilation.GetSymbolsWithName(typeName, SymbolFilter.Type).OfType<INamedTypeSymbol>().FirstOrDefault()
+            ?? throw new System.Exception($"Type '{typeName}' not found in compilation");
+
+        return symbol.GetMembers().OfType<IPropertySymbol>().ToList();
+    }
+
+    private static Net9MvcEfController CreateNet9Template(EfControllerModel model)
+    {
+        var template = new Net9MvcEfController();
+        template.Session = new Dictionary<string, object> { { "Model", model } };
+        template.Initialize();
+        return template;
+    }
+
+    private static Net10MvcEfController CreateNet10Template(EfControllerModel model)
+    {
+        var template = new Net10MvcEfController();
+        template.Session = new Dictionary<string, object> { { "Model", model } };
+        template.Initialize();
+        return template;
+    }
+
+    private static Net11MvcEfController CreateNet11Template(EfControllerModel model)
+    {
+        var template = new Net11MvcEfController();
+        template.Session = new Dictionary<string, object> { { "Model", model } };
+        template.Initialize();
+        return template;
+    }
+
+    private static int CountOccurrences(string source, string value)
+    {
+        int count = 0;
+        int index = 0;
+        while ((index = source.IndexOf(value, index, System.StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            index += value.Length;
+        }
+        return count;
+    }
+
+    #endregion
+}


### PR DESCRIPTION
fix [AzDo bug](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2941859)
This bug is coming from the fact that some values in the template files used for code generation are hard coded. This change removes those hard coded values that were causing these errors. Furthermore, additional tests are added. 
