### PR TITLE
Ensure Linux files created with the same name as on Windows

### DIFF
--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/ScaffoldSteps/DotnetNewScaffolderStep.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/ScaffoldSteps/DotnetNewScaffolderStep.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-using System.Globalization;
 using Microsoft.DotNet.Scaffolding.Core.Scaffolders;
 using Microsoft.DotNet.Scaffolding.Core.Steps;
 using Microsoft.DotNet.Scaffolding.Internal.CliHelpers;
@@ -132,8 +131,8 @@ internal class DotnetNewScaffolderStep : ScaffoldStep
         }
         else
         {
-            //Component names cannot start with a lowercase character, using CurrentCulture to capitalize the first letter
-            FileName = CultureInfo.CurrentCulture.TextInfo.ToTitleCase(FileName);
+            //Component names cannot start with a lowercase character, capitalize the first letter only
+            FileName = char.ToUpper(FileName[0]) + FileName.Substring(1);
         }
 
         return new DotnetNewStepSettings

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/ScaffoldSteps/EmptyControllerScaffolderStep.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/ScaffoldSteps/EmptyControllerScaffolderStep.cs
@@ -1,6 +1,5 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
-using System.Globalization;
 using Microsoft.DotNet.Scaffolding.Core.Scaffolders;
 using Microsoft.DotNet.Scaffolding.Core.Steps;
 using Microsoft.DotNet.Scaffolding.Internal.CliHelpers;
@@ -114,8 +113,8 @@ internal class EmptyControllerScaffolderStep : ScaffoldStep
         }
         else
         {
-            //Component names cannot start with a lowercase character, using CurrentCulture to capitalize the first letter
-            FileName = CultureInfo.CurrentCulture.TextInfo.ToTitleCase(FileName);
+            //Component names cannot start with a lowercase character, capitalize the first letter only
+            FileName = char.ToUpper(FileName[0]) + FileName.Substring(1);
         }
 
         return new EmptyControllerStepSettings

--- a/test/dotnet-scaffolding/dotnet-scaffold.Tests/AspNet/Integration/Blazor/RazorComponentNet10IntegrationTests.cs
+++ b/test/dotnet-scaffolding/dotnet-scaffold.Tests/AspNet/Integration/Blazor/RazorComponentNet10IntegrationTests.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -405,22 +404,22 @@ public class RazorComponentNet10IntegrationTests : IDisposable
 
     #endregion
 
-    #region DotnetNewScaffolderStep — Title Casing
+    #region DotnetNewScaffolderStep — First Character Uppercasing
 
     [Theory]
     [InlineData("product", "Product")]
-    [InlineData("productCard", "Productcard")]
+    [InlineData("productCard", "ProductCard")]
     [InlineData("UPPERCASE", "UPPERCASE")]
     [InlineData("a", "A")]
-    public void TitleCase_CapitalizesFirstLetter(string input, string expected)
+    public void FirstCharUppercase_CapitalizesFirstLetter(string input, string expected)
     {
-        // The step uses CultureInfo.CurrentCulture.TextInfo.ToTitleCase to capitalize the first letter
-        string result = CultureInfo.CurrentCulture.TextInfo.ToTitleCase(input);
+        // The step only capitalizes the first character, preserving the rest
+        string result = char.ToUpper(input[0]) + input.Substring(1);
         Assert.Equal(expected, result);
     }
 
     [Fact]
-    public async Task ExecuteAsync_TitleCasesFileName_WhenLowercaseProvided()
+    public async Task ExecuteAsync_CapitalizesFirstChar_WhenLowercaseProvided()
     {
         // Arrange
         string componentsDir = Path.Combine(_testProjectDir, "Components");
@@ -440,13 +439,12 @@ public class RazorComponentNet10IntegrationTests : IDisposable
         // Act
         await step.ExecuteAsync(_context, CancellationToken.None);
 
-        // Assert — after validation, FileName should be title-cased
-        string expected = CultureInfo.CurrentCulture.TextInfo.ToTitleCase("myComponent");
-        Assert.Equal(expected, step.FileName);
+        // Assert — after validation, only first char should be uppercased
+        Assert.Equal("MyComponent", step.FileName);
     }
 
     [Fact]
-    public async Task ExecuteAsync_AppliesTitleCase_WhenAlreadyCapitalized()
+    public async Task ExecuteAsync_PreservesFileName_WhenAlreadyCapitalized()
     {
         // Arrange
         string componentsDir = Path.Combine(_testProjectDir, "Components");
@@ -466,9 +464,8 @@ public class RazorComponentNet10IntegrationTests : IDisposable
         // Act
         await step.ExecuteAsync(_context, CancellationToken.None);
 
-        // Assert — ToTitleCase treats "ProductCard" as a single word, lowering inner capitalization
-        string expected = CultureInfo.CurrentCulture.TextInfo.ToTitleCase("ProductCard");
-        Assert.Equal(expected, step.FileName);
+        // Assert — already capitalized, name should be preserved
+        Assert.Equal("ProductCard", step.FileName);
     }
 
     #endregion

