### PR TITLE
Resolve ArgumentIsEmpty Error after ef migrations

### DIFF
--- a/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Core/NuGet/Package.cs
+++ b/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Core/NuGet/Package.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.Extensions.Logging;
 using NuGet.Versioning;
+using System.Xml.Linq;
 
 namespace Microsoft.DotNet.Scaffolding.Core.Model;
 
@@ -19,6 +20,18 @@ internal sealed record Package(string Name, bool IsVersionRequired = false)
 
 internal static class PackageExtensions
 {
+    private static readonly StringComparer PackageNameComparer = StringComparer.OrdinalIgnoreCase;
+    private static readonly string[] AspNetEfVersionAnchorPackages =
+    [
+        PackageNameConstants.AspNetCorePackages.IdentityEntityFrameworkCorePackageName,
+        PackageNameConstants.AspNetCorePackages.DiagnosticsEntityFrameworkCorePackageName
+    ];
+
+    public static Task<Package> WithResolvedVersionAsync(this Package package, TargetFramework? targetFramework, NuGetVersionService nugetVersionHelper, ILogger? logger)
+    {
+        return package.WithResolvedVersionAsync(targetFramework, nugetVersionHelper, projectPath: null, logger: logger);
+    }
+
     /// <summary>
     /// Returns a copy of the specified package with its version property resolved for the given target framework, if
     /// the version is not already set.
@@ -29,16 +42,17 @@ internal static class PackageExtensions
     /// <param name="package">The package instance for which to resolve the version. Must not be null.</param>
     /// <param name="targetFramework">The target framework identifier used to determine the appropriate package version. For example, "net6.0".</param>
     /// <param name="nugetVersionHelper">The NuGet version helper to use for version resolution.</param>
+    /// <param name="projectPath">The path to the target project file. Used for project-specific version alignment.</param>
     /// <param name="logger">The logger to use for logging messages.</param>
     /// <returns>A package instance with the version property set to the resolved version for the specified target framework, or
     /// the original package if the version is already set or cannot be resolved.</returns>
-    public static async Task<Package> WithResolvedVersionAsync(this Package package, TargetFramework? targetFramework, NuGetVersionService nugetVersionHelper, ILogger? logger = null)
+    public static async Task<Package> WithResolvedVersionAsync(this Package package, TargetFramework? targetFramework, NuGetVersionService nugetVersionHelper, string? projectPath = null, ILogger? logger = null)
     {
         if (package.PackageVersion is not null)
         {
             return package;
         }
-        NuGetVersion? resolvedVersion = await package.GetVersionForTargetFrameworkAsync(targetFramework, nugetVersionHelper, logger);
+        NuGetVersion? resolvedVersion = await package.GetVersionForTargetFrameworkAsync(targetFramework, nugetVersionHelper, projectPath, logger);
         if (resolvedVersion is null)
         {
             return package;
@@ -56,10 +70,11 @@ internal static class PackageExtensions
     /// <param name="targetFramework">The target framework identifier (for example, "net8.0", "net9.0", "net10.0" or "net11.0") for which the package version is
     /// requested. Case-insensitive.</param>
     /// <param name="nugetVersionHelper">The NuGet version helper to use for version resolution.</param>
+    /// <param name="projectPath">The path to the target project file. Used for project-specific version alignment.</param>
     /// <param name="logger">The logger to use for logging messages.</param>
     /// <returns>A task that represents the asynchronous operation. The task result contains the corresponding NuGet package
     /// version if available; otherwise, <see langword="null"/> if the package does not require a version or target framework is not supported.</returns>
-    private static Task<NuGetVersion?> GetVersionForTargetFrameworkAsync(this Package package, TargetFramework? targetFramework, NuGetVersionService nugetVersionHelper, ILogger? logger = null)
+    private static Task<NuGetVersion?> GetVersionForTargetFrameworkAsync(this Package package, TargetFramework? targetFramework, NuGetVersionService nugetVersionHelper, string? projectPath = null, ILogger? logger = null)
     {
         if (!package.IsVersionRequired)
         {
@@ -70,6 +85,11 @@ internal static class PackageExtensions
         {
             logger?.LogError("Project contains a Target Framework that is not supported. Supported Target Frameworks are .NET8, .NET9, .NET10, .NET11. Installing latest stable version of '{PackageName}'. Consider upgrading your Target Framework to install a compatible package version.", package.Name);
             return Task.FromResult<NuGetVersion?>(null);
+        }
+
+        if (TryResolveAspNetAlignedEfVersion(package.Name, projectPath, out NuGetVersion? alignedVersion))
+        {
+            return Task.FromResult<NuGetVersion?>(alignedVersion);
         }
 
         if (targetFramework is TargetFramework.Net8)
@@ -93,5 +113,82 @@ internal static class PackageExtensions
             logger?.LogError("Target Framework '{TargetFramework}' is not supported. Supported Target Frameworks are .NET8, .NET9, .NET10, .NET11. Installing latest stable version of '{PackageName}'. Consider upgrading your Target Framework to install a compatible package version.", targetFramework, package.Name);
             return Task.FromResult<NuGetVersion?>(null);
         }
+    }
+
+    private static bool TryResolveAspNetAlignedEfVersion(string packageName, string? projectPath, out NuGetVersion? version)
+    {
+        version = null;
+
+        if (string.IsNullOrWhiteSpace(projectPath) ||
+            !packageName.StartsWith(PackageNameConstants.AspNetCorePackages.EntityFrameworkPackageNamePrefix, StringComparison.OrdinalIgnoreCase) ||
+            !File.Exists(projectPath))
+        {
+            return false;
+        }
+
+        try
+        {
+            XDocument projectDocument = XDocument.Load(projectPath);
+            if (projectDocument.Root is not XElement root)
+            {
+                return false;
+            }
+
+            XName packageReference = root.Name.Namespace + "PackageReference";
+
+            foreach (string anchorPackage in AspNetEfVersionAnchorPackages)
+            {
+                NuGetVersion? matchedVersion = projectDocument
+                    .Descendants(packageReference)
+                    .Where(p => PackageNameComparer.Equals((string?)p.Attribute("Include"), anchorPackage))
+                    .Select(GetPackageReferenceVersion)
+                    .Where(v => NuGetVersion.TryParse(v, out _))
+                    .Select(v => NuGetVersion.Parse(v!))
+                    .FirstOrDefault();
+
+                if (matchedVersion is not null)
+                {
+                    version = matchedVersion;
+                    return true;
+                }
+            }
+        }
+        catch
+        {
+            return false;
+        }
+
+        return false;
+    }
+
+    private static string? GetPackageReferenceVersion(XElement packageReference)
+    {
+        string? version = (string?)packageReference.Attribute("Version");
+        if (!string.IsNullOrWhiteSpace(version))
+        {
+            return version;
+        }
+
+        string? versionOverride = (string?)packageReference.Attribute("VersionOverride");
+        if (!string.IsNullOrWhiteSpace(versionOverride))
+        {
+            return versionOverride;
+        }
+
+        XName versionElementName = packageReference.Name.Namespace + "Version";
+        XElement? versionElement = packageReference.Element(versionElementName);
+        if (versionElement is not null && !string.IsNullOrWhiteSpace(versionElement.Value))
+        {
+            return versionElement.Value;
+        }
+
+        XName versionOverrideElementName = packageReference.Name.Namespace + "VersionOverride";
+        XElement? versionOverrideElement = packageReference.Element(versionOverrideElementName);
+        if (versionOverrideElement is not null && !string.IsNullOrWhiteSpace(versionOverrideElement.Value))
+        {
+            return versionOverrideElement.Value;
+        }
+
+        return null;
     }
 }

--- a/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Core/NuGet/PackageNameConstants.cs
+++ b/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Core/NuGet/PackageNameConstants.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.DotNet.Scaffolding.Core.Model;
+
+public static class PackageNameConstants
+{
+    public static class AspNetCorePackages
+    {
+        public const string IdentityEntityFrameworkCorePackageName = "Microsoft.AspNetCore.Identity.EntityFrameworkCore";
+        public const string DiagnosticsEntityFrameworkCorePackageName = "Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore";
+
+        public const string EntityFrameworkPackageNamePrefix = "Microsoft.EntityFrameworkCore.";
+    }
+}

--- a/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Core/Steps/AddPackagesStep.cs
+++ b/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Core/Steps/AddPackagesStep.cs
@@ -58,7 +58,7 @@ internal class AddPackagesStep : ScaffoldStep
             Package resolvedPackage = package;
             if (package.IsVersionRequired && !Prerelease)
             {
-                resolvedPackage = await package.WithResolvedVersionAsync(targetFramework, _nugetVersionHelper, _logger);
+                resolvedPackage = await package.WithResolvedVersionAsync(targetFramework, _nugetVersionHelper, ProjectPath, _logger);
                 packageVersion = resolvedPackage.PackageVersion;
             }
 

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Common/PackageConstants.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Common/PackageConstants.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-using Microsoft.CodeAnalysis.Elfie.Serialization;
 using Microsoft.DotNet.Scaffolding.Core.Model;
 
 namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Common;
@@ -65,9 +64,9 @@ internal class PackageConstants
     public static class AspNetCorePackages
     {
         public static readonly Package QuickGridEfAdapterPackage = new("Microsoft.AspNetCore.Components.QuickGrid.EntityFrameworkAdapter", IsVersionRequired: true);
-        public static readonly Package AspNetCoreDiagnosticsEfCorePackage = new("Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore", IsVersionRequired: true);
+        public static readonly Package AspNetCoreDiagnosticsEfCorePackage = new(PackageNameConstants.AspNetCorePackages.DiagnosticsEntityFrameworkCorePackageName, IsVersionRequired: true);
         public static readonly Package OpenApiPackage = new("Microsoft.AspNetCore.OpenApi", IsVersionRequired: true);
-        public static readonly Package AspNetCoreIdentityEfPackage = new("Microsoft.AspNetCore.Identity.EntityFrameworkCore", IsVersionRequired: true);
+        public static readonly Package AspNetCoreIdentityEfPackage = new(PackageNameConstants.AspNetCorePackages.IdentityEntityFrameworkCorePackageName, IsVersionRequired: true);
         public static readonly Package AspNetCoreIdentityUiPackage = new("Microsoft.AspNetCore.Identity.UI", IsVersionRequired: true);
         public static readonly Package AspNetCoreComponentsWebAssemblyAuthenticationPackage = new("Microsoft.AspNetCore.Components.WebAssembly.Authentication", IsVersionRequired: true);
         public static readonly Package AspNetCoreAuthenticationJwtBearerPackage = new("Microsoft.AspNetCore.Authentication.JwtBearer", IsVersionRequired: true);

--- a/test/dotnet-scaffolding/dotnet-scaffold.Tests/Models/PackageTests.cs
+++ b/test/dotnet-scaffolding/dotnet-scaffold.Tests/Models/PackageTests.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Threading.Tasks;
+using System;
+using System.IO;
 using Microsoft.DotNet.Scaffolding.Core.Model;
 using Microsoft.DotNet.Scaffolding.Internal.Services;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -80,6 +82,41 @@ public class PackageTests
         // Assert
         Assert.NotNull(result.PackageVersion);
         Assert.NotEqual(package, result);
+    }
+
+    [Fact]
+    public async Task WithResolvedVersionAsync_Net10EfPackage_UsesAspNetReferenceVersion()
+    {
+        // Arrange
+        string tempProjectPath = Path.Combine(Path.GetTempPath(), $"{nameof(PackageTests)}-{Guid.NewGuid():N}.csproj");
+        await File.WriteAllTextAsync(
+            tempProjectPath,
+            """
+            <Project Sdk="Microsoft.NET.Sdk.Web">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+              </PropertyGroup>
+              <ItemGroup>
+                <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="10.0.0-preview.5.25277.114" />
+              </ItemGroup>
+            </Project>
+            """);
+
+        Package package = new Package("Microsoft.EntityFrameworkCore.Tools", IsVersionRequired: true);
+
+        try
+        {
+            // Act
+            Package result = await package.WithResolvedVersionAsync(TargetFramework.Net10, _nugetVersionService, tempProjectPath);
+
+            // Assert
+            Assert.Equal("10.0.0-preview.5.25277.114", result.PackageVersion);
+            Assert.NotEqual(package, result);
+        }
+        finally
+        {
+            File.Delete(tempProjectPath);
+        }
     }
 
     [Fact]


### PR DESCRIPTION
fixes [Azdo bug 2960694](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2960694)
The issue that sometimes users can have a version of the Entity Framework packages specified in their csproj file, but when adding a new entity framework version we would just add the most recent non prerelease version of the package. Now, match the package version to that existing in the csproj file. 

