### PR TITLE
Redact client secret from user-secrets error and trace logs

### DIFF
--- a/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/CodeReaderWriter/CodeWriter.cs
+++ b/src/MSIdentityScaffolding/Microsoft.DotNet.MSIdentity/CodeReaderWriter/CodeWriter.cs
@@ -175,7 +175,7 @@ namespace Microsoft.DotNet.MSIdentity.CodeReaderWriter
 
             if (result.ExitCode != 0)
             {
-                throw new Exception($"Error while running dotnet-user-secrets set {key} {value}");
+                throw new Exception($"Error while running 'dotnet user-secrets set {key} ***'");
             }
             else
             {

--- a/src/Shared/Microsoft.DotNet.Scaffolding.Shared/Cli.Utils/Command.cs
+++ b/src/Shared/Microsoft.DotNet.Scaffolding.Shared/Cli.Utils/Command.cs
@@ -71,11 +71,31 @@ namespace Microsoft.Extensions.Internal
             return $"{psi.FileName} {psi.Arguments}";
         }
 
+        private static string RedactSecrets(string command)
+        {
+            if (string.IsNullOrEmpty(command))
+            {
+                return command;
+            }
+
+            // Redact the secret value passed to 'user-secrets set <key> <value>'
+            // so plaintext secrets are never written to trace logs.
+            var setMatch = System.Text.RegularExpressions.Regex.Match(
+                command,
+                @"(user-secrets\b.*?\bset\s+\S+\s+)(.+)$");
+            if (setMatch.Success)
+            {
+                return setMatch.Groups[1].Value + "***";
+            }
+
+            return command;
+        }
+
         public CommandResult Execute()
         {
             ThrowIfRunning();
             Command._logger.LogMessage(
-                $"Executing external command:\n{this}\n", LogMessageLevel.Trace
+                $"Executing external command:\n{RedactSecrets(ToString())}\n", LogMessageLevel.Trace
             );
             _running = true;
             _process.EnableRaisingEvents = true;

--- a/src/Shared/Microsoft.DotNet.Scaffolding.Shared/Cli.Utils/DotnetCommands.cs
+++ b/src/Shared/Microsoft.DotNet.Scaffolding.Shared/Cli.Utils/DotnetCommands.cs
@@ -158,7 +158,7 @@ namespace Microsoft.DotNet.Scaffolding.Shared.Cli.Utils
 
             if (result.ExitCode != 0)
             {
-                throw new Exception($"Error while running dotnet-user-secrets set {key} {value}");
+                throw new Exception($"Error while running 'dotnet user-secrets set {key} ***'");
             }
             else
             {


### PR DESCRIPTION
## Why

fixes https://dev.azure.com/devdiv/DevDiv/_workitems/edit/2982575

When `dotnet-msidentity` creates an AAD client secret via Microsoft Graph and then fails to store it locally with `dotnet user-secrets set`, the plaintext secret was being included in the thrown exception message. That message is written to the console, the VS Output window, and `--json` stdout (captured by VS Connected Services / ActivityLog). Because the secret is already created and valid in AAD when the local store step fails, anyone with read access to CI logs, VS diagnostic bundles, or a screen-share could authenticate as the registered application. Tracked as SCAFFOLD-002 (CWE-532 / CWE-209).

## What changed

- `CodeWriter.cs` and `DotnetCommands.cs`: the failure exception no longer embeds the secret `value`. It now reads `Error while running 'dotnet user-secrets set {key} ***'`, keeping the (harmless) key for diagnostics while masking the secret.
- `Command.cs`: the `Execute()` trace log printed the entire argv, which also contained the secret. Added a `RedactSecrets` helper that masks the value following `user-secrets ... set <key>` before the command string is trace-logged.

## Notes

- The key name (e.g. `AzureAd:ClientSecret`) is intentionally preserved since it is not sensitive and aids debugging; only the value is redacted.
- Both affected projects build clean with 0 warnings / 0 errors.
- No tests were added; the change is a message-string redaction with no behavioral change to the success path.