### PR TITLE
Remove NuGet audit to fix release build failure

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -24,15 +24,8 @@
   <PropertyGroup Label="Package and Assembly Metadata">
     <Product>Microsoft ASP.NET Core</Product>
   </PropertyGroup>
-
+  
   <ItemGroup>
     <None Include="$(RepoRoot)NOTICE.txt" Pack="true" PackagePath="" />
   </ItemGroup>
-
-  <PropertyGroup>
-    <NuGetAudit Condition="'$(TF_BUILD)' == 'true'">false</NuGetAudit>
-    <NuGetAudit Condition="'$(TF_BUILD)' != 'true'">true</NuGetAudit>
-    <NuGetAuditMode>all</NuGetAuditMode>
-    <NuGetAuditLevel>low</NuGetAuditLevel>
-  </PropertyGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -55,6 +55,5 @@
   <ItemGroup>
     <!-- Pinned transitive package versions for Component Governance alerts -->
     <PackageVersion Include="System.Formats.Asn1" Version="$(SystemFormatsAsn1Version)" />
-    <PackageVersion Include="System.Security.Cryptography.Xml" Version="$(SystemSecurityCryptographyXmlVersion)" />
   </ItemGroup>
 </Project>

--- a/NuGet.config
+++ b/NuGet.config
@@ -23,9 +23,5 @@
     <add key="dotnet-libraries" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-libraries/nuget/v3/index.json" />
     <add key="dotnet6-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6-transport/nuget/v3/index.json" />
   </packageSources>
-  <auditSources>
-    <clear />
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-  </auditSources>
   <disabledPackageSources />
 </configuration>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -21,13 +21,13 @@
     <MicrosoftEntityFrameworkCorePackageVersion10>10.0.3</MicrosoftEntityFrameworkCorePackageVersion10>
     <MicrosoftEntityFrameworkCorePackageVersion9>9.0.13</MicrosoftEntityFrameworkCorePackageVersion9>
     <MicrosoftEntityFrameworkCorePackageVersion8>8.0.24</MicrosoftEntityFrameworkCorePackageVersion8>
-
+    
     <!-- Microsoft.EntityFrameworkCore.SqlServer - TFM-specific versions -->
     <MicrosoftEntityFrameworkCoreSqlServerPackageVersion>11.0.0-preview.1.26104.118</MicrosoftEntityFrameworkCoreSqlServerPackageVersion>
     <MicrosoftEntityFrameworkCoreSqlServerPackageVersion10>10.0.3</MicrosoftEntityFrameworkCoreSqlServerPackageVersion10>
     <MicrosoftEntityFrameworkCoreSqlServerPackageVersion9>9.0.13</MicrosoftEntityFrameworkCoreSqlServerPackageVersion9>
     <MicrosoftEntityFrameworkCoreSqlServerPackageVersion8>8.0.24</MicrosoftEntityFrameworkCoreSqlServerPackageVersion8>
-
+    
     <!-- Microsoft.Extensions.DependencyInjection -->
     <MicrosoftExtensionsDependencyInjectionPackageVersion>11.0.0-preview.1.26104.118</MicrosoftExtensionsDependencyInjectionPackageVersion>
     <!-- Microsoft.Extensions.FileProviders.Physical -->
@@ -70,8 +70,6 @@
     <MicrosoftExtensionsConfigurationBinderPackageVersion>11.0.0-preview.1.26104.118</MicrosoftExtensionsConfigurationBinderPackageVersion>
     <!-- Microsoft.Extensions.Configuration.CommandLine -->
     <MicrosoftExtensionsConfigurationCommandLinePackageVersion>11.0.0-preview.1.26104.118</MicrosoftExtensionsConfigurationCommandLinePackageVersion>
-    <!-- System.Security.Cryptography.Xml -->
-    <SystemSecurityCryptographyXmlVersion>9.0.15</SystemSecurityCryptographyXmlVersion>
     <!-- System.Text.Json -->
     <SystemTextJsonPackageVersion>11.0.0-preview.1.26104.118</SystemTextJsonPackageVersion>
     <SpectreConsoleFlowVersion>0.5.638</SpectreConsoleFlowVersion>
@@ -103,11 +101,11 @@
     <MicrosoftBuildPackageVersion>18.3.3</MicrosoftBuildPackageVersion>
     <MicrosoftBuildPackageVersion9>17.13.26</MicrosoftBuildPackageVersion9>
     <MicrosoftBuildPackageVersion8>17.11.48</MicrosoftBuildPackageVersion8>
-
+    
     <MicrosoftBuildTasksCorePackageVersion>18.3.3</MicrosoftBuildTasksCorePackageVersion>
     <MicrosoftBuildTasksCorePackageVersion9>17.13.26</MicrosoftBuildTasksCorePackageVersion9>
     <MicrosoftBuildTasksCorePackageVersion8>17.11.48</MicrosoftBuildTasksCorePackageVersion8>
-
+    
     <!-- Microsoft.Build.Utilities - TFM-specific versions -->
     <MicrosoftBuildUtilitiesCorePackageVersion>18.3.3</MicrosoftBuildUtilitiesCorePackageVersion>
     <MicrosoftBuildUtilitiesCorePackageVersion9>17.13.26</MicrosoftBuildUtilitiesCorePackageVersion9>

--- a/src/dotnet-scaffolding/Directory.Packages.props
+++ b/src/dotnet-scaffolding/Directory.Packages.props
@@ -33,10 +33,9 @@
     <PackageVersion Include="Spectre.Console" Version="$(SpectreConsoleVersion)" />
     <PackageVersion Include="Spectre.Console.Cli" Version="$(SpectreConsoleVersion)" />
     <PackageVersion Include="System.CommandLine" Version="$(SystemCommandLinePackageVersion)" />
-    <PackageVersion Include="System.Security.Cryptography.Xml" Version="$(SystemSecurityCryptographyXmlVersion)" />
   </ItemGroup>
   <!-- <ItemGroup>
-     Pins for Component Governance Alerts
+     Pins for Component Governance Alerts 
     <PackageVersion Include="System.Formats.Asn1" Version="9.0.0" />
     <PackageVersion Include="System.Text.Json" Version="9.0.0" />
   </ItemGroup> -->


### PR DESCRIPTION
The release build agent cannot reach api.nuget.org for vulnerability data, causing the toolset restore to fail. The auditSources section is unnecessary since NuGetAudit is already disabled in CI via Directory.Build.props.