### PR TITLE
Disable NuGet publishing on release/8.0

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,7 +12,7 @@ variables:
   - name: TeamName
     value: DotNetCore
   - name: _PublishUsingPipelines
-    value: true
+    value: false
   - name: _DotNetArtifactsCategory
     value: .NETCore
   - template: /eng/common/templates-official/variables/pool-providers.yml@self
@@ -46,7 +46,7 @@ extends:
           enableMicrobuild: true
           enablePublishBuildArtifacts: true
           enablePublishTestResults: true
-          enablePublishBuildAssets: true
+          enablePublishBuildAssets: false
           enablePublishUsingPipelines: ${{ variables._PublishUsingPipelines }}
           enableTelemetry: true
           helixRepo: dotnet/scaffolding


### PR DESCRIPTION
Stop publishing NuGet packages from this branch by setting _PublishUsingPipelines to false and disabling enablePublishBuildAssets. The release/8.0 packages are no longer being actively maintained. Now support for Net 8 scaffolding will be available by publishing the main branch. 
