### PR TITLE
ensure that the controllers namespace is correct

### DIFF
--- a/src/Shared/Microsoft.DotNet.Scaffolding.Shared/CodeModifier/DocumentBuilder.cs
+++ b/src/Shared/Microsoft.DotNet.Scaffolding.Shared/CodeModifier/DocumentBuilder.cs
@@ -109,10 +109,10 @@ namespace Microsoft.DotNet.Scaffolding.Shared.CodeModifier
             if (_codeFile.ClassProperties != null && _codeFile.ClassProperties.Any() && classDeclarationSyntax != null)
             {
                 _codeFile.ClassProperties = ProjectModifierHelper.FilterCodeBlocks(_codeFile.ClassProperties, options);
-                //get a sample member for leading trivia. Trailing trivia will still be semi colon and new line.
+                // get a sample member for leading trivia; trailing trivia should only add a newline.
                 var sampleMember = modifiedClassDeclarationSyntax.Members.FirstOrDefault();
                 var memberLeadingTrivia = sampleMember?.GetLeadingTrivia() ?? SyntaxFactory.TriviaList(SyntaxFactory.Whitespace("    "));
-                var memberTrailingTrivia = SyntaxFactory.TriviaList(SemiColonTrivia, SyntaxFactory.CarriageReturnLineFeed);
+                var memberTrailingTrivia = SyntaxFactory.TriviaList(SyntaxFactory.CarriageReturnLineFeed);
 
                 //create MemberDeclarationSyntax[] with all the Property strings. 
                 var classProperties = CreateClassProperties(modifiedClassDeclarationSyntax.Members, memberLeadingTrivia, memberTrailingTrivia);

--- a/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.CodeModification/CodeModification/DocumentBuilder.cs
+++ b/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.CodeModification/CodeModification/DocumentBuilder.cs
@@ -185,10 +185,10 @@ internal class DocumentBuilder
         if (_codeFile.ClassProperties != null && _codeFile.ClassProperties.Any() && classDeclarationSyntax != null)
         {
             _codeFile.ClassProperties = ProjectModifierHelper.FilterCodeBlocks(_codeFile.ClassProperties, options);
-            //get a sample member for leading trivia. Trailing trivia will still be semi colon and new line.
+            // get a sample member for leading trivia; trailing trivia should only add a newline.
             var sampleMember = modifiedClassDeclarationSyntax.Members.FirstOrDefault();
             var memberLeadingTrivia = sampleMember?.GetLeadingTrivia() ?? SyntaxFactory.TriviaList(SyntaxFactory.Whitespace("    "));
-            var memberTrailingTrivia = SyntaxFactory.TriviaList(SemiColonTrivia, SyntaxFactory.CarriageReturnLineFeed);
+            var memberTrailingTrivia = SyntaxFactory.TriviaList(SyntaxFactory.CarriageReturnLineFeed);
 
             //create MemberDeclarationSyntax[] with all the Property strings. 
             var classProperties = CreateClassProperties(modifiedClassDeclarationSyntax.Members, memberLeadingTrivia, memberTrailingTrivia);

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Common/ClassAnalyzers.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Common/ClassAnalyzers.cs
@@ -37,13 +37,20 @@ internal static class ClassAnalyzers
             dbContextInfo.DbContextClassName = existingDbContextClass.Name;
             dbContextInfo.DbContextClassPath = existingDbContextClass.Locations.FirstOrDefault()?.SourceTree?.FilePath;
             dbContextInfo.DbContextNamespace = existingDbContextClass.ContainingNamespace.ToDisplayString();
-            dbContextInfo.EntitySetVariableName = modelInfo is null ?
-                string.Empty : EfDbContextHelpers.GetEntitySetVariableName(existingDbContextClass, modelInfo.ModelTypeName, modelInfo.ModelFullName) ?? string.Empty;
+            var discoveredEntitySetName = modelInfo is null
+                ? string.Empty
+                : EfDbContextHelpers.GetEntitySetVariableName(existingDbContextClass, modelInfo.ModelTypeName, modelInfo.ModelFullName) ?? string.Empty;
 
-            // If the DbSet for this model doesn't exist in the existing context yet, prepare the statement to add it.
-            if (string.IsNullOrEmpty(dbContextInfo.EntitySetVariableName) && modelInfo is not null)
+            // If the DbSet for this model doesn't exist in the existing context yet, prepare the statement to add it
+            // and use the model type name as the controller's entity set reference.
+            if (string.IsNullOrWhiteSpace(discoveredEntitySetName) && modelInfo is not null)
             {
                 dbContextInfo.NewDbSetStatement = $"public DbSet<{modelInfo.ModelFullName}> {modelInfo.ModelTypeName} {{ get; set; }} = default!;";
+                dbContextInfo.EntitySetVariableName = modelInfo.ModelTypeName;
+            }
+            else
+            {
+                dbContextInfo.EntitySetVariableName = discoveredEntitySetName;
             }
         }
         //properties for creating a new DbContext

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/ScaffoldSteps/AddDbSetToExistingContextStep.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/ScaffoldSteps/AddDbSetToExistingContextStep.cs
@@ -54,7 +54,13 @@ internal class AddDbSetToExistingContextStep : ScaffoldStep
         //     handled by WithDbContextStep via its T4 template which already includes the DbSet).
         //   A DbSet statement was produced (only set when GetDbContextInfo found no existing DbSet).
         //   The project path is available to initialise the Roslyn workspace.
-        if (string.IsNullOrEmpty(dbContextPath) || !File.Exists(dbContextPath) || string.IsNullOrEmpty(dbSetStatement) || string.IsNullOrEmpty(ProjectPath))
+        if (string.IsNullOrEmpty(dbContextPath) || !File.Exists(dbContextPath) || string.IsNullOrWhiteSpace(dbSetStatement) || string.IsNullOrEmpty(ProjectPath))
+        {
+            return true;
+        }
+
+        dbSetStatement = NormalizeDbSetStatement(dbSetStatement);
+        if (string.IsNullOrWhiteSpace(dbSetStatement))
         {
             return true;
         }
@@ -96,6 +102,8 @@ internal class AddDbSetToExistingContextStep : ScaffoldStep
     /// </summary>
     internal static string BuildCodeModifierConfig(string dbContextFileName, string dbSetStatement)
     {
+        dbSetStatement = NormalizeDbSetStatement(dbSetStatement);
+
         object config = new
         {
             Files = new[]
@@ -112,6 +120,18 @@ internal class AddDbSetToExistingContextStep : ScaffoldStep
         };
 
         return JsonSerializer.Serialize(config);
+    }
+
+    internal static string NormalizeDbSetStatement(string dbSetStatement)
+    {
+        if (string.IsNullOrWhiteSpace(dbSetStatement))
+        {
+            return string.Empty;
+        }
+
+        string normalized = dbSetStatement.Trim();
+        normalized = normalized.TrimEnd(';').TrimEnd();
+        return string.IsNullOrWhiteSpace(normalized) ? string.Empty : $"{normalized};";
     }
 
     /// <summary>

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net10.0/EfController/MvcEfController.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net10.0/EfController/MvcEfController.cs
@@ -32,7 +32,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.EfController
     string modelNameLowerInv = modelName.ToLowerInvariant();
     string dbContextNamespace = string.IsNullOrEmpty(Model.DbContextInfo.DbContextNamespace) ? string.Empty : Model.DbContextInfo.DbContextNamespace;
     string dbContextName = Model.DbContextInfo.DbContextClassName;
-    string entitySetName = Model.DbContextInfo.EntitySetVariableName ?? modelName;
+    string entitySetName = string.IsNullOrWhiteSpace(Model.DbContextInfo.EntitySetVariableName) ? modelName : Model.DbContextInfo.EntitySetVariableName;
     string modelNamespace = Model.ModelInfo.ModelNamespace;
     string primaryKeyName = Model.ModelInfo.PrimaryKeyName;
     string primaryKeyNameLowerInv = primaryKeyName.ToLowerInvariant();

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net10.0/EfController/MvcEfController.tt
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net10.0/EfController/MvcEfController.tt
@@ -10,7 +10,7 @@
     string modelNameLowerInv = modelName.ToLowerInvariant();
     string dbContextNamespace = string.IsNullOrEmpty(Model.DbContextInfo.DbContextNamespace) ? string.Empty : Model.DbContextInfo.DbContextNamespace;
     string dbContextName = Model.DbContextInfo.DbContextClassName;
-    string entitySetName = Model.DbContextInfo.EntitySetVariableName ?? modelName;
+    string entitySetName = string.IsNullOrWhiteSpace(Model.DbContextInfo.EntitySetVariableName) ? modelName : Model.DbContextInfo.EntitySetVariableName;
     string modelNamespace = Model.ModelInfo.ModelNamespace;
     string primaryKeyName = Model.ModelInfo.PrimaryKeyName;
     string primaryKeyNameLowerInv = primaryKeyName.ToLowerInvariant();

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/EfController/MvcEfController.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/EfController/MvcEfController.cs
@@ -32,7 +32,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.EfController
     string modelNameLowerInv = modelName.ToLowerInvariant();
     string dbContextNamespace = string.IsNullOrEmpty(Model.DbContextInfo.DbContextNamespace) ? string.Empty : Model.DbContextInfo.DbContextNamespace;
     string dbContextName = Model.DbContextInfo.DbContextClassName;
-    string entitySetName = Model.DbContextInfo.EntitySetVariableName ?? modelName;
+    string entitySetName = string.IsNullOrWhiteSpace(Model.DbContextInfo.EntitySetVariableName) ? modelName : Model.DbContextInfo.EntitySetVariableName;
     string modelNamespace = Model.ModelInfo.ModelNamespace;
     string primaryKeyName = Model.ModelInfo.PrimaryKeyName;
     string primaryKeyNameLowerInv = primaryKeyName.ToLowerInvariant();

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/EfController/MvcEfController.tt
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/EfController/MvcEfController.tt
@@ -10,7 +10,7 @@
     string modelNameLowerInv = modelName.ToLowerInvariant();
     string dbContextNamespace = string.IsNullOrEmpty(Model.DbContextInfo.DbContextNamespace) ? string.Empty : Model.DbContextInfo.DbContextNamespace;
     string dbContextName = Model.DbContextInfo.DbContextClassName;
-    string entitySetName = Model.DbContextInfo.EntitySetVariableName ?? modelName;
+    string entitySetName = string.IsNullOrWhiteSpace(Model.DbContextInfo.EntitySetVariableName) ? modelName : Model.DbContextInfo.EntitySetVariableName;
     string modelNamespace = Model.ModelInfo.ModelNamespace;
     string primaryKeyName = Model.ModelInfo.PrimaryKeyName;
     string primaryKeyNameLowerInv = primaryKeyName.ToLowerInvariant();

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net9.0/EfController/MvcEfController.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net9.0/EfController/MvcEfController.cs
@@ -32,7 +32,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net9.EfController
     string modelNameLowerInv = modelName.ToLowerInvariant();
     string dbContextNamespace = string.IsNullOrEmpty(Model.DbContextInfo.DbContextNamespace) ? string.Empty : Model.DbContextInfo.DbContextNamespace;
     string dbContextName = Model.DbContextInfo.DbContextClassName;
-    string entitySetName = Model.DbContextInfo.EntitySetVariableName ?? modelName;
+    string entitySetName = string.IsNullOrWhiteSpace(Model.DbContextInfo.EntitySetVariableName) ? modelName : Model.DbContextInfo.EntitySetVariableName;
     string modelNamespace = Model.ModelInfo.ModelNamespace;
     string primaryKeyName = Model.ModelInfo.PrimaryKeyName;
     string primaryKeyNameLowerInv = primaryKeyName.ToLowerInvariant();

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net9.0/EfController/MvcEfController.tt
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net9.0/EfController/MvcEfController.tt
@@ -10,7 +10,7 @@
     string modelNameLowerInv = modelName.ToLowerInvariant();
     string dbContextNamespace = string.IsNullOrEmpty(Model.DbContextInfo.DbContextNamespace) ? string.Empty : Model.DbContextInfo.DbContextNamespace;
     string dbContextName = Model.DbContextInfo.DbContextClassName;
-    string entitySetName = Model.DbContextInfo.EntitySetVariableName ?? modelName;
+    string entitySetName = string.IsNullOrWhiteSpace(Model.DbContextInfo.EntitySetVariableName) ? modelName : Model.DbContextInfo.EntitySetVariableName;
     string modelNamespace = Model.ModelInfo.ModelNamespace;
     string primaryKeyName = Model.ModelInfo.PrimaryKeyName;
     string primaryKeyNameLowerInv = primaryKeyName.ToLowerInvariant();

--- a/test/dotnet-scaffolding/dotnet-scaffold.Tests/AspNet/Common/ClassAnalyzersTests.cs
+++ b/test/dotnet-scaffolding/dotnet-scaffold.Tests/AspNet/Common/ClassAnalyzersTests.cs
@@ -358,8 +358,8 @@ namespace MyApp.Data
         // Assert
         Assert.NotNull(result);
         Assert.Equal("ApplicationDbContext", result.DbContextClassName);
-        // EntitySetVariableName should be empty (not found)
-        Assert.True(string.IsNullOrEmpty(result.EntitySetVariableName));
+        // EntitySetVariableName should fall back to model name when DbSet is missing.
+        Assert.Equal("Movie", result.EntitySetVariableName);
         // NewDbSetStatement must be set so AddDbSetToExistingContextStep can insert it
         Assert.NotNull(result.NewDbSetStatement);
         Assert.Contains("DbSet<MyApp.Data.Movie>", result.NewDbSetStatement);
@@ -428,7 +428,7 @@ namespace MyApp.Data
 
         // Assert
         Assert.NotNull(result);
-        Assert.True(string.IsNullOrEmpty(result.EntitySetVariableName));
+        Assert.Equal(string.Empty, result.EntitySetVariableName);
         Assert.Null(result.NewDbSetStatement);
     }
 

