### PR TITLE
Add patched SQLitePCLRaw bundle when scaffolding SQLite to avoid NU1903 warning

### DIFF
--- a/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Core/NuGet/NuGetVersionService.cs
+++ b/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Core/NuGet/NuGetVersionService.cs
@@ -53,6 +53,24 @@ internal class NuGetVersionService
         return compatibleVersions.FirstOrDefault();
     }
 
+    /// <summary>
+    /// Gets the latest stable (non-prerelease) NuGet package version available on the configured feeds,
+    /// irrespective of the target framework. Used for packages whose versioning is not aligned to the
+    /// .NET major version (for example native runtime bundles such as SQLitePCLRaw).
+    /// </summary>
+    /// <param name="packageId">the ID of the NuGet package</param>
+    /// <param name="projectDirectory">
+    /// Optional directory of the project being scaffolded. When provided, NuGet settings are loaded
+    /// from this directory so that the same package sources used by <c>dotnet add package</c> are queried.
+    /// </param>
+    /// <returns>The highest stable version found, or <see langword="null"/> if none is available.</returns>
+    public async Task<NuGetVersion?> GetLatestStableVersionAsync(string packageId, string? projectDirectory = null)
+    {
+        IEnumerable<NuGetVersion> versions = await GetVersionsForPackageAsync(packageId, projectDirectory);
+
+        return versions.Where(v => !v.IsPrerelease).OrderByDescending(v => v).FirstOrDefault();
+    }
+
     private async Task<IEnumerable<NuGetVersion>> GetVersionsForPackageAsync(string packageId, string? projectDirectory = null)
     {
         // When a project directory is provided, load settings from there so that the package

--- a/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Core/NuGet/Package.cs
+++ b/src/dotnet-scaffolding/Microsoft.DotNet.Scaffolding.Core/NuGet/Package.cs
@@ -16,6 +16,14 @@ internal sealed record Package(string Name, bool IsVersionRequired = false)
     /// Gets or sets the package version.
     /// </summary>
     public string? PackageVersion { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether the version should be resolved to the latest stable version available
+    /// on the configured NuGet feeds, ignoring the target framework's .NET major version. Use this for
+    /// packages whose versioning is not aligned to the .NET release cadence (for example native runtime
+    /// bundles such as SQLitePCLRaw).
+    /// </summary>
+    public bool UseLatestVersion { get; init; }
 }
 
 internal static class PackageExtensions
@@ -79,6 +87,15 @@ internal static class PackageExtensions
         if (!package.IsVersionRequired)
         {
             return Task.FromResult<NuGetVersion?>(null);
+        }
+
+        // Some packages (for example native runtime bundles such as SQLitePCLRaw) are not versioned in
+        // lockstep with the .NET major release. Resolve those to the latest stable version on the feed
+        // instead of filtering by the target framework's major version.
+        if (package.UseLatestVersion)
+        {
+            string? latestProjectDirectory = string.IsNullOrEmpty(projectPath) ? null : Path.GetDirectoryName(projectPath);
+            return nugetVersionHelper.GetLatestStableVersionAsync(package.Name, latestProjectDirectory);
         }
 
         if (targetFramework is null)

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Common/PackageConstants.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Common/PackageConstants.cs
@@ -25,6 +25,11 @@ internal class PackageConstants
         public static readonly Package SqlitePackage = new("Microsoft.EntityFrameworkCore.Sqlite", IsVersionRequired: true);
         public static readonly Package CosmosPackage = new("Microsoft.EntityFrameworkCore.Cosmos", IsVersionRequired: true);
         public static readonly Package PostgresPackage = new("Npgsql.EntityFrameworkCore.PostgreSQL", IsVersionRequired: true);
+        public static readonly Package SqlitePclRawBundlePackage = new("SQLitePCLRaw.bundle_e_sqlite3", IsVersionRequired: true)
+        {
+            UseLatestVersion = true
+        };
+
         public const string ConnectionStringVariableName = "connectionString";
 
         /// <summary>

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Extensions/BlazorCrudScaffolderBuilderExtensions.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Extensions/BlazorCrudScaffolderBuilderExtensions.cs
@@ -78,6 +78,10 @@ internal static class BlazorCrudScaffolderBuilderExtensions
                     PackageConstants.EfConstants.EfPackagesDict.TryGetValue(commandSettings.DatabaseProvider, out Package? projectPackage))
                 {
                     packages.Add(projectPackage);
+                    if (commandSettings.DatabaseProvider == PackageConstants.EfConstants.SQLite)
+                    {
+                        packages.Add(PackageConstants.EfConstants.SqlitePclRawBundlePackage);
+                    }
                 }
 
                 step.Packages = packages;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Extensions/BlazorIdentityScaffolderBuilderExtensions.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Extensions/BlazorIdentityScaffolderBuilderExtensions.cs
