### PR TITLE
Stabilize flaky net11 integration tests by restoring from repo dnceng feeds instead of live nuget.org

### DIFF
--- a/test/dotnet-scaffolding/dotnet-scaffold.Tests/Helpers/ScaffoldCliHelper.cs
+++ b/test/dotnet-scaffolding/dotnet-scaffold.Tests/Helpers/ScaffoldCliHelper.cs
@@ -501,21 +501,51 @@ public class {modelName}
     }
 
     /// <summary>
-    /// NuGet.config content for net11.0 preview feeds.
-    /// net11.0 is in preview — the SDK and its NuGet packages live on preview-only feeds
-    /// that are not in the default NuGet sources. Write this into the temp project directory
-    /// so dotnet restore / build can find them.
+    /// NuGet.config content used by net11.0 integration tests when restoring the temporary
+    /// scaffolded projects.
+    /// <para>
+    /// The temporary test projects live under <see cref="Path.GetTempPath"/>, i.e. outside the
+    /// repository tree, so they cannot discover the repository's root <c>NuGet.config</c> by the
+    /// normal directory walk. To keep a single source of truth — and, critically, to restore from
+    /// the exact same curated, CI-mirrored dnceng feeds the rest of the build uses — this returns
+    /// the repository root <c>NuGet.config</c> content verbatim.
+    /// </para>
+    /// <para>
+    /// This deliberately avoids the live public <c>https://api.nuget.org</c> feed (which the repo's
+    /// own config does not use). Restoring the scaffolded preview projects directly against the live
+    /// nuget.org endpoint was the root cause of the CI flakiness: transient throttling/timeouts on
+    /// that endpoint failed the pre-/post-build restores. The dnceng mirror feeds in the repo config
+    /// are the same ones the solution build already warmed, so these restores become cache hits.
+    /// </para>
     /// </summary>
-    public static readonly string PreviewNuGetConfig = @"<?xml version=""1.0"" encoding=""utf-8""?>
+    public static string PreviewNuGetConfig => GetRepoRootNuGetConfig();
+
+    /// <summary>
+    /// Reads the repository root <c>NuGet.config</c> so temporary test projects restore from the
+    /// identical feed set as the rest of the build. Falls back to an embedded copy of the repo's
+    /// dnceng feeds (still excluding the live nuget.org endpoint) if the file cannot be located.
+    /// </summary>
+    private static string GetRepoRootNuGetConfig()
+    {
+        var repoConfig = Path.Combine(GetRepoRoot(), "NuGet.config");
+        if (File.Exists(repoConfig))
+        {
+            return File.ReadAllText(repoConfig);
+        }
+
+        // Defensive fallback mirroring the repo's dnceng feeds. Intentionally excludes
+        // https://api.nuget.org — the dotnet-public feed is a reliable mirror of it.
+        return @"<?xml version=""1.0"" encoding=""utf-8""?>
 <configuration>
   <packageSources>
     <clear />
-    <add key=""nuget.org"" value=""https://api.nuget.org/v3/index.json"" />
+    <add key=""dotnet-public"" value=""https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json"" />
     <add key=""dotnet11"" value=""https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet11/nuget/v3/index.json"" />
     <add key=""dotnet11-transport"" value=""https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet11-transport/nuget/v3/index.json"" />
-    <add key=""dotnet-public"" value=""https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json"" />
   </packageSources>
+  <disabledPackageSources />
 </configuration>";
+    }
 
     /// <summary>
     /// NuGet.config content that restricts package sources to nuget.org only.


### PR DESCRIPTION
## Problem

The `dotnet-scaffold.Tests_net11.0` CI test report is intermittently flaky (notably on the macOS Debug build job, which runs the full suite inline).

**Root cause:** the net11 integration tests scaffold temporary projects under `Path.GetTempPath()` — outside the repository tree — so they cannot discover the repo-root `NuGet.config`. To compensate, the test harness wrote a hand-rolled `PreviewNuGetConfig` that injected the **live `https://api.nuget.org` feed**. The repository itself never uses that feed: its `NuGet.config` does `<clear/>` and restores exclusively from curated **dnceng mirror feeds** (`dotnet-public`, `dotnet11`, `dotnet11-transport`, …).

As a result, every pre-build and post-build restore in these tests hit the live nuget.org endpoint, whose transient throttling/timeouts on hosted CI agents were the root cause of the flaky restores/builds.

## Fix

Make the net11 temp projects restore from a **single source of truth** — the repository's own feed set:

- `PreviewNuGetConfig` now returns the repo-root `NuGet.config` content verbatim, with a defensive dnceng-only fallback (still excluding `api.nuget.org`) if the file can't be located.
- The temp net11 projects now restore from the exact same feeds the solution build already warmed, so these restores become cache hits instead of live-network calls.
- All 8 net11 call sites are unchanged — they simply get correct, reliable feeds.

This addresses the flakiness at its source rather than masking it with retries/timeouts.

## Verification

- Installed the pinned net11 preview SDK + net8/9/10 runtimes locally to match CI.
- Ran the net11 CLI integration tests (each does a real restore + `dotnet build` + scaffold + build cycle): **8 passed / 6 skipped / 0 failed**. The 6 skips are pre-existing `[Fact(Skip=…)]` markers unrelated to NuGet.

## Scope

`StableNuGetConfig` (used only by net8/9 tests) is intentionally left unchanged — it pins nuget.org-only on purpose to keep preview feeds out of stable-TFM tests, and net8/9 is not the flaky target here.