--- a/test/dotnet-scaffolding/dotnet-scaffold.Tests/AspNet/ScaffoldSteps/AddDbSetToExistingContextStepTests.cs
+++ b/test/dotnet-scaffolding/dotnet-scaffold.Tests/AspNet/ScaffoldSteps/AddDbSetToExistingContextStepTests.cs
@@ -194,6 +194,23 @@ public class AddDbSetToExistingContextStepTests : IDisposable
         Assert.Equal(dbSetStatement, block.GetString());
     }
 
+    [Fact]
+    public void BuildCodeModifierConfig_NormalizesTrailingSemicolons()
+    {
+        const string fileName = "AppDb.cs";
+        const string dbSetStatementWithExtraSemicolons = "public DbSet<MyApp.Models.Movie> Movie { get; set; } = default!;;;";
+
+        string json = AddDbSetToExistingContextStep.BuildCodeModifierConfig(fileName, dbSetStatementWithExtraSemicolons);
+
+        JsonDocument doc = JsonDocument.Parse(json);
+        JsonElement block = doc.RootElement
+            .GetProperty("Files")[0]
+            .GetProperty("ClassProperties")[0]
+            .GetProperty("Block");
+
+        Assert.Equal("public DbSet<MyApp.Models.Movie> Movie { get; set; } = default!;", block.GetString());
+    }
+
     // -----------------------------------------------------------------------
     // Scenario 9: ProjectPath is exposed as a settable property
     // -----------------------------------------------------------------------