@@ -169,6 +169,10 @@ internal static class BlazorIdentityScaffolderBuilderExtensions
                     PackageConstants.EfConstants.IdentityEfPackagesDict.TryGetValue(commandSettings.DatabaseProvider, out Package? projectPackage))
                 {
                     packages.Add(projectPackage);
+                    if (commandSettings.DatabaseProvider == PackageConstants.EfConstants.SQLite)
+                    {
+                        packages.Add(PackageConstants.EfConstants.SqlitePclRawBundlePackage);
+                    }
                 }
 
                 step.Packages = packages;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Extensions/EfControllerScaffolderBuilderExtensions.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Extensions/EfControllerScaffolderBuilderExtensions.cs
@@ -69,6 +69,10 @@ internal static class EfControllerScaffolderBuilderExtensions
                     PackageConstants.EfConstants.EfPackagesDict.TryGetValue(commandSettings.DatabaseProvider, out Package? projectPackage))
                 {
                     packages.Add(projectPackage);
+                    if (commandSettings.DatabaseProvider == PackageConstants.EfConstants.SQLite)
+                    {
+                        packages.Add(PackageConstants.EfConstants.SqlitePclRawBundlePackage);
+                    }
                 }
 
                 step.Packages = packages;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Extensions/IdentityScaffolderBuilderExtensions.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Extensions/IdentityScaffolderBuilderExtensions.cs
@@ -45,6 +45,10 @@ internal static class IdentityScaffolderBuilderExtensions
                     PackageConstants.EfConstants.IdentityEfPackagesDict.TryGetValue(commandSettings.DatabaseProvider, out Package? dbProviderPackage))
                 {
                     packages.Add(dbProviderPackage);
+                    if (commandSettings.DatabaseProvider == PackageConstants.EfConstants.SQLite)
+                    {
+                        packages.Add(PackageConstants.EfConstants.SqlitePclRawBundlePackage);
+                    }
                 }
 
                 step.Packages = packages;

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Extensions/MinimalApiScaffolderBuilderExtensions.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Extensions/MinimalApiScaffolderBuilderExtensions.cs
@@ -87,6 +87,10 @@ internal static class MinimalApiScaffolderBuilderExtensions
                 {
                     packages.Add(PackageConstants.EfConstants.EfCoreToolsPackage);
                     packages.Add(projectPackage);
+                    if (commandSettings.DatabaseProvider == PackageConstants.EfConstants.SQLite)
+                    {
+                        packages.Add(PackageConstants.EfConstants.SqlitePclRawBundlePackage);
+                    }
                 }
 
                 if (commandSettings.OpenApi)

--- a/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Extensions/RazorPagesScaffolderBuilderExtensions.cs
+++ b/src/dotnet-scaffolding/dotnet-scaffold/AspNet/Extensions/RazorPagesScaffolderBuilderExtensions.cs
@@ -120,6 +120,10 @@ internal static class RazorPagesScaffolderBuilderExtensions
                     PackageConstants.EfConstants.EfPackagesDict.TryGetValue(commandSettings.DatabaseProvider, out Package? projectPackage))
                 {
                     packages.Add(projectPackage);
+                    if (commandSettings.DatabaseProvider == PackageConstants.EfConstants.SQLite)
+                    {
+                        packages.Add(PackageConstants.EfConstants.SqlitePclRawBundlePackage);
+                    }
                 }
 
                 step.Packages = packages;

--- a/test/dotnet-scaffolding/dotnet-scaffold.Tests/AspNet/Integration/Identity/IdentityIntegrationTestsBase.cs
+++ b/test/dotnet-scaffolding/dotnet-scaffold.Tests/AspNet/Integration/Identity/IdentityIntegrationTestsBase.cs
@@ -235,6 +235,19 @@ public abstract class IdentityIntegrationTestsBase : IDisposable
         Assert.False(PackageConstants.EfConstants.IdentityEfPackagesDict.ContainsKey(provider));
     }
 
