### PR TITLE
Ensure build after API with read write endpoints

### DIFF
--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/MinimalApi/MinimalApiEf.cshtml
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/MinimalApi/MinimalApiEf.cshtml
@@ -107,7 +107,7 @@ public static class @endPointsClassName
             @:var affected = await db.@entitySetName
                 @:.Where(model => model.@primaryKeyName == @primaryKeyNameLowerCase)
                 @:.ExecuteUpdateAsync(setters => setters
-    //should be atleast one property (primary key)
+    //should be atleast one property
     foreach(var modelProperty in entityProperties)
     {
         string modelPropertyName = modelProperty.PropertyName;

--- a/src/Scaffolding/VS.Web.CG.Mvc/Templates/MinimalApi/MinimalApiEfNoClass.cshtml
+++ b/src/Scaffolding/VS.Web.CG.Mvc/Templates/MinimalApi/MinimalApiEfNoClass.cshtml
@@ -97,7 +97,7 @@
             @:var affected = await db.@entitySetName
                 @:.Where(model => model.@primaryKeyName == @primaryKeyNameLowerCase)
                 @:.ExecuteUpdateAsync(setters => setters
-    //should be atleast one property (primary key)
+    //should be atleast one property
     foreach(var modelProperty in entityProperties)
     {
         string modelPropertyName = modelProperty.PropertyName;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net10.0/MinimalApi/MinimalApiEf.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net10.0/MinimalApi/MinimalApiEf.cs
@@ -40,8 +40,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.MinimalApi
     string dbContextName = Model.DbContextInfo.DbContextClassName;
     var entitySetName = Model.DbContextInfo.EntitySetVariableName ?? modelName;
     var entitySetNoTracking = $"{entitySetName}.AsNoTracking()";
-    var entityProperties =  Model.ModelInfo.ModelProperties
-        .Where(x => !x.Name.Equals(Model.ModelInfo.PrimaryKeyName, StringComparison.OrdinalIgnoreCase)).ToList();
+    var entityProperties =  Model.ModelInfo.ModelProperties;
     var primaryKeyName = Model.ModelInfo.PrimaryKeyName;
     var primaryKeyNameLowerCase = primaryKeyName.ToLowerInvariant();
     var primaryKeyShortTypeName = Model.ModelInfo.PrimaryKeyShortTypeName;
@@ -176,7 +175,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net10.MinimalApi
             this.Write(this.ToStringHelper.ToStringWithCulture(primaryKeyNameLowerCase));
             this.Write(")\r\n                .ExecuteUpdateAsync(setters => setters\r\n        ");
 
-            //should be atleast one property (primary key)
+            //should be atleast one property
             foreach(var modelProperty in entityProperties)
             {
                 string modelPropertyName = modelProperty.Name;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net10.0/MinimalApi/MinimalApiEf.tt
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net10.0/MinimalApi/MinimalApiEf.tt
@@ -18,8 +18,7 @@
     string dbContextName = Model.DbContextInfo.DbContextClassName;
     var entitySetName = Model.DbContextInfo.EntitySetVariableName ?? modelName;
     var entitySetNoTracking = $"{entitySetName}.AsNoTracking()";
-    var entityProperties =  Model.ModelInfo.ModelProperties
-        .Where(x => !x.Name.Equals(Model.ModelInfo.PrimaryKeyName, StringComparison.OrdinalIgnoreCase)).ToList();
+    var entityProperties =  Model.ModelInfo.ModelProperties;
     var primaryKeyName = Model.ModelInfo.PrimaryKeyName;
     var primaryKeyNameLowerCase = primaryKeyName.ToLowerInvariant();
     var primaryKeyShortTypeName = Model.ModelInfo.PrimaryKeyShortTypeName;
@@ -115,7 +114,7 @@ public static class <#= Model.EndpointsClassName #>
                 .Where(model => model.<#= primaryKeyName #> == <#= primaryKeyNameLowerCase #>)
                 .ExecuteUpdateAsync(setters => setters
         <#
-            //should be atleast one property (primary key)
+            //should be atleast one property
             foreach(var modelProperty in entityProperties)
             {
                 string modelPropertyName = modelProperty.Name;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/MinimalApi/MinimalApiEf.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/MinimalApi/MinimalApiEf.cs
@@ -40,8 +40,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.MinimalApi
     string dbContextName = Model.DbContextInfo.DbContextClassName;
     var entitySetName = Model.DbContextInfo.EntitySetVariableName ?? modelName;
     var entitySetNoTracking = $"{entitySetName}.AsNoTracking()";
-    var entityProperties =  Model.ModelInfo.ModelProperties
-        .Where(x => !x.Name.Equals(Model.ModelInfo.PrimaryKeyName, StringComparison.OrdinalIgnoreCase)).ToList();
+    var entityProperties =  Model.ModelInfo.ModelProperties;
     var primaryKeyName = Model.ModelInfo.PrimaryKeyName;
     var primaryKeyNameLowerCase = primaryKeyName.ToLowerInvariant();
     var primaryKeyShortTypeName = Model.ModelInfo.PrimaryKeyShortTypeName;
@@ -176,7 +175,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net11.MinimalApi
             this.Write(this.ToStringHelper.ToStringWithCulture(primaryKeyNameLowerCase));
             this.Write(")\r\n                .ExecuteUpdateAsync(setters => setters\r\n        ");
 
-            //should be atleast one property (primary key)
+            //should be atleast one property
             foreach(var modelProperty in entityProperties)
             {
                 string modelPropertyName = modelProperty.Name;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/MinimalApi/MinimalApiEf.tt
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net11.0/MinimalApi/MinimalApiEf.tt
@@ -18,8 +18,7 @@
     string dbContextName = Model.DbContextInfo.DbContextClassName;
     var entitySetName = Model.DbContextInfo.EntitySetVariableName ?? modelName;
     var entitySetNoTracking = $"{entitySetName}.AsNoTracking()";
-    var entityProperties =  Model.ModelInfo.ModelProperties
-        .Where(x => !x.Name.Equals(Model.ModelInfo.PrimaryKeyName, StringComparison.OrdinalIgnoreCase)).ToList();
+    var entityProperties =  Model.ModelInfo.ModelProperties;
     var primaryKeyName = Model.ModelInfo.PrimaryKeyName;
     var primaryKeyNameLowerCase = primaryKeyName.ToLowerInvariant();
     var primaryKeyShortTypeName = Model.ModelInfo.PrimaryKeyShortTypeName;
@@ -115,7 +114,7 @@ public static class <#= Model.EndpointsClassName #>
                 .Where(model => model.<#= primaryKeyName #> == <#= primaryKeyNameLowerCase #>)
                 .ExecuteUpdateAsync(setters => setters
         <#
-            //should be atleast one property (primary key)
+            //should be atleast one property
             foreach(var modelProperty in entityProperties)
             {
                 string modelPropertyName = modelProperty.Name;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net8.0/MinimalApi/MinimalApiEf.cshtml
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net8.0/MinimalApi/MinimalApiEf.cshtml
@@ -125,7 +125,7 @@ public static class @endPointsClassName
             @:var affected = await db.@entitySetName
                 @:.Where(model => model.@primaryKeyName == @primaryKeyNameLowerCase)
                 @:.ExecuteUpdateAsync(setters => setters
-    //should be atleast one property (primary key)
+    //should be atleast one property
     foreach(var modelProperty in entityProperties)
     {
         string modelPropertyName = modelProperty.PropertyName;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net8.0/MinimalApi/MinimalApiEfNoClass.cshtml
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net8.0/MinimalApi/MinimalApiEfNoClass.cshtml
@@ -114,7 +114,7 @@
             @:var affected = await db.@entitySetName
                 @:.Where(model => model.@primaryKeyName == @primaryKeyNameLowerCase)
                 @:.ExecuteUpdateAsync(setters => setters
-    //should be atleast one property (primary key)
+    //should be atleast one property
     foreach(var modelProperty in entityProperties)
     {
         string modelPropertyName = modelProperty.PropertyName;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net9.0/MinimalApi/MinimalApiEf.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net9.0/MinimalApi/MinimalApiEf.cs
@@ -40,8 +40,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net9.MinimalApi
     string dbContextName = Model.DbContextInfo.DbContextClassName;
     var entitySetName = Model.DbContextInfo.EntitySetVariableName ?? modelName;
     var entitySetNoTracking = $"{entitySetName}.AsNoTracking()";
-    var entityProperties =  Model.ModelInfo.ModelProperties
-        .Where(x => !x.Name.Equals(Model.ModelInfo.PrimaryKeyName, StringComparison.OrdinalIgnoreCase)).ToList();
+    var entityProperties =  Model.ModelInfo.ModelProperties;
     var primaryKeyName = Model.ModelInfo.PrimaryKeyName;
     var primaryKeyNameLowerCase = primaryKeyName.ToLowerInvariant();
     var primaryKeyShortTypeName = Model.ModelInfo.PrimaryKeyShortTypeName;
@@ -176,7 +175,7 @@ namespace Microsoft.DotNet.Tools.Scaffold.AspNet.Templates.net9.MinimalApi
             this.Write(this.ToStringHelper.ToStringWithCulture(primaryKeyNameLowerCase));
             this.Write(")\r\n                .ExecuteUpdateAsync(setters => setters\r\n        ");
 
-            //should be atleast one property (primary key)
+            //should be atleast one property
             foreach(var modelProperty in entityProperties)
             {
                 string modelPropertyName = modelProperty.Name;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net9.0/MinimalApi/MinimalApiEf.tt
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Templates/net9.0/MinimalApi/MinimalApiEf.tt
@@ -18,8 +18,7 @@
     string dbContextName = Model.DbContextInfo.DbContextClassName;
     var entitySetName = Model.DbContextInfo.EntitySetVariableName ?? modelName;
     var entitySetNoTracking = $"{entitySetName}.AsNoTracking()";
-    var entityProperties =  Model.ModelInfo.ModelProperties
-        .Where(x => !x.Name.Equals(Model.ModelInfo.PrimaryKeyName, StringComparison.OrdinalIgnoreCase)).ToList();
+    var entityProperties =  Model.ModelInfo.ModelProperties;
     var primaryKeyName = Model.ModelInfo.PrimaryKeyName;
     var primaryKeyNameLowerCase = primaryKeyName.ToLowerInvariant();
     var primaryKeyShortTypeName = Model.ModelInfo.PrimaryKeyShortTypeName;
@@ -115,7 +114,7 @@ public static class <#= Model.EndpointsClassName #>
                 .Where(model => model.<#= primaryKeyName #> == <#= primaryKeyNameLowerCase #>)
                 .ExecuteUpdateAsync(setters => setters
         <#
-            //should be atleast one property (primary key)
+            //should be atleast one property
             foreach(var modelProperty in entityProperties)
             {
                 string modelPropertyName = modelProperty.Name;

--- a/test/dotnet-scaffolding/dotnet-scaffold.Tests/AspNet/Templates/MinimalApiTemplateTests.cs
+++ b/test/dotnet-scaffolding/dotnet-scaffold.Tests/AspNet/Templates/MinimalApiTemplateTests.cs
@@ -2,6 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.DotNet.Scaffolding.TextTemplating;
 using Microsoft.DotNet.Tools.Scaffold.AspNet.Common;
 using Microsoft.DotNet.Tools.Scaffold.AspNet.Models;
@@ -182,6 +185,17 @@ public class MinimalApiTemplateTests
 
     private MinimalApiModel CreateTestMinimalApiModel(bool efScenario, bool useTypedResults)
     {
+        List<IPropertySymbol> properties = GetPropertiesFromCode(@"
+namespace TestProject.Models
+{
+    public class Product
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+        public decimal Price { get; set; }
+    }
+}", "Product");
+
         return new MinimalApiModel
         {
             OpenAPI = true,
@@ -206,9 +220,9 @@ public class MinimalApiTemplateTests
                 PrimaryKeyName = "Id",
                 PrimaryKeyShortTypeName = "int",
                 PrimaryKeyTypeName = "System.Int32",
-                ModelProperties = new List<Microsoft.CodeAnalysis.IPropertySymbol>()
+                ModelProperties = properties
             },
-            ProjectInfo = new ProjectInfo(Path.Combine("test", "project", "TestProject.csproj"))
+            ProjectInfo = new Microsoft.DotNet.Tools.Scaffold.AspNet.Common.ProjectInfo(Path.Combine("test", "project", "TestProject.csproj"))
         };
     }
 
@@ -597,4 +611,45 @@ public class MinimalApiTemplateTests
     }
 
     #endregion
+
+    #region SetProperty Tests
+
+    [Fact]
+    public void MinimalApiEf_MapPut_GeneratesSetPropertyCalls()
+    {
+        // Arrange
+        var model = CreateTestMinimalApiModel(efScenario: true, useTypedResults: true);
+        var template = CreateMinimalApiEfTemplate(model);
+
+        // Act
+        var result = template.TransformText();
+
+        // Assert - SetProperty calls should be generated for all model properties
+        Assert.Contains(".SetProperty(m => m.Id, product.Id)", result);
+        Assert.Contains(".SetProperty(m => m.Name, product.Name)", result);
+        Assert.Contains(".SetProperty(m => m.Price, product.Price)", result);
+        Assert.Contains("ExecuteUpdateAsync(setters => setters", result);
+    }
+
+    #endregion
+
+    private static List<IPropertySymbol> GetPropertiesFromCode(string source, string typeName)
+    {
+        SyntaxTree syntaxTree = CSharpSyntaxTree.ParseText(source);
+        MetadataReference[] references =
+        [
+            MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+        ];
+        CSharpCompilation compilation = CSharpCompilation.Create(
+            "TestAssembly",
+            [syntaxTree],
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        INamedTypeSymbol? symbol = compilation.GetTypeByMetadataName($"TestProject.Models.{typeName}")
+            ?? compilation.GetSymbolsWithName(typeName, SymbolFilter.Type).OfType<INamedTypeSymbol>().FirstOrDefault()
+            ?? throw new System.Exception($"Type '{typeName}' not found in compilation");
+
+        return symbol.GetMembers().OfType<IPropertySymbol>().ToList();
+    }
 }


### PR DESCRIPTION
fixes #3733 
 
There `Where()` in the Minimal EF templates is invalid and causing this invalid partial code. 

**MinimalApiEf.tt** (net9.0, net10.0, net11.0) — removed the .Where() primary key filter from `entityProperties`, so all model properties are included in `SetProperty` calls (matching the legacy .cshtml template behavior)

**MinimalApiEf.cs** (net9.0, net10.0, net11.0) — same fix in the generated T4 output files

**MinimalApiTemplateTests.cs**— the test model previously used an empty `ModelProperties` list. Now uses real `IPropertySymbol` objects (via Roslyn compilation) and includes a new `MinimalApiEf_MapPut_GeneratesSetPropertyCalls` test that verifies `.SetProperty()` calls are generated for all properties.