@@ -284,6 +301,16 @@ public class AddDbSetToExistingContextStepTests : IDisposable
         const string fileContent = "public class Ctx { public string Foo { get; set; } }";
 
         Assert.False(AddDbSetToExistingContextStep.DbSetAlreadyPresent(fileContent, statement));
+    }
+
+    [Fact]
+    public void NormalizeDbSetStatement_EnsuresSingleTrailingSemicolon()
+    {
+        const string statement = "  public DbSet<Movie> Movie { get; set; } = default!;;  ";
+
+        string normalized = AddDbSetToExistingContextStep.NormalizeDbSetStatement(statement);
+
+        Assert.Equal("public DbSet<Movie> Movie { get; set; } = default!;", normalized);
     }
 }
 

--- a/test/dotnet-scaffolding/dotnet-scaffold.Tests/AspNet/Templates/MvcEfControllerTemplateTests.cs
+++ b/test/dotnet-scaffolding/dotnet-scaffold.Tests/AspNet/Templates/MvcEfControllerTemplateTests.cs
@@ -118,6 +118,32 @@ public class MvcEfControllerTemplateTests
     }
 
     [Fact]
+    public void Net9_WhenEntitySetVariableNameEmpty_FallsBackToModelName()
+    {
+        EfControllerModel model = CreateBlogEfControllerModel();
+        model.DbContextInfo.EntitySetVariableName = string.Empty;
+        var template = CreateNet9Template(model);
+
+        string result = template.TransformText();
+
+        Assert.Contains("_context.Blog.ToListAsync()", result);
+        Assert.DoesNotContain("_context..ToListAsync()", result);
+    }
+
+    [Fact]
+    public void Net9_WhenEntitySetVariableNameWhitespace_FallsBackToModelName()
+    {
+        EfControllerModel model = CreateBlogEfControllerModel();
+        model.DbContextInfo.EntitySetVariableName = "   ";
+        var template = CreateNet9Template(model);
+
+        string result = template.TransformText();
+
+        Assert.Contains("_context.Blog.ToListAsync()", result);
+        Assert.DoesNotContain("_context.   .ToListAsync()", result);
+    }
+
+    [Fact]
     public void Net9_Create_BindAttribute_UsesProductProperties()
     {
         // Arrange – Product model: ProductId (PK), Name, Price
@@ -207,6 +233,32 @@ public class MvcEfControllerTemplateTests
         Assert.DoesNotContain(" movie)", result);
     }
 