+    [Fact]
+    public void SqlitePclRawBundlePackage_IsResolvedFromFeed()
+    {
+        // EF Core's SQLite provider transitively pins the vulnerable SQLitePCLRaw.lib.e_sqlite3 <= 2.1.11
+        // (CVE-2025-6965 / GHSA-2m69-gcr7-jv3q). Scaffolding adds this bundle directly to override it, with
+        // the version resolved to the latest stable release from the feed rather than hardcoded.
+        var bundle = PackageConstants.EfConstants.SqlitePclRawBundlePackage;
+        Assert.Equal("SQLitePCLRaw.bundle_e_sqlite3", bundle.Name);
+        Assert.True(bundle.IsVersionRequired);
+        Assert.True(bundle.UseLatestVersion);
+        Assert.Null(bundle.PackageVersion);
+    }
+
     #endregion
 
     #region Identity — Template Folder Structure

--- a/test/dotnet-scaffolding/dotnet-scaffold.Tests/Models/PackageTests.cs
+++ b/test/dotnet-scaffolding/dotnet-scaffold.Tests/Models/PackageTests.cs
@@ -120,6 +120,27 @@ public class PackageTests
     }
 
     [Fact]
+    public async Task WithResolvedVersionAsync_UseLatestVersion_ResolvesNonVulnerableSqlitePclRawBundle()
+    {
+        // Arrange: SQLitePCLRaw is not versioned in lockstep with .NET, so it is resolved to the latest
+        // stable version on the feed regardless of target framework. CVE-2025-6965 (GHSA-2m69-gcr7-jv3q)
+        // flags SQLitePCLRaw.lib.e_sqlite3 <= 2.1.11, so the resolved version must be strictly greater.
+        Package package = new Package("SQLitePCLRaw.bundle_e_sqlite3", IsVersionRequired: true)
+        {
+            UseLatestVersion = true
+        };
+
+        // Act
+        Package result = await package.WithResolvedVersionAsync(TargetFramework.Net10, _nugetVersionService);
+
+        // Assert
+        Assert.NotNull(result.PackageVersion);
+        NuGetVersion resolved = NuGetVersion.Parse(result.PackageVersion!);
+        Assert.False(resolved.IsPrerelease);
+        Assert.True(resolved > NuGetVersion.Parse("2.1.11"));
+    }
+
+    [Fact]
     public async Task WithResolvedVersionAsync_Net11Framework_ResolvesVersion()
     {
         // Arrange


### PR DESCRIPTION
## Problem

fixes https://dev.azure.com/devdiv/DevDiv/_workitems/edit/3020803

Scaffolding an EF provider with **SQLite** selected (Identity, Blazor Identity, Razor Pages, MVC, Minimal API, and EF controller scaffolders) adds only `Microsoft.EntityFrameworkCore.Sqlite`. That provider pulls in `SQLitePCLRaw.lib.e_sqlite3` transitively, which causes the scaffolded project to emit the **NU1903** NuGet warning on .NET 10 projects and blocks `Add-Migration`.

This did not reproduce on .NET 8/9 projects, only .NET 10.

## Fix

When the SQLite provider is selected, the scaffolders now add a direct reference to `SQLitePCLRaw.bundle_e_sqlite3`, which overrides the transitively-referenced version that triggers the NU1903 warning.

Rather than hardcoding a version, the reference is resolved to the latest stable release from the project's configured NuGet feeds:

- Added `Package.UseLatestVersion` for packages whose versioning is not aligned to the .NET major release cadence (e.g. native runtime bundles like SQLitePCLRaw).
- Added `NuGetVersionService.GetLatestStableVersionAsync`, which returns the highest stable version from the same feeds used by `dotnet add package` (mirrors the existing `GetLatestPackageForNetVersionAsync`).
- The SQLite companion reference is added inline in each scaffolder, following the existing conditional-`packages.Add(...)` pattern.

## Tests

- `SqlitePclRawBundlePackage_IsResolvedFromFeed` — verifies the bundle package is defined to resolve its version from the feed rather than a hardcoded value.
- `WithResolvedVersionAsync_UseLatestVersion_ResolvesNonVulnerableSqlitePclRawBundle` — verifies feed resolution returns a stable version that overrides the transitive one.

All targeted tests pass and the solution builds.