### PR TITLE
Fix flaky net11 scaffolding tests

### DIFF
--- a/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Core/NuGet/Package.cs
+++ b/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Core/NuGet/Package.cs
@@ -92,21 +92,29 @@ internal static class PackageExtensions
             return Task.FromResult<NuGetVersion?>(alignedVersion);
         }
 
+        // Resolve versions using the target project's NuGet settings (not the scaffold process's
+        // current directory). This ensures the same package sources used by restore / 'dotnet add
+        // package' are queried. It is essential for preview target frameworks such as net11.0 whose
+        // packages live on preview-only feeds (declared in the project's NuGet.config): without it,
+        // no matching major version is found on the default feeds and version resolution silently
+        // returns null, producing flaky/incorrect package references.
+        string? projectDirectory = string.IsNullOrEmpty(projectPath) ? null : Path.GetDirectoryName(projectPath);
+
         if (targetFramework is TargetFramework.Net8)
         {
-            return nugetVersionHelper.GetLatestPackageForNetVersionAsync(package.Name, 8);
+            return nugetVersionHelper.GetLatestPackageForNetVersionAsync(package.Name, 8, projectDirectory);
         }
         else if (targetFramework is TargetFramework.Net9)
         {
-            return nugetVersionHelper.GetLatestPackageForNetVersionAsync(package.Name, 9);
+            return nugetVersionHelper.GetLatestPackageForNetVersionAsync(package.Name, 9, projectDirectory);
         }
         else if (targetFramework is TargetFramework.Net10)
         {
-            return nugetVersionHelper.GetLatestPackageForNetVersionAsync(package.Name, 10);
+            return nugetVersionHelper.GetLatestPackageForNetVersionAsync(package.Name, 10, projectDirectory);
         }
         else if (targetFramework is TargetFramework.Net11)
         {
-            return nugetVersionHelper.GetLatestPackageForNetVersionAsync(package.Name, 11);
+            return nugetVersionHelper.GetLatestPackageForNetVersionAsync(package.Name, 11, projectDirectory);
         }
         else
         {


### PR DESCRIPTION
Fix flaky net11 scaffolding tests: resolve package versions from project's NuGet feeds

GetVersionForTargetFrameworkAsync now forwards the target project's directory into GetLatestPackageForNetVersionAsync so package-version resolution reads the same NuGet.config/feeds as restore. Previously net11 preview versions were queried against the scaffold process CWD (which lacks the dotnet11 preview feeds), yielding null/incorrect versions and flaky restore/build.

I ran it a few times and passing the project directory makes it way less flakey for net 11 stuff