+    [Fact]
+    public void Net10_WhenEntitySetVariableNameEmpty_FallsBackToModelName()
+    {
+        EfControllerModel model = CreateBlogEfControllerModel();
+        model.DbContextInfo.EntitySetVariableName = string.Empty;
+        var template = CreateNet10Template(model);
+
+        string result = template.TransformText();
+
+        Assert.Contains("_context.Blog.ToListAsync()", result);
+        Assert.DoesNotContain("_context..ToListAsync()", result);
+    }
+
+    [Fact]
+    public void Net10_WhenEntitySetVariableNameWhitespace_FallsBackToModelName()
+    {
+        EfControllerModel model = CreateBlogEfControllerModel();
+        model.DbContextInfo.EntitySetVariableName = "   ";
+        var template = CreateNet10Template(model);
+
+        string result = template.TransformText();
+
+        Assert.Contains("_context.Blog.ToListAsync()", result);
+        Assert.DoesNotContain("_context.   .ToListAsync()", result);
+    }
+
     #endregion
 
     #region Net11 — [Bind] uses actual model properties
@@ -280,6 +332,32 @@ public class MvcEfControllerTemplateTests
         Assert.DoesNotContain("Title,ReleaseDate,Genre,Price", result);
         Assert.DoesNotContain("Id,Title,ReleaseDate,Genre,Price", result);
         Assert.DoesNotContain(" movie)", result);
