### PR TITLE
Ensure Identity scaffolding includes Microsoft.EntityFrameworkCore.Design 

### DIFF
--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Common/PackageConstants.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Common/PackageConstants.cs
@@ -20,6 +20,7 @@ internal class PackageConstants
         public const string Postgres = "npgsql-efcore";
         public static readonly Package EfCorePackage = new("Microsoft.EntityFrameworkCore", IsVersionRequired: true);
         public static readonly Package EfCoreToolsPackage = new("Microsoft.EntityFrameworkCore.Tools", IsVersionRequired: true);
+        public static readonly Package EfCoreDesignPackage = new("Microsoft.EntityFrameworkCore.Design", IsVersionRequired: true);
         public static readonly Package SqlServerPackage = new("Microsoft.EntityFrameworkCore.SqlServer", IsVersionRequired: true);
         public static readonly Package SqlitePackage = new("Microsoft.EntityFrameworkCore.Sqlite", IsVersionRequired: true);
         public static readonly Package CosmosPackage = new("Microsoft.EntityFrameworkCore.Cosmos", IsVersionRequired: true);

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Extensions/BlazorIdentityScaffolderBuilderExtensions.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Extensions/BlazorIdentityScaffolderBuilderExtensions.cs
@@ -156,7 +156,8 @@ internal static class BlazorIdentityScaffolderBuilderExtensions
             List<Package> packages = [
                 PackageConstants.AspNetCorePackages.AspNetCoreIdentityEfPackage,
                 PackageConstants.AspNetCorePackages.AspNetCoreDiagnosticsEfCorePackage,
-                PackageConstants.EfConstants.EfCoreToolsPackage
+                PackageConstants.EfConstants.EfCoreToolsPackage,
+                PackageConstants.EfConstants.EfCoreDesignPackage
             ];
 
             if (context.Properties.TryGetValue(nameof(IdentitySettings), out var commandSettingsObj) &&

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Extensions/IdentityScaffolderBuilderExtensions.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Extensions/IdentityScaffolderBuilderExtensions.cs
@@ -32,7 +32,8 @@ internal static class IdentityScaffolderBuilderExtensions
             List<Package> packages = [
                 PackageConstants.AspNetCorePackages.AspNetCoreIdentityEfPackage,
                 PackageConstants.AspNetCorePackages.AspNetCoreIdentityUiPackage,
-                PackageConstants.EfConstants.EfCoreToolsPackage
+                PackageConstants.EfConstants.EfCoreToolsPackage,
+                PackageConstants.EfConstants.EfCoreDesignPackage
             ];
 
             if (context.Properties.TryGetValue(nameof(IdentitySettings), out var commandSettingsObj) &&


### PR DESCRIPTION
When scaffolding ASP.NET Identity (or Blazor Identity), the Microsoft.EntityFrameworkCore.Design package was not being added to the project. This package is required by the EF Core tooling to run migrations (dotnet ef migrations add).

The package was missing from the list of packages installed by WithIdentityAddPackagesStep and WithBlazorIdentityAddPackagesStep, causing dotnet ef migrations add to fail with a missing package error after scaffolding in .NET 10.0 and later projects.

fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2993247