### PR TITLE
Disable NuGet audit in CI to avoid restore failures and failing CI

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -30,7 +30,8 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <NuGetAudit>true</NuGetAudit>
+    <NuGetAudit Condition="'$(TF_BUILD)' == 'true'">false</NuGetAudit>
+    <NuGetAudit Condition="'$(TF_BUILD)' != 'true'">true</NuGetAudit>
     <NuGetAuditMode>all</NuGetAuditMode>
     <NuGetAuditLevel>low</NuGetAuditLevel>
   </PropertyGroup>


### PR DESCRIPTION
the official pipeline is failing because the audit information is not available during this stage, hopefully this change unblocks the official pipeline. 


