### PR TITLE
Stabilize flaky NuGet package resolution in CI

### DIFF
--- a/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Core/NuGet/NuGetVersionService.cs
+++ b/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Core/NuGet/NuGetVersionService.cs
@@ -97,29 +97,41 @@ internal class NuGetVersionService
         SourceCacheContext cache = new();
         var allVersionsTasks = repositories.Select(async repo =>
         {
-            try
+            PackageMetadataResource? metadataResource = await repo.GetResourceAsync<PackageMetadataResource>();
+            if (metadataResource == null)
             {
-                PackageMetadataResource? metadataResource = await repo.GetResourceAsync<PackageMetadataResource>();
-                if (metadataResource == null)
+                return Enumerable.Empty<IPackageSearchMetadata>();
+            }
+
+            // Retry transient failures (e.g. network blips or feed throttling) before giving up on a
+            // source. Silently dropping a source here is a primary cause of flaky version resolution:
+            // when the source that hosts the package fails, resolution returns no version and callers
+            // fall back to installing the latest (potentially framework-incompatible) package.
+            const int maxAttempts = 3;
+            for (int attempt = 1; attempt <= maxAttempts; attempt++)
+            {
+                try
                 {
-                    return [];
+                    return await metadataResource.GetMetadataAsync(
+                        packageId,
+                        includePrerelease: true,
+                        includeUnlisted: false,
+                        cache,
+                        NuGet.Common.NullLogger.Instance,
+                        CancellationToken.None);
                 }
-
-                IEnumerable<IPackageSearchMetadata> metadata = await metadataResource.GetMetadataAsync(
-                    packageId,
-                    includePrerelease: true,
-                    includeUnlisted: false,
-                    cache,
-                    NuGet.Common.NullLogger.Instance,
-                    CancellationToken.None);
-
-                return metadata;
+                catch when (attempt < maxAttempts)
+                {
+                    await Task.Delay(TimeSpan.FromMilliseconds(200 * attempt));
+                }
+                catch
+                {
+                    // If a source keeps failing after all retries, continue with other sources.
+                    return Enumerable.Empty<IPackageSearchMetadata>();
+                }
             }
-            catch
-            {
-                // If a source fails, continue with other sources
-                return [];
-            }
+
+            return Enumerable.Empty<IPackageSearchMetadata>();
         });
 
         IEnumerable<IPackageSearchMetadata>[] allMetadataResults = await Task.WhenAll(allVersionsTasks);

--- a/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Core/NuGet/TargetFrameworkConstants.cs
+++ b/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Core/NuGet/TargetFrameworkConstants.cs
@@ -33,3 +33,27 @@ public enum TargetFramework
     Net10,
     Net11
 }
+
+internal static class TargetFrameworkExtensions
+{
+    /// <summary>
+    /// Attempts to get the .NET major version number (for example, 9 for <see cref="TargetFramework.Net9"/>)
+    /// for the specified target framework.
+    /// </summary>
+    /// <param name="targetFramework">The target framework to resolve. May be <see langword="null"/>.</param>
+    /// <param name="majorVersion">When this method returns, contains the .NET major version number if resolution succeeded; otherwise 0.</param>
+    /// <returns><see langword="true"/> if a major version could be determined; otherwise <see langword="false"/>.</returns>
+    public static bool TryGetMajorVersion(this TargetFramework? targetFramework, out int majorVersion)
+    {
+        majorVersion = targetFramework switch
+        {
+            TargetFramework.Net8 => 8,
+            TargetFramework.Net9 => 9,
+            TargetFramework.Net10 => 10,
+            TargetFramework.Net11 => 11,
+            _ => 0
+        };
+
+        return majorVersion != 0;
+    }
+}

--- a/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Core/Steps/AddPackagesStep.cs
+++ b/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Core/Steps/AddPackagesStep.cs
@@ -60,6 +60,22 @@ internal class AddPackagesStep : ScaffoldStep
             {
                 resolvedPackage = await package.WithResolvedVersionAsync(targetFramework, _nugetVersionHelper, ProjectPath, _logger);
                 packageVersion = resolvedPackage.PackageVersion;
+
+                // Stabilization: if a concrete compatible version could not be resolved (for example a
+                // transient NuGet metadata query failure), fall back to a floating version constrained to
+                // the target framework's major version. Without this, 'dotnet add package' would be invoked
+                // with no version and install the absolute latest package, which is frequently incompatible
+                // with the project's target framework (e.g. installing a net10.0-only package into a net9.0
+                // project) and produced flaky NU1202 failures in CI. The trailing '-*' keeps the fallback
+                // prerelease-aware so preview target frameworks are still satisfied.
+                if (string.IsNullOrEmpty(packageVersion) && targetFramework.TryGetMajorVersion(out int majorVersion))
+                {
+                    packageVersion = $"{majorVersion}.*-*";
+                    _logger.LogInformation(
+                        "Could not resolve a specific version of '{PackageName}' for the target framework; falling back to floating version '{PackageVersion}' to keep the package compatible.",
+                        resolvedPackage.Name,
+                        packageVersion);
+                }
             }
 
             // Add the package to the project


### PR DESCRIPTION
## Problem

Integration tests such as `ApiControllerNet9IntegrationTests.Scaffold_ApiControllerCrud_Net9_CliInvocation` intermittently fail in CI with `NU1202`, e.g. installing `Microsoft.EntityFrameworkCore.Sqlite 10.0.10` (net10.0-only) into a `net9.0` project.

## Root cause

When scaffolding adds a package, `AddPackagesStep` first resolves a version compatible with the project's target framework via a NuGet metadata query. That query runs inside a `try/catch` that **silently swallows failures and returns no versions**. On a transient network/feed failure, resolution returns `null`, and `dotnet add package` is then invoked **with no version at all** — so NuGet installs the absolute latest package, which is frequently incompatible with the target framework. This produced the flaky `NU1202` failures.

## Changes

- **`NuGetVersionService`** — retry transient per-source metadata query failures (up to 3× with backoff) before giving up, so a network blip no longer silently drops the source that hosts the package.
- **`AddPackagesStep`** — when a concrete compatible version cannot be resolved, fall back to a floating version constrained to the target framework's major (e.g. `9.*-*`) instead of installing the unconstrained latest. This guarantees restore never selects a framework-incompatible major. The trailing `-*` keeps the fallback prerelease-aware for preview target frameworks.
- **`TargetFrameworkConstants`** — add `TargetFramework.TryGetMajorVersion` helper used by the fallback.

## Verification

- Verified via a real `dotnet add package Microsoft.EntityFrameworkCore.Sqlite -v "9.*-*"` that NuGet resolves a net9-compatible 9.x version and never selects the incompatible 10.0.10.
- Core project builds clean (0 warnings / 0 errors).