### PR TITLE
Suppress NU5104 globally for stable releases

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -19,6 +19,9 @@
     <Nullable>enable</Nullable>
     <!-- Suppress TFM support warnings for .NET 11 preview packages used on net9.0 - required to support net8 and net9 projects -->
     <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
+    <!-- Suppress NU5104 for stable releases: Microsoft.Extensions.* packages targeting net11.0
+         are still in preview. Not actionable until net11.0 ships stable framework packages. -->
+    <NoWarn Condition="'$(StabilizePackageVersion)' == 'true'">$(NoWarn);NU5104</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup Label="Package and Assembly Metadata">


### PR DESCRIPTION

these NuGet suppressions are needed to publish the stable version of dotnet scaffold without changing the dependencies in this repo.