### PR TITLE
Fix ManageLayout.razor uses wrong layout namespace for WASM/Auto Global Blazor projects

### DIFF
--- a/src/Scaffolding/VS.Web.CG.Mvc/BlazorIdentity/BlazorIdentityGenerator.cs
+++ b/src/Scaffolding/VS.Web.CG.Mvc/BlazorIdentity/BlazorIdentityGenerator.cs
@@ -171,7 +171,12 @@ namespace Microsoft.VisualStudio.Web.CodeGenerators.Mvc.Blazor
             }
 
             var rootIdentityNamespace = $"{commandlineModel.RootNamespace}.Components.Account";
-            var layoutNamespace = $"{commandlineModel.RootNamespace}.Components.Layout.MainLayout";
+            // For WASM/Auto Global Blazor projects, MainLayout lives in the client project (e.g. BlazorApp1.Client).
+            // For Blazor Server projects, it lives directly under Components/Layout/ in the server project.
+            var mainLayoutInServerProject = Path.Combine(AppInfo.ApplicationBasePath, "Components", "Layout", "MainLayout.razor");
+            var layoutNamespace = FileSystem.FileExists(mainLayoutInServerProject)
+                ? $"{commandlineModel.RootNamespace}.Components.Layout.MainLayout"
+                : $"{commandlineModel.RootNamespace}.Client.Layout.MainLayout";
             var defaultDbContextNamespace = $"{commandlineModel.RootNamespace}.Data";
             var defaultUserNamespace = $"{commandlineModel.RootNamespace}.Data";
             var blazorIdentityModel = new BlazorIdentityModel

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/ScaffoldSteps/ValidateIdentityStep.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/ScaffoldSteps/ValidateIdentityStep.cs
@@ -213,7 +213,16 @@ internal class ValidateIdentityStep : ScaffoldStep
         if (!string.IsNullOrEmpty(projectName))
         {
             identityNamespace = settings.BlazorScenario ? $"{projectName}.Components.Account" : $"{projectName}.Areas.Identity";
-            identityLayoutNamespace = settings.BlazorScenario ? $"{projectName}.Components.Layout.MainLayout" : string.Empty;
+            if (settings.BlazorScenario)
+            {
+                // For WASM/Auto Global Blazor projects, MainLayout lives in the client project (e.g. BlazorApp1.Client).
+                // For Blazor Server projects, it lives directly under Components/Layout/ in the server project.
+                var mainLayoutInServerProject = Path.Combine(projectDirectory, "Components", "Layout", "MainLayout.razor");
+                identityLayoutNamespace = _fileSystem.FileExists(mainLayoutInServerProject)
+                    ? $"{projectName}.Components.Layout.MainLayout"
+                    : $"{projectName}.Client.Layout.MainLayout";
+            }
+
             userClassNamespace = $"{projectName}.Data";
         }
 


### PR DESCRIPTION
fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2993217


In Blazor WASM/Auto (Global interactivity) projects, MainLayout.razor lives in the client project (e.g. BlazorApp1.Client), not the server project's Components/Layout/ folder. The scaffolder was always generating:

  @layout BlazorApp1.Components.Layout.MainLayout

which causes CS0234 because the Layout namespace doesn't exist under BlazorApp1.Components in WASM/Auto Global projects.

Fix: detect whether Components/Layout/MainLayout.razor exists in the server project directory. If it does (Blazor Server), use the .Components.Layout namespace. If not (WASM/Auto Global), use .Client.Layout instead.

Fixes both the dotnet-scaffold (ValidateIdentityStep) and the VS scaffolder (BlazorIdentityGenerator) code paths.