+    }
+
+    [Fact]
+    public void Net11_WhenEntitySetVariableNameEmpty_FallsBackToModelName()
+    {
+        EfControllerModel model = CreateBlogEfControllerModel();
+        model.DbContextInfo.EntitySetVariableName = string.Empty;
+        var template = CreateNet11Template(model);
+
+        string result = template.TransformText();
+
+        Assert.Contains("_context.Blog.ToListAsync()", result);
+        Assert.DoesNotContain("_context..ToListAsync()", result);
+    }
+
+    [Fact]
+    public void Net11_WhenEntitySetVariableNameWhitespace_FallsBackToModelName()
+    {
+        EfControllerModel model = CreateBlogEfControllerModel();
+        model.DbContextInfo.EntitySetVariableName = "   ";
+        var template = CreateNet11Template(model);
+
+        string result = template.TransformText();
+
+        Assert.Contains("_context.Blog.ToListAsync()", result);
+        Assert.DoesNotContain("_context.   .ToListAsync()", result);
     }
 
     #endregion


### PR DESCRIPTION
Sometimes `dbContextInfo.EntitySetVariableName` is empty which was causing the namespace for the DBContext in a pre-exisiting database was screwed up. This PR ensures that this value is populated correctly and there is an additional bug with an extra semicolon being generated. 

