### PR TITLE
Suppress NU5104 for stable releases of dotnet-scaffold packages

### DIFF
--- a/eng/Versions.DotNetScaffold.props
+++ b/eng/Versions.DotNetScaffold.props
@@ -11,5 +11,9 @@
     -->
     <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>
     <DotNetFinalVersionKind Condition="'$(StabilizePackageVersion)' == 'true'">release</DotNetFinalVersionKind>
+    <!-- Suppress NU5104 for stable releases: the tool intentionally targets net11.0 whose
+         Microsoft.Extensions.* packages are still in preview. The warning is not actionable
+         until net11.0 ships stable framework packages. -->
+    <NoWarn Condition="'$(StabilizePackageVersion)' == 'true'">$(NoWarn);NU5104</NoWarn>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
In order to release a stable version of dotnet scaffold without errors, we will need to suppress this nuget warning related to having prerelease dependencies in a stable release of this NuGet package. We don't want to have two implementations of this tool one that relies on these dependencies and one without, so suppressing these errors.  