--- a/test/dotnet-scaffolding/dotnet-scaffold.Tests/AspNet/Integration/Blazor/RazorComponentNet11IntegrationTests.cs
+++ b/test/dotnet-scaffolding/dotnet-scaffold.Tests/AspNet/Integration/Blazor/RazorComponentNet11IntegrationTests.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -404,22 +403,22 @@ public class RazorComponentNet11IntegrationTests : IDisposable
 
     #endregion
 
-    #region DotnetNewScaffolderStep — Title Casing
+    #region DotnetNewScaffolderStep — First Character Uppercasing
 
     [Theory]
     [InlineData("product", "Product")]
-    [InlineData("productCard", "Productcard")]
+    [InlineData("productCard", "ProductCard")]
     [InlineData("UPPERCASE", "UPPERCASE")]
     [InlineData("a", "A")]
-    public void TitleCase_CapitalizesFirstLetter(string input, string expected)
+    public void FirstCharUppercase_CapitalizesFirstLetter(string input, string expected)
     {
-        // The step uses CultureInfo.CurrentCulture.TextInfo.ToTitleCase to capitalize the first letter
-        string result = CultureInfo.CurrentCulture.TextInfo.ToTitleCase(input);
+        // The step only capitalizes the first character, preserving the rest
+        string result = char.ToUpper(input[0]) + input.Substring(1);
         Assert.Equal(expected, result);
     }
 
     [Fact]
-    public async Task ExecuteAsync_TitleCasesFileName_WhenLowercaseProvided()
+    public async Task ExecuteAsync_CapitalizesFirstChar_WhenLowercaseProvided()
     {
         // Arrange
         string componentsDir = Path.Combine(_testProjectDir, "Components");
@@ -439,9 +438,8 @@ public class RazorComponentNet11IntegrationTests : IDisposable
         // Act
         await step.ExecuteAsync(_context, CancellationToken.None);
 
-        // Assert — after validation, FileName should be title-cased
-        string expected = CultureInfo.CurrentCulture.TextInfo.ToTitleCase("myComponent");
-        Assert.Equal(expected, step.FileName);
+        // Assert — after validation, only first char should be uppercased
+        Assert.Equal("MyComponent", step.FileName);
     }
 
     [Fact]
@@ -465,9 +463,8 @@ public class RazorComponentNet11IntegrationTests : IDisposable
         // Act
         await step.ExecuteAsync(_context, CancellationToken.None);
 
-        // Assert — ToTitleCase treats "ProductCard" as a single word, lowering inner capitalization
-        string expected = CultureInfo.CurrentCulture.TextInfo.ToTitleCase("ProductCard");
-        Assert.Equal(expected, step.FileName);
+        // Assert — already capitalized, name should be preserved
+        Assert.Equal("ProductCard", step.FileName);
     }
 
     #endregion

--- a/test/dotnet-scaffolding/dotnet-scaffold.Tests/AspNet/Integration/Blazor/RazorComponentNet8IntegrationTests.cs
+++ b/test/dotnet-scaffolding/dotnet-scaffold.Tests/AspNet/Integration/Blazor/RazorComponentNet8IntegrationTests.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -380,21 +379,22 @@ public class RazorComponentNet8IntegrationTests : IDisposable
 
     #endregion
 
-    #region DotnetNewScaffolderStep — Title Casing
+    #region DotnetNewScaffolderStep — First Character Uppercasing
 
     [Theory]
     [InlineData("product", "Product")]
-    [InlineData("productCard", "Productcard")]
+    [InlineData("productCard", "ProductCard")]
     [InlineData("UPPERCASE", "UPPERCASE")]
     [InlineData("a", "A")]
-    public void TitleCase_CapitalizesFirstLetter(string input, string expected)
+    public void FirstCharUppercase_CapitalizesFirstLetter(string input, string expected)
     {
-        string result = CultureInfo.CurrentCulture.TextInfo.ToTitleCase(input);
+        // The step only capitalizes the first character, preserving the rest
+        string result = char.ToUpper(input[0]) + input.Substring(1);
         Assert.Equal(expected, result);
     }
 
     [Fact]
-    public async Task ExecuteAsync_TitleCasesFileName_WhenLowercaseProvided()
+    public async Task ExecuteAsync_CapitalizesFirstChar_WhenLowercaseProvided()
     {
         string componentsDir = Path.Combine(_testProjectDir, "Components");
         _mockFileSystem.Setup(fs => fs.FileExists(_testProjectPath)).Returns(true);
@@ -412,12 +412,11 @@ public class RazorComponentNet8IntegrationTests : IDisposable
 
         await step.ExecuteAsync(_context, CancellationToken.None);
 
-        string expected = CultureInfo.CurrentCulture.TextInfo.ToTitleCase("myComponent");
-        Assert.Equal(expected, step.FileName);
+        Assert.Equal("MyComponent", step.FileName);
     }
 
     [Fact]
