### PR TITLE
Remove Publish-Build-Assets variable group from main

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -73,7 +73,6 @@ extends:
             - _ValidateSdkArgs: ''
             - _InternalBuildArgs: ''
             # DotNet-Symbol-Server-Pats provides: microsoft-symbol-server-pat, symweb-symbol-server-pat
-            # Publish-Build-Assets provides: MaestroAccessToken, BotAccount-dotnet-maestro-bot-PAT
             - group: DotNet-Symbol-Server-Pats
             - _InternalBuildArgs: /p:DotNetSignType=$(_SignType) /p:TeamName=$(_TeamName)
                 /p:DotNetPublishUsingPipelines=$(_PublishUsingPipelines)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -75,7 +75,6 @@ extends:
             # DotNet-Symbol-Server-Pats provides: microsoft-symbol-server-pat, symweb-symbol-server-pat
             # Publish-Build-Assets provides: MaestroAccessToken, BotAccount-dotnet-maestro-bot-PAT
             - group: DotNet-Symbol-Server-Pats
-            - group: Publish-Build-Assets
             - _InternalBuildArgs: /p:DotNetSignType=$(_SignType) /p:TeamName=$(_TeamName)
                 /p:DotNetPublishUsingPipelines=$(_PublishUsingPipelines)
                 /p:OfficialBuildId=$(BUILD.BUILDNUMBER)


### PR DESCRIPTION
Removes the repository-owned `Publish-Build-Assets` variable group import from:

- `azure-pipelines.yml`

This is part of the tracked VG20 cleanup: https://dev.azure.com/dnceng/internal/_workitems/edit/12131