-    public async Task ExecuteAsync_AppliesTitleCase_WhenAlreadyCapitalized()
+    public async Task ExecuteAsync_PreservesFileName_WhenAlreadyCapitalized()
     {
         string componentsDir = Path.Combine(_testProjectDir, "Components");
         _mockFileSystem.Setup(fs => fs.FileExists(_testProjectPath)).Returns(true);
@@ -435,8 +434,7 @@ public class RazorComponentNet8IntegrationTests : IDisposable
 
         await step.ExecuteAsync(_context, CancellationToken.None);
 
-        string expected = CultureInfo.CurrentCulture.TextInfo.ToTitleCase("ProductCard");
-        Assert.Equal(expected, step.FileName);
+        Assert.Equal("ProductCard", step.FileName);
     }
 
     #endregion

--- a/test/dotnet-scaffolding/dotnet-scaffold.Tests/AspNet/Integration/Blazor/RazorComponentNet9IntegrationTests.cs
+++ b/test/dotnet-scaffolding/dotnet-scaffold.Tests/AspNet/Integration/Blazor/RazorComponentNet9IntegrationTests.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -405,22 +404,22 @@ public class RazorComponentNet9IntegrationTests : IDisposable
 
     #endregion
 
-    #region DotnetNewScaffolderStep — Title Casing
+    #region DotnetNewScaffolderStep — First Character Uppercasing
 
     [Theory]
     [InlineData("product", "Product")]
-    [InlineData("productCard", "Productcard")]
+    [InlineData("productCard", "ProductCard")]
     [InlineData("UPPERCASE", "UPPERCASE")]
     [InlineData("a", "A")]
-    public void TitleCase_CapitalizesFirstLetter(string input, string expected)
+    public void FirstCharUppercase_CapitalizesFirstLetter(string input, string expected)
     {
-        // The step uses CultureInfo.CurrentCulture.TextInfo.ToTitleCase to capitalize the first letter
-        string result = CultureInfo.CurrentCulture.TextInfo.ToTitleCase(input);
+        // The step only capitalizes the first character, preserving the rest
+        string result = char.ToUpper(input[0]) + input.Substring(1);
         Assert.Equal(expected, result);
     }
 
     [Fact]
-    public async Task ExecuteAsync_TitleCasesFileName_WhenLowercaseProvided()
+    public async Task ExecuteAsync_CapitalizesFirstChar_WhenLowercaseProvided()
     {
         // Arrange
         string componentsDir = Path.Combine(_testProjectDir, "Components");
@@ -440,13 +439,12 @@ public class RazorComponentNet9IntegrationTests : IDisposable
         // Act
         await step.ExecuteAsync(_context, CancellationToken.None);
 
-        // Assert — after validation, FileName should be title-cased
-        string expected = CultureInfo.CurrentCulture.TextInfo.ToTitleCase("myComponent");
-        Assert.Equal(expected, step.FileName);
+        // Assert — after validation, only first char should be uppercased
+        Assert.Equal("MyComponent", step.FileName);
     }
 
     [Fact]
-    public async Task ExecuteAsync_AppliesTitleCase_WhenAlreadyCapitalized()
+    public async Task ExecuteAsync_PreservesFileName_WhenAlreadyCapitalized()
     {
         // Arrange
         string componentsDir = Path.Combine(_testProjectDir, "Components");
@@ -466,9 +464,8 @@ public class RazorComponentNet9IntegrationTests : IDisposable
         // Act
         await step.ExecuteAsync(_context, CancellationToken.None);
 
-        // Assert — ToTitleCase treats "ProductCard" as a single word, lowering inner capitalization
-        string expected = CultureInfo.CurrentCulture.TextInfo.ToTitleCase("ProductCard");
-        Assert.Equal(expected, step.FileName);
+        // Assert — already capitalized, name should be preserved
+        Assert.Equal("ProductCard", step.FileName);
     }
 
     #endregion


### PR DESCRIPTION
This is to ensure consistent file names across windows and linux, came across this when writing tests. 

The problem: `ToTitleCase("TestController")` produces "Testcontroller" — it capitalizes the first letter but lowercases the rest of each "word." On Windows (case-insensitive filesystem), `File.Exists("TestController.cs")` still matches Testcontroller.cs. On Linux (case-sensitive), it doesn't — so every scaffolded file appeared missing.

The fix: `char.ToUpper(FileName[0]) + FileName.Substring(1)` only uppercases the first character, preserving the user's original casing for the rest of the name. This satisfies the original intent (ensure names don't start lowercase, as required by Razor/Blazor conventions) without mangling PascalCase